### PR TITLE
include xtensor headers in package

### DIFF
--- a/inst/include/xtensor/xadapt.hpp
+++ b/inst/include/xtensor/xadapt.hpp
@@ -1,0 +1,213 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XADAPT_HPP
+#define XADAPT_HPP
+
+#include <array>
+#include <cstddef>
+#include <type_traits>
+#include <memory>
+
+#include "xarray.hpp"
+#include "xtensor.hpp"
+
+namespace xt
+{
+
+    /**************************
+     * xarray_adaptor builder *
+     **************************/
+
+    /**
+     * Constructs an xarray_adaptor of the given stl-like container,
+     * with the specified shape and layout.
+     * @param container the container to adapt
+     * @param shape the shape of the xarray_adaptor
+     * @param l the layout_type of the xarray_adaptor
+     */
+    template <class C, class SC, layout_type L = DEFAULT_LAYOUT>
+    std::enable_if_t<!detail::is_array<SC>::value, xarray_adaptor<C, L, SC>>
+    xadapt(C& container, const SC& shape, layout_type l = L);
+
+    /**
+     * Constructs an xarray_adaptor of the given stl-like container,
+     * with the specified shape and strides.
+     * @param container the container to adapt
+     * @param shape the shape of the xarray_adaptor
+     * @param strides the strides of the xarray_adaptor
+     */
+    template <class C, class SC>
+    std::enable_if_t<!detail::is_array<SC>::value, xarray_adaptor<C, layout_type::dynamic, SC>>
+    xadapt(C& container, const SC& shape, const SC& strides);
+
+    /**
+     * Constructs an xarray_adaptor of the given dynamically allocated C array,
+     * with the specified shape and layout.
+     * @param pointer the pointer to the beginning of the dynamic array
+     * @param size the size of the dynamic array
+     * @param ownership indicates whether the adaptor takes ownership of the array.
+     *        Possible values are ``no_ownerhsip()`` or ``accept_ownership()``
+     * @param shape the shape of the xarray_adaptor
+     * @param l the layout_type of the xarray_adaptor
+     * @param alloc the allocator used for allocating / deallocating the dynamic array
+     */
+    template <class P, class O, class SC, layout_type L = DEFAULT_LAYOUT, class A = std::allocator<std::remove_pointer_t<P>>>
+    std::enable_if_t<!detail::is_array<SC>::value, xarray_adaptor<xbuffer_adaptor<std::remove_pointer_t<P>, O, A>, L, SC>>
+    xadapt(P& pointer, typename A::size_type size, O ownership, const SC& shape, layout_type l = L, const A& alloc = A());
+    
+    /**
+     * Constructs an xarray_adaptor of the given dynamically allocated C array,
+     * with the specified shape and layout.
+     * @param pointer the pointer to the beginning of the dynamic array
+     * @param size the size of the dynamic array
+     * @param ownership indicates whether the adaptor takes ownership of the array.
+     *        Possible values are ``no_ownerhsip()`` or ``accept_ownership()``
+     * @param shape the shape of the xarray_adaptor
+     * @param strides the strides of the xarray_adaptor
+     * @param alloc the allocator used for allocating / deallocating the dynamic array
+    */
+    template <class P, class O, class SC, class A = std::allocator<std::remove_pointer_t<P>>>
+    std::enable_if_t<!detail::is_array<SC>::value, xarray_adaptor<xbuffer_adaptor<std::remove_pointer_t<P>, O, A>, layout_type::dynamic, SC>>
+    xadapt(P& pointer, typename A::size_type size, O ownership, const SC& shape, const SC& strides, const A& alloc = A());
+
+    /***************************
+     * xtensor_adaptor builder *
+     ***************************/
+
+     /**
+      * Constructs an xtensor_adaptor of the given stl-like container,
+      * with the specified shape and layout_type.
+      * @param container the container to adapt
+      * @param shape the shape of the xtensor_adaptor
+      * @param l the layout_type of the xtensor_adaptor
+      */
+    template <class C, std::size_t N, layout_type L = DEFAULT_LAYOUT>
+    xtensor_adaptor<C, N, L>
+    xadapt(C& container, const std::array<typename C::size_type, N>& shape, layout_type l = L);
+
+    /**
+     * Constructs an xtensor_adaptor of the given stl-like container,
+     * with the specified shape and strides.
+     * @param container the container to adapt
+     * @param shape the shape of the xtensor_adaptor
+     * @param strides the strides of the xtensor_adaptor
+     */
+    template <class C, std::size_t N>
+    xtensor_adaptor<C, N, layout_type::dynamic>
+    xadapt(C& container, const std::array<typename C::size_type, N>& shape, const std::array<typename C::size_type, N>& strides);
+
+    /**
+     * Constructs an xtensor_adaptor of the given dynamically allocated C array,
+     * with the specified shape and layout.
+     * @param pointer the pointer to the beginning of the dynamic array
+     * @param size the size of the dynamic array
+     * @param ownership indicates whether the adaptor takes ownership of the array.
+     *        Possible values are ``no_ownerhsip()`` or ``accept_ownership()``
+     * @param shape the shape of the xtensor_adaptor
+     * @param l the layout_type of the xtensor_adaptor
+     * @param alloc the allocator used for allocating / deallocating the dynamic array
+     */
+    template <class P, std::size_t N, class O, layout_type L = DEFAULT_LAYOUT, class A = std::allocator<std::remove_pointer_t<P>>>
+    xtensor_adaptor<xbuffer_adaptor<std::remove_pointer_t<P>, O, A>, N, L>
+    xadapt(P& pointer, typename A::size_type size, O ownership,
+           const std::array<typename A::size_type, N>& shape, layout_type l = L, const A& alloc = A());
+
+    /**
+     * Constructs an xtensor_adaptor of the given dynamically allocated C array,
+     * with the specified shape and layout.
+     * @param pointer the pointer to the beginning of the dynamic array
+     * @param size the size of the dynamic array
+     * @param ownership indicates whether the adaptor takes ownership of the array.
+     *        Possible values are ``no_ownerhsip()`` or ``accept_ownership()``
+     * @param shape the shape of the xtensor_adaptor
+     * @param strides the strides of the xtensor_adaptor
+     * @param alloc the allocator used for allocating / deallocating the dynamic array
+     */
+    template <class P, std::size_t N, class O, class A = std::allocator<std::remove_pointer_t<P>>>
+    xtensor_adaptor<xbuffer_adaptor<std::remove_pointer_t<P>, O, A>, N, layout_type::dynamic>
+    xadapt(P& pointer, typename A::size_type size, O ownership,
+           const std::array<typename A::size_type, N>& shape, const std::array<typename A::size_type, N>& strides, const A& alloc = A());
+
+    /*****************************************
+     * xarray_adaptor builder implementation *
+     *****************************************/
+
+    template <class C, class SC, layout_type L>
+    inline std::enable_if_t<!detail::is_array<SC>::value, xarray_adaptor<C, L, SC>>
+    xadapt(C& container, const SC& shape, layout_type l)
+    {
+        return xarray_adaptor<C, L, SC>(container, shape, l);
+    }
+
+    template <class C, class SC>
+    inline std::enable_if_t<!detail::is_array<SC>::value, xarray_adaptor<C, layout_type::dynamic, SC>>
+    xadapt(C& container, const SC& shape, const SC& strides)
+    {
+        return xarray_adaptor<C, layout_type::dynamic, SC>(container, shape, strides);
+    }
+
+    template <class P, class O, class SC, layout_type L, class A>
+    inline std::enable_if_t<!detail::is_array<SC>::value, xarray_adaptor<xbuffer_adaptor<std::remove_pointer_t<P>, O, A>, L, SC>>
+    xadapt(P& pointer, typename A::size_type size, O, const SC& shape, layout_type l, const A& alloc)
+    {
+        using buffer_type = xbuffer_adaptor<std::remove_pointer_t <P>, O, A>;
+        buffer_type buf(pointer, size, alloc);
+        return xarray_adaptor<buffer_type, L, SC>(std::move(buf), shape, l);
+    }
+
+    template <class P, class O, class SC, class A>
+    inline std::enable_if_t<!detail::is_array<SC>::value, xarray_adaptor<xbuffer_adaptor<std::remove_pointer_t<P>, O, A>, layout_type::dynamic, SC>>
+    xadapt(P& pointer, typename A::size_type size, O, const SC& shape, const SC& strides, const A& alloc)
+    {
+        using buffer_type = xbuffer_adaptor<std::remove_pointer_t <P>, O, A>;
+        buffer_type buf(pointer, size, alloc);
+        return xarray_adaptor<buffer_type, layout_type::dynamic, SC>(std::move(buf), shape, strides);
+    }
+
+    /******************************************
+     * xtensor_adaptor builder implementation *
+     ******************************************/
+
+    template <class C, std::size_t N, layout_type L>
+    inline xtensor_adaptor<C, N, L>
+    xadapt(C& container, const std::array<typename C::size_type, N>& shape, layout_type l)
+    {
+        return xtensor_adaptor<C, N, L>(container, shape, l);
+    }
+
+    template <class C, std::size_t N>
+    inline xtensor_adaptor<C, N, layout_type::dynamic>
+    xadapt(C& container, const std::array<typename C::size_type, N>& shape, const std::array<typename C::size_type, N>& strides)
+    {
+        return xtensor_adaptor<C, N, layout_type::dynamic>(container, shape, strides);
+    }
+
+    template <class P, std::size_t N, class O, layout_type L, class A>
+    inline xtensor_adaptor<xbuffer_adaptor<std::remove_pointer_t<P>, O, A>, N, L>
+    xadapt(P& pointer, typename A::size_type size, O,
+           const std::array<typename A::size_type, N>& shape, layout_type l, const A& alloc)
+    {
+        using buffer_type = xbuffer_adaptor<std::remove_pointer_t <P>, O, A>;
+        buffer_type buf(pointer, size, alloc);
+        return xtensor_adaptor<buffer_type, N, L>(std::move(buf), shape, l);
+    }
+
+    template <class P, std::size_t N, class O, class A>
+    inline xtensor_adaptor<xbuffer_adaptor<std::remove_pointer_t<P>, O, A>, N, layout_type::dynamic>
+    xadapt(P& pointer, typename A::size_type size, O,
+           const std::array<typename A::size_type, N>& shape, const std::array<typename A::size_type, N>& strides, const A& alloc)
+    {
+        using buffer_type = xbuffer_adaptor<std::remove_pointer_t <P>, O, A>;
+        buffer_type buf(pointer, size, alloc);
+        return xtensor_adaptor<buffer_type, N, layout_type::dynamic>(std::move(buf), shape, strides);
+    }
+
+}
+
+#endif

--- a/inst/include/xtensor/xarray.hpp
+++ b/inst/include/xtensor/xarray.hpp
@@ -1,0 +1,527 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XARRAY_HPP
+#define XARRAY_HPP
+
+#include <algorithm>
+#include <initializer_list>
+#include <utility>
+
+#include "xbuffer_adaptor.hpp"
+#include "xcontainer.hpp"
+#include "xsemantic.hpp"
+
+namespace xt
+{
+
+    /********************************
+     * xarray_container declaration *
+     ********************************/
+
+    template <class EC, layout_type L, class SC>
+    struct xcontainer_inner_types<xarray_container<EC, L, SC>>
+    {
+        using container_type = EC;
+        using shape_type = SC;
+        using strides_type = shape_type;
+        using backstrides_type = shape_type;
+        using inner_shape_type = shape_type;
+        using inner_strides_type = strides_type;
+        using inner_backstrides_type = backstrides_type;
+        using temporary_type = xarray_container<EC, L, SC>;
+    };
+
+    template <class EC, layout_type L, class SC>
+    struct xiterable_inner_types<xarray_container<EC, L, SC>>
+        : xcontainer_iterable_types<xarray_container<EC, L, SC>>
+    {
+    };
+
+    /**
+     * @class xarray_container
+     * @brief Dense multidimensional container with tensor semantic.
+     *
+     * The xarray_container class implements a dense multidimensional container
+     * with tensor semantic.
+     *
+     * @tparam EC The type of the container holding the elements.
+     * @tparam L The layout_type of the container.
+     * @tparam SC The type of the containers holding the shape and the strides.
+     * @sa xarray
+     */
+    template <class EC, layout_type L, class SC>
+    class xarray_container : public xstrided_container<xarray_container<EC, L, SC>, L>,
+                             public xcontainer_semantic<xarray_container<EC, L, SC>>
+    {
+
+    public:
+
+        using self_type = xarray_container<EC, L, SC>;
+        using base_type = xstrided_container<self_type, L>;
+        using semantic_base = xcontainer_semantic<self_type>;
+        using container_type = typename base_type::container_type;
+        using value_type = typename base_type::value_type;
+        using reference = typename base_type::reference;
+        using const_reference = typename base_type::const_reference;
+        using pointer = typename base_type::pointer;
+        using const_pointer = typename base_type::const_pointer;
+        using shape_type = typename base_type::shape_type;
+        using inner_shape_type = typename base_type::inner_shape_type;
+        using strides_type = typename base_type::strides_type;
+        using inner_strides_type = typename base_type::inner_strides_type;
+
+        xarray_container();
+        explicit xarray_container(const shape_type& shape, layout_type l = L);
+        explicit xarray_container(const shape_type& shape, const_reference value, layout_type l = L);
+        explicit xarray_container(const shape_type& shape, const strides_type& strides);
+        explicit xarray_container(const shape_type& shape, const strides_type& strides, const_reference value);
+        explicit xarray_container(container_type&& data, inner_shape_type&& shape, inner_strides_type&& strides);
+
+        xarray_container(const value_type& t);
+        xarray_container(nested_initializer_list_t<value_type, 1> t);
+        xarray_container(nested_initializer_list_t<value_type, 2> t);
+        xarray_container(nested_initializer_list_t<value_type, 3> t);
+        xarray_container(nested_initializer_list_t<value_type, 4> t);
+        xarray_container(nested_initializer_list_t<value_type, 5> t);
+
+        template <class S = shape_type>
+        static xarray_container from_shape(S&& s);
+
+        ~xarray_container() = default;
+
+        xarray_container(const xarray_container&) = default;
+        xarray_container& operator=(const xarray_container&) = default;
+
+        xarray_container(xarray_container&&) = default;
+        xarray_container& operator=(xarray_container&&) = default;
+
+        template <class E>
+        xarray_container(const xexpression<E>& e);
+
+        template <class E>
+        xarray_container& operator=(const xexpression<E>& e);
+
+    private:
+
+        container_type m_data;
+
+        container_type& data_impl() noexcept;
+        const container_type& data_impl() const noexcept;
+
+        friend class xcontainer<xarray_container<EC, L, SC>>;
+    };
+
+    /******************************
+     * xarray_adaptor declaration *
+     ******************************/
+
+    template <class EC, layout_type L = DEFAULT_LAYOUT, class SC = std::vector<typename EC::size_type>>
+    class xarray_adaptor;
+
+    template <class EC, layout_type L, class SC>
+    struct xcontainer_inner_types<xarray_adaptor<EC, L, SC>>
+    {
+        using container_type = EC;
+        using shape_type = SC;
+        using strides_type = shape_type;
+        using backstrides_type = shape_type;
+        using inner_shape_type = shape_type;
+        using inner_strides_type = strides_type;
+        using inner_backstrides_type = backstrides_type;
+        using temporary_type = xarray_container<EC, L, SC>;
+    };
+
+    template <class EC, layout_type L, class SC>
+    struct xiterable_inner_types<xarray_adaptor<EC, L, SC>>
+        : xcontainer_iterable_types<xarray_adaptor<EC, L, SC>>
+    {
+    };
+
+    /**
+     * @class xarray_adaptor
+     * @brief Dense multidimensional container adaptor with
+     * tensor semantic.
+     *
+     * The xarray_adaptor class implements a dense multidimensional
+     * container adaptor with tensor semantic. It is used to provide
+     * a multidimensional container semantic and a tensor semantic to
+     * stl-like containers.
+     *
+     * @tparam EC The container type to adapt.
+     * @tparam L The layout_type of the adaptor.
+     * @tparam SC The type of the containers holding the shape and the strides.
+     */
+    template <class EC, layout_type L, class SC>
+    class xarray_adaptor : public xstrided_container<xarray_adaptor<EC, L, SC>, L>,
+                           public xadaptor_semantic<xarray_adaptor<EC, L, SC>>
+    {
+
+    public:
+
+        using self_type = xarray_adaptor<EC, L, SC>;
+        using base_type = xstrided_container<self_type, L>;
+        using semantic_base = xadaptor_semantic<self_type>;
+        using container_type = typename base_type::container_type;
+        using shape_type = typename base_type::shape_type;
+        using strides_type = typename base_type::strides_type;
+
+        using container_closure_type = adaptor_closure_t<container_type>;
+
+        xarray_adaptor(container_closure_type data);
+        xarray_adaptor(container_closure_type data, const shape_type& shape, layout_type l = L);
+        xarray_adaptor(container_closure_type data, const shape_type& shape, const strides_type& strides);
+
+        ~xarray_adaptor() = default;
+
+        xarray_adaptor(const xarray_adaptor&) = default;
+        xarray_adaptor& operator=(const xarray_adaptor&);
+
+        xarray_adaptor(xarray_adaptor&&) = default;
+        xarray_adaptor& operator=(xarray_adaptor&&);
+
+        template <class E>
+        xarray_adaptor& operator=(const xexpression<E>& e);
+
+    private:
+
+        container_closure_type m_data;
+
+        container_type& data_impl() noexcept;
+        const container_type& data_impl() const noexcept;
+
+        using temporary_type = typename xcontainer_inner_types<self_type>::temporary_type;
+        void assign_temporary_impl(temporary_type& tmp);
+
+
+        friend class xcontainer<xarray_adaptor<EC, L, SC>>;
+        friend class xadaptor_semantic<xarray_adaptor<EC, L, SC>>;
+    };
+
+    /***********************************
+     * xarray_container implementation *
+     ***********************************/
+
+    /**
+     * @name Constructors
+     */
+    //@{
+    /**
+     * Allocates an uninitialized xarray_container that holds 0 element.
+     */
+    template <class EC, layout_type L, class SC>
+    inline xarray_container<EC, L, SC>::xarray_container()
+        : base_type(), m_data(1, value_type())
+    {
+    }
+
+    /**
+     * Allocates an uninitialized xarray_container with the specified shape and
+     * layout_type.
+     * @param shape the shape of the xarray_container
+     * @param l the layout_type of the xarray_container
+     */
+    template <class EC, layout_type L, class SC>
+    inline xarray_container<EC, L, SC>::xarray_container(const shape_type& shape, layout_type l)
+        : base_type()
+    {
+        base_type::reshape(shape, l);
+    }
+
+    /**
+     * Allocates an xarray_container with the specified shape and layout_type. Elements
+     * are initialized to the specified value.
+     * @param shape the shape of the xarray_container
+     * @param value the value of the elements
+     * @param l the layout_type of the xarray_container
+     */
+    template <class EC, layout_type L, class SC>
+    inline xarray_container<EC, L, SC>::xarray_container(const shape_type& shape, const_reference value, layout_type l)
+        : base_type()
+    {
+        base_type::reshape(shape, l);
+        std::fill(m_data.begin(), m_data.end(), value);
+    }
+
+    /**
+     * Allocates an uninitialized xarray_container with the specified shape and strides.
+     * @param shape the shape of the xarray_container
+     * @param strides the strides of the xarray_container
+     */
+    template <class EC, layout_type L, class SC>
+    inline xarray_container<EC, L, SC>::xarray_container(const shape_type& shape, const strides_type& strides)
+        : base_type()
+    {
+        base_type::reshape(shape, strides);
+    }
+
+    /**
+     * Allocates an uninitialized xarray_container with the specified shape and strides.
+     * Elements are initialized to the specified value.
+     * @param shape the shape of the xarray_container
+     * @param strides the strides of the xarray_container
+     * @param value the value of the elements
+     */
+    template <class EC, layout_type L, class SC>
+    inline xarray_container<EC, L, SC>::xarray_container(const shape_type& shape, const strides_type& strides, const_reference value)
+        : base_type()
+    {
+        base_type::reshape(shape, strides);
+        std::fill(m_data.begin(), m_data.end(), value);
+    }
+
+    /**
+     * Allocates an xarray_container that holds a single element initialized to the
+     * specified value.
+     * @param t the value of the element
+     */
+    template <class EC, layout_type L, class SC>
+    inline xarray_container<EC, L, SC>::xarray_container(const value_type& t)
+        : base_type()
+    {
+        base_type::reshape(xt::shape<shape_type>(t), true);
+        nested_copy(m_data.begin(), t);
+    }
+
+    /**
+     * Allocates an xarray_container by moving specified data, shape and strides
+     *
+     * @param data the data for the xarray_container
+     * @param shape the shape of the xarray_container
+     * @param strides the strides of the xarray_container
+     */
+    template <class EC, layout_type L, class SC>
+    inline xarray_container<EC, L, SC>::xarray_container(container_type&& data, inner_shape_type&& shape, inner_strides_type&& strides)
+        : base_type(std::move(shape), std::move(strides)), m_data(std::move(data))
+    {
+    }
+    //@}
+
+    /**
+     * @name Constructors from initializer list
+     */
+    //@{
+    /**
+     * Allocates a one-dimensional xarray_container.
+     * @param t the elements of the xarray_container
+     */
+    template <class EC, layout_type L, class SC>
+    inline xarray_container<EC, L, SC>::xarray_container(nested_initializer_list_t<value_type, 1> t)
+        : base_type()
+    {
+        base_type::reshape(xt::shape<shape_type>(t));
+        L == layout_type::row_major ? nested_copy(m_data.begin(), t) : nested_copy(this->xbegin(), t);
+    }
+
+    /**
+     * Allocates a two-dimensional xarray_container.
+     * @param t the elements of the xarray_container
+     */
+    template <class EC, layout_type L, class SC>
+    inline xarray_container<EC, L, SC>::xarray_container(nested_initializer_list_t<value_type, 2> t)
+        : base_type()
+    {
+        base_type::reshape(xt::shape<shape_type>(t));
+        L == layout_type::row_major ? nested_copy(m_data.begin(), t) : nested_copy(this->xbegin(), t);
+    }
+
+    /**
+     * Allocates a three-dimensional xarray_container.
+     * @param t the elements of the xarray_container
+     */
+    template <class EC, layout_type L, class SC>
+    inline xarray_container<EC, L, SC>::xarray_container(nested_initializer_list_t<value_type, 3> t)
+        : base_type()
+    {
+        base_type::reshape(xt::shape<shape_type>(t));
+        L == layout_type::row_major ? nested_copy(m_data.begin(), t) : nested_copy(this->xbegin(), t);
+    }
+
+    /**
+     * Allocates a four-dimensional xarray_container.
+     * @param t the elements of the xarray_container
+     */
+    template <class EC, layout_type L, class SC>
+    inline xarray_container<EC, L, SC>::xarray_container(nested_initializer_list_t<value_type, 4> t)
+        : base_type()
+    {
+        base_type::reshape(xt::shape<shape_type>(t));
+        L == layout_type::row_major ? nested_copy(m_data.begin(), t) : nested_copy(this->xbegin(), t);
+    }
+
+    /**
+     * Allocates a five-dimensional xarray_container.
+     * @param t the elements of the xarray_container
+     */
+    template <class EC, layout_type L, class SC>
+    inline xarray_container<EC, L, SC>::xarray_container(nested_initializer_list_t<value_type, 5> t)
+        : base_type()
+    {
+        base_type::reshape(xt::shape<shape_type>(t));
+        L == layout_type::row_major ? nested_copy(m_data.begin(), t) : nested_copy(this->xbegin(), t);
+    }
+
+    template <class EC, layout_type L, class SC>
+    template <class S>
+    inline xarray_container<EC, L, SC> xarray_container<EC, L, SC>::from_shape(S&& s)
+    {
+        shape_type shape = forward_sequence<shape_type>(s);
+        return self_type(shape);
+    }
+    //@}
+
+
+    /**
+     * @name Extended copy semantic
+     */
+    //@{
+    /**
+     * The extended copy constructor.
+     */
+    template <class EC, layout_type L, class SC>
+    template <class E>
+    inline xarray_container<EC, L, SC>::xarray_container(const xexpression<E>& e)
+        : base_type()
+    {
+        // Avoids unintialized data because of (m_shape == shape) condition
+        // in reshape (called by assign), which is always true when dimension == 0.
+        if (e.derived_cast().dimension() == 0)
+        {
+            m_data.resize(1);
+        }
+        semantic_base::assign(e);
+    }
+
+    /**
+     * The extended assignment operator.
+     */
+    template <class EC, layout_type L, class SC>
+    template <class E>
+    inline auto xarray_container<EC, L, SC>::operator=(const xexpression<E>& e) -> self_type&
+    {
+        return semantic_base::operator=(e);
+    }
+    //@}
+
+    template <class EC, layout_type L, class SC>
+    inline auto xarray_container<EC, L, SC>::data_impl() noexcept -> container_type&
+    {
+        return m_data;
+    }
+
+    template <class EC, layout_type L, class SC>
+    inline auto xarray_container<EC, L, SC>::data_impl() const noexcept -> const container_type&
+    {
+        return m_data;
+    }
+
+    /******************
+     * xarray_adaptor *
+     ******************/
+
+    /**
+     * @name Constructors
+     */
+    //@{
+    /**
+     * Constructs an xarray_adaptor of the given stl-like container.
+     * @param data the container to adapt
+     */
+    template <class EC, layout_type L, class SC>
+    inline xarray_adaptor<EC, L, SC>::xarray_adaptor(container_closure_type data)
+        : base_type(), m_data(std::forward<container_closure_type>(data))
+    {
+    }
+
+    /**
+     * Constructs an xarray_adaptor of the given stl-like container,
+     * with the specified shape and layout_type.
+     * @param data the container to adapt
+     * @param shape the shape of the xarray_adaptor
+     * @param l the layout_type of the xarray_adaptor
+     */
+    template <class EC, layout_type L, class SC>
+    inline xarray_adaptor<EC, L, SC>::xarray_adaptor(container_closure_type data, const shape_type& shape, layout_type l)
+        : base_type(), m_data(std::forward<container_closure_type>(data))
+    {
+        base_type::reshape(shape, l);
+    }
+
+    /**
+     * Constructs an xarray_adaptor of the given stl-like container,
+     * with the specified shape and strides.
+     * @param data the container to adapt
+     * @param shape the shape of the xarray_adaptor
+     * @param strides the strides of the xarray_adaptor
+     */
+    template <class EC, layout_type L, class SC>
+    inline xarray_adaptor<EC, L, SC>::xarray_adaptor(container_closure_type data, const shape_type& shape, const strides_type& strides)
+        : base_type(), m_data(std::forward<container_closure_type>(data))
+    {
+        base_type::reshape(shape, strides);
+    }
+    //@}
+
+    template <class EC, layout_type L, class SC>
+    inline auto xarray_adaptor<EC, L, SC>::operator=(const xarray_adaptor& rhs) -> self_type&
+    {
+        base_type::operator=(rhs);
+        m_data = rhs.m_data;
+        return *this;
+    }
+
+    template <class EC, layout_type L, class SC>
+    inline auto xarray_adaptor<EC, L, SC>::operator=(xarray_adaptor&& rhs) -> self_type&
+    {
+        base_type::operator=(std::move(rhs));
+        m_data = rhs.m_data;
+        return *this;
+    }
+
+    /**
+     * @name Extended copy semantic
+     */
+    //@{
+    /**
+     * The extended assignment operator.
+     */
+    template <class EC, layout_type L, class SC>
+    template <class E>
+    inline auto xarray_adaptor<EC, L, SC>::operator=(const xexpression<E>& e) -> self_type&
+    {
+        return semantic_base::operator=(e);
+    }
+    //@}
+
+    template <class EC, layout_type L, class SC>
+    inline auto xarray_adaptor<EC, L, SC>::data_impl() noexcept -> container_type&
+    {
+        return m_data;
+    }
+
+    template <class EC, layout_type L, class SC>
+    inline auto xarray_adaptor<EC, L, SC>::data_impl() const noexcept -> const container_type&
+    {
+        return m_data;
+    }
+
+    template <class EC, layout_type L, class SC>
+    inline void xarray_adaptor<EC, L, SC>::assign_temporary_impl(temporary_type& tmp)
+    {
+        // TODO (performance improvement) : consider moving tmps
+        // shape and strides
+        base_type::shape_impl() = tmp.shape();
+        base_type::strides_impl() = tmp.strides();
+        base_type::backstrides_impl() = tmp.backstrides();
+        m_data.resize(tmp.size());
+        std::copy(tmp.data().cbegin(), tmp.data().cend(), m_data.begin());
+    }
+
+}
+
+#endif

--- a/inst/include/xtensor/xassign.hpp
+++ b/inst/include/xtensor/xassign.hpp
@@ -1,0 +1,230 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XASSIGN_HPP
+#define XASSIGN_HPP
+
+#include "xiterator.hpp"
+#include "xtensor_forward.hpp"
+#include <algorithm>
+
+namespace xt
+{
+    template <class E>
+    class xexpression;
+
+    /********************
+     * Assign functions *
+     ********************/
+
+    template <class E1, class E2>
+    void assign_data(xexpression<E1>& e1, const xexpression<E2>& e2, bool trivial);
+
+    template <class E1, class E2>
+    bool reshape(xexpression<E1>& e1, const xexpression<E2>& e2);
+
+    template <class E1, class E2>
+    void assign_xexpression(xexpression<E1>& e1, const xexpression<E2>& e2);
+
+    template <class E1, class E2>
+    void computed_assign(xexpression<E1>& e1, const xexpression<E2>& e2);
+
+    template <class E1, class E2, class F>
+    void scalar_computed_assign(xexpression<E1>& e1, const E2& e2, F&& f);
+
+    template <class E1, class E2>
+    void assert_compatible_shape(const xexpression<E1>& e1, const xexpression<E2>& e2);
+
+    /*****************
+     * data_assigner *
+     *****************/
+
+    template <class E1, class E2>
+    class data_assigner
+    {
+
+    public:
+
+        using lhs_iterator = typename E1::stepper;
+        using rhs_iterator = typename E2::const_stepper;
+        using shape_type = typename E1::shape_type;
+        using index_type = xindex_type_t<shape_type>;
+        using size_type = typename lhs_iterator::size_type;
+
+        data_assigner(E1& e1, const E2& e2);
+
+        void run();
+
+        void step(size_type i);
+        void reset(size_type i);
+
+        void to_end();
+
+    private:
+
+        E1& m_e1;
+
+        lhs_iterator m_lhs;
+        rhs_iterator m_rhs;
+        rhs_iterator m_rhs_end;
+
+        index_type m_index;
+    };
+
+    /***********************************
+     * Assign functions implementation *
+     ***********************************/
+
+    namespace detail
+    {
+        template <class E1, class E2>
+        inline bool is_trivial_broadcast(const E1& e1, const E2& e2)
+        {
+            return e2.is_trivial_broadcast(e1.strides());
+        }
+
+        template <class D, class E2, class... SL>
+        inline bool is_trivial_broadcast(const xview<D, SL...>&, const E2&)
+        {
+            return false;
+        }
+    }
+
+    template <class E1, class E2>
+    inline void assign_data(xexpression<E1>& e1, const xexpression<E2>& e2, bool trivial)
+    {
+        E1& de1 = e1.derived_cast();
+        const E2& de2 = e2.derived_cast();
+
+        bool trivial_broadcast = trivial && detail::is_trivial_broadcast(de1, de2);
+        if (trivial_broadcast)
+        {
+            std::copy(de2.cbegin(), de2.cend(), de1.begin());
+        }
+        else
+        {
+            data_assigner<E1, E2> assigner(de1, de2);
+            assigner.run();
+        }
+    }
+
+    template <class E1, class E2>
+    inline bool reshape(xexpression<E1>& e1, const xexpression<E2>& e2)
+    {
+        using shape_type = typename E1::shape_type;
+        using size_type = typename E1::size_type;
+        const E2& de2 = e2.derived_cast();
+        size_type size = de2.dimension();
+        shape_type shape = make_sequence<shape_type>(size, size_type(1));
+        bool trivial_broadcast = de2.broadcast_shape(shape);
+        e1.derived_cast().reshape(shape);
+        return trivial_broadcast;
+    }
+
+    template <class E1, class E2>
+    inline void assign_xexpression(xexpression<E1>& e1, const xexpression<E2>& e2)
+    {
+        bool trivial_broadcast = reshape(e1, e2);
+        assign_data(e1, e2, trivial_broadcast);
+    }
+
+    template <class E1, class E2>
+    inline void computed_assign(xexpression<E1>& e1, const xexpression<E2>& e2)
+    {
+        using shape_type = typename E1::shape_type;
+        using size_type = typename E1::size_type;
+
+        E1& de1 = e1.derived_cast();
+        const E2& de2 = e2.derived_cast();
+
+        size_type dim = de2.dimension();
+        shape_type shape(dim, size_type(1));
+        bool trivial_broadcast = de2.broadcast_shape(shape);
+
+        if (dim > de1.dimension() || shape > de1.shape())
+        {
+            typename E1::temporary_type tmp(shape);
+            assign_data(tmp, e2, trivial_broadcast);
+            de1.assign_temporary(tmp);
+        }
+        else
+        {
+            assign_data(e1, e2, trivial_broadcast);
+        }
+    }
+
+    template <class E1, class E2, class F>
+    inline void scalar_computed_assign(xexpression<E1>& e1, const E2& e2, F&& f)
+    {
+        E1& d = e1.derived_cast();
+        std::transform(d.cbegin(), d.cend(), d.begin(),
+                       [e2, &f](const auto& v) { return f(v, e2); });
+    }
+
+    template <class E1, class E2>
+    inline void assert_compatible_shape(const xexpression<E1>& e1, const xexpression<E2>& e2)
+    {
+        using shape_type = typename E1::shape_type;
+        using size_type = typename E1::size_type;
+        const E1& de1 = e1.derived_cast();
+        const E2& de2 = e2.derived_cast();
+        size_type size = de2.dimension();
+        shape_type shape(size, size_type(1));
+        de2.broadcast_shape(shape);
+        if (shape.size() > de1.shape().size() || shape > de1.shape())
+        {
+            throw broadcast_error(shape, de1.shape());
+        }
+    }
+
+    /********************************
+     * data_assigner implementation *
+     ********************************/
+
+    template <class E1, class E2>
+    inline data_assigner<E1, E2>::data_assigner(E1& e1, const E2& e2)
+        : m_e1(e1), m_lhs(e1.stepper_begin(e1.shape())),
+          m_rhs(e2.stepper_begin(e1.shape())), m_rhs_end(e2.stepper_end(e1.shape())),
+          m_index(make_sequence<index_type>(e1.shape().size(), size_type(0)))
+    {
+    }
+
+    template <class E1, class E2>
+    inline void data_assigner<E1, E2>::run()
+    {
+        while (m_rhs != m_rhs_end)
+        {
+            *m_lhs = *m_rhs;
+            stepper_tools<default_assignable_layout(E1::static_layout)>::increment_stepper(*this, m_index, m_e1.shape());
+        }
+    }
+
+    template <class E1, class E2>
+    inline void data_assigner<E1, E2>::step(size_type i)
+    {
+        m_lhs.step(i);
+        m_rhs.step(i);
+    }
+
+    template <class E1, class E2>
+    inline void data_assigner<E1, E2>::reset(size_type i)
+    {
+        m_lhs.reset(i);
+        m_rhs.reset(i);
+    }
+
+    template <class E1, class E2>
+    inline void data_assigner<E1, E2>::to_end()
+    {
+        m_lhs.to_end();
+        m_rhs.to_end();
+    }
+}
+
+#endif
+

--- a/inst/include/xtensor/xaxis_iterator.hpp
+++ b/inst/include/xtensor/xaxis_iterator.hpp
@@ -1,0 +1,196 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XAXIS_ITERATOR_HPP
+#define XAXIS_ITERATOR_HPP
+
+#include "xview.hpp"
+
+namespace xt
+{
+
+    /******************
+     * xaxis_iterator *
+     ******************/
+
+    template <class CT>
+    class xaxis_iterator
+    {
+
+    public:
+
+        using self_type = xaxis_iterator<CT>;
+
+        using xexpression_type = std::decay_t<CT>;
+        using size_type = typename xexpression_type::size_type;
+        using difference_type = typename xexpression_type::difference_type;
+        using value_type = xview<CT, size_type>;
+        using reference = std::remove_reference_t<apply_cv_t<CT, value_type>>;
+        using pointer = std::nullptr_t;
+
+        using iterator_category = std::forward_iterator_tag;
+
+        xaxis_iterator();
+        template <class CTA>
+        xaxis_iterator(CTA&& e, size_type index);
+
+        self_type& operator++();
+        self_type operator++(int);
+
+        reference operator*() const;
+        pointer operator->() const;
+
+        bool equal(const self_type& rhs) const;
+
+    private:
+
+        using storing_type = ptr_closure_t<CT>;
+        mutable storing_type p_expression;
+        size_type m_index;
+
+        template <class T>
+        std::enable_if_t<std::is_pointer<T>::value, std::add_lvalue_reference_t<std::remove_pointer_t<T>>>
+        deref(T val) const;
+
+        template <class T>
+        std::enable_if_t<!std::is_pointer<T>::value, T>
+        deref(T& val) const;
+
+        template <class T, class CTA>
+        std::enable_if_t<std::is_pointer<T>::value, T>
+        get_storage_init(CTA&& e) const;
+
+        template <class T, class CTA>
+        std::enable_if_t<!std::is_pointer<T>::value, T>
+        get_storage_init(CTA&& e) const;
+    };
+
+    template <class CT>
+    bool operator==(const xaxis_iterator<CT>& lhs, const xaxis_iterator<CT>& rhs);
+
+    template <class CT>
+    bool operator!=(const xaxis_iterator<CT>& lhs, const xaxis_iterator<CT>& rhs);
+
+    template <class E>
+    auto axis_begin(E&& e);
+
+    template <class E>
+    auto axis_end(E&& e);
+
+    /*********************************
+     * xaxis_iterator implementation *
+     *********************************/
+
+    template <class CT>
+    template <class T>
+    inline std::enable_if_t<std::is_pointer<T>::value, std::add_lvalue_reference_t<std::remove_pointer_t<T>>>
+    xaxis_iterator<CT>::deref(T val) const
+    {
+        return *val;
+    }
+
+    template <class CT>
+    template <class T>
+    inline std::enable_if_t<!std::is_pointer<T>::value, T>
+    xaxis_iterator<CT>::deref(T& val) const
+    {
+        return val;
+    }
+
+    template <class CT>
+    template <class T, class CTA>
+    inline std::enable_if_t<std::is_pointer<T>::value, T>
+    xaxis_iterator<CT>::get_storage_init(CTA&& e) const
+    {
+        return &e;
+    }
+
+    template <class CT>
+    template <class T, class CTA>
+    inline std::enable_if_t<!std::is_pointer<T>::value, T>
+    xaxis_iterator<CT>::get_storage_init(CTA&& e) const
+    {
+        return e;
+    }
+
+    template <class CT>
+    inline xaxis_iterator<CT>::xaxis_iterator()
+        : p_expression(nullptr), m_index(0)
+    {
+    }
+
+    template <class CT>
+    template <class CTA>
+    inline xaxis_iterator<CT>::xaxis_iterator(CTA&& e, size_type index)
+        : p_expression(get_storage_init<storing_type>(std::forward<CTA>(e))), m_index(index)
+    {
+    }
+
+    template <class CT>
+    inline auto xaxis_iterator<CT>::operator++() -> self_type&
+    {
+        ++m_index;
+        return *this;
+    }
+
+    template <class CT>
+    inline auto xaxis_iterator<CT>::operator++(int) -> self_type
+    {
+        self_type tmp(*this);
+        ++(*this);
+        return tmp;
+    }
+
+    template <class CT>
+    inline auto xaxis_iterator<CT>::operator*() const -> reference
+    {
+        return view(deref(p_expression), size_type(m_index));
+    }
+
+    template <class CT>
+    inline auto xaxis_iterator<CT>::operator->() const -> pointer
+    {
+        return nullptr;
+    }
+
+    template<class CT>
+    inline bool xaxis_iterator<CT>::equal(const self_type& rhs) const
+    {
+        return p_expression == rhs.p_expression && m_index == rhs.m_index;
+    }
+
+    template <class CT>
+    inline bool operator==(const xaxis_iterator<CT>& lhs, const xaxis_iterator<CT>& rhs)
+    {
+        return lhs.equal(rhs);
+    }
+
+    template <class CT>
+    inline bool operator!=(const xaxis_iterator<CT>& lhs, const xaxis_iterator<CT>& rhs)
+    {
+        return !(lhs == rhs);
+    }
+
+    template <class E>
+    inline auto axis_begin(E&& e)
+    {
+        using return_type = xaxis_iterator<closure_t<E>>;
+        using size_type = typename std::decay_t<E>::size_type;
+        return return_type(std::forward<E>(e), size_type(0));
+    }
+
+    template <class E>
+    inline auto axis_end(E&& e)
+    {
+        using return_type = xaxis_iterator<closure_t<E>>;
+        using size_type = typename std::decay_t<E>::size_type;
+        return return_type(std::forward<E>(e), size_type(e.shape()[0]));
+    }
+}
+
+#endif

--- a/inst/include/xtensor/xbroadcast.hpp
+++ b/inst/include/xtensor/xbroadcast.hpp
@@ -1,0 +1,336 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XBROADCAST_HPP
+#define XBROADCAST_HPP
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <iterator>
+#include <numeric>
+#include <type_traits>
+#include <utility>
+
+#include "xexpression.hpp"
+#include "xiterable.hpp"
+#include "xstrides.hpp"
+#include "xutils.hpp"
+
+namespace xt
+{
+
+    /*************
+     * broadcast *
+     *************/
+
+    template <class E, class S>
+    auto broadcast(E&& e, const S& s) noexcept;
+
+#ifdef X_OLD_CLANG
+    template <class E, class I>
+    auto broadcast(E&& e, std::initializer_list<I> s) noexcept;
+#else
+    template <class E, class I, std::size_t L>
+    auto broadcast(E&& e, const I (&s)[L]) noexcept;
+#endif
+
+    /**************
+     * xbroadcast *
+     **************/
+
+    template <class CT, class X>
+    class xbroadcast;
+
+    template <class CT, class X>
+    struct xiterable_inner_types<xbroadcast<CT, X>>
+    {
+        using xexpression_type = std::decay_t<CT>;
+        using inner_shape_type = promote_shape_t<typename xexpression_type::shape_type, X>;
+        using const_stepper = typename xexpression_type::const_stepper;
+        using stepper = const_stepper;
+        using const_iterator = xiterator<const_stepper, inner_shape_type*, DEFAULT_LAYOUT>;
+        using iterator = const_iterator;
+        using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+        using reverse_iterator = std::reverse_iterator<iterator>;
+    };
+
+    /**
+     * @class xbroadcast
+     * @brief Broadcasted xexpression to a specified shape.
+     *
+     * The xbroadcast class implements the broadcasting of an \ref xexpression
+     * to a specified shape. xbroadcast is not meant to be used directly, but
+     * only with the \ref broadcast helper functions.
+     *
+     * @tparam CT the closure type of the \ref xexpression to broadcast
+     * @tparam X the type of the specified shape.
+     *
+     * @sa broadcast
+     */
+    template <class CT, class X>
+    class xbroadcast : public xexpression<xbroadcast<CT, X>>,
+                       public xexpression_const_iterable<xbroadcast<CT, X>>
+    {
+
+    public:
+        using self_type = xbroadcast<CT, X>;
+        using xexpression_type = std::decay_t<CT>;
+
+        using value_type = typename xexpression_type::value_type;
+        using reference = typename xexpression_type::reference;
+        using const_reference = typename xexpression_type::const_reference;
+        using pointer = typename xexpression_type::pointer;
+        using const_pointer = typename xexpression_type::const_pointer;
+        using size_type = typename xexpression_type::size_type;
+        using difference_type = typename xexpression_type::difference_type;
+
+        using iterable_base = xexpression_const_iterable<self_type>;
+        using inner_shape_type = typename iterable_base::inner_shape_type;
+        using shape_type = inner_shape_type;
+
+        using stepper = typename iterable_base::stepper;
+        using const_stepper = typename iterable_base::const_stepper;
+
+        static constexpr layout_type static_layout = xexpression_type::static_layout;
+        static constexpr bool contiguous_layout = xexpression_type::contiguous_layout;
+
+        template <class CTA, class S>
+        xbroadcast(CTA&& e, S&& s) noexcept;
+
+        size_type size() const noexcept;
+        size_type dimension() const noexcept;
+        const inner_shape_type& shape() const noexcept;
+        layout_type layout() const noexcept;
+
+        template <class... Args>
+        const_reference operator()(Args... args) const;
+        const_reference operator[](const xindex& index) const;
+        const_reference operator[](size_type i) const;
+
+        template <class It>
+        const_reference element(It, It last) const;
+
+        template <class S>
+        bool broadcast_shape(S& shape) const;
+
+        template <class S>
+        bool is_trivial_broadcast(const S& strides) const noexcept;
+
+        template <class S>
+        const_stepper stepper_begin(const S& shape) const noexcept;
+        template <class S>
+        const_stepper stepper_end(const S& shape) const noexcept;
+
+    private:
+        CT m_e;
+        inner_shape_type m_shape;
+    };
+
+    /****************************
+     * broadcast implementation *
+     ****************************/
+
+    /**
+     * @brief Returns an \ref xexpression broadcasting the given expression to
+     * a specified shape.
+     *
+     * @tparam e the \ref xexpression to broadcast
+     * @tparam s the specified shape to broadcast.
+     *
+     * The returned expression either hold a const reference to \p e or a copy
+     * depending on whether \p e is an lvalue or an rvalue.
+     */
+    template <class E, class S>
+    inline auto broadcast(E&& e, const S& s) noexcept
+    {
+        using broadcast_type = xbroadcast<const_xclosure_t<E>, S>;
+        using shape_type = typename broadcast_type::shape_type;
+        return broadcast_type(std::forward<E>(e), forward_sequence<shape_type>(s));
+    }
+
+#ifdef X_OLD_CLANG
+    template <class E, class I>
+    inline auto broadcast(E&& e, std::initializer_list<I> s) noexcept
+    {
+        using broadcast_type = xbroadcast<const_xclosure_t<E>, std::vector<std::size_t>>;
+        using shape_type = typename broadcast_type::shape_type;
+        return broadcast_type(std::forward<E>(e), forward_sequence<shape_type>(s));
+    }
+#else
+    template <class E, class I, std::size_t L>
+    inline auto broadcast(E&& e, const I (&s)[L]) noexcept
+    {
+        using broadcast_type = xbroadcast<const_xclosure_t<E>, std::array<std::size_t, L>>;
+        using shape_type = typename broadcast_type::shape_type;
+        return broadcast_type(std::forward<E>(e), forward_sequence<shape_type>(s));
+    }
+#endif
+
+    /*****************************
+     * xbroadcast implementation *
+     *****************************/
+
+    /**
+     * @name Constructor
+     */
+    //@{
+    /**
+     * Constructs an xbroadcast expression broadcasting the specified
+     * \ref xexpression to the given shape
+     *
+     * @param e the expression to broadcast
+     * @param s the shape to apply
+     */
+    template <class CT, class X>
+    template <class CTA, class S>
+    inline xbroadcast<CT, X>::xbroadcast(CTA&& e, S&& s) noexcept
+        : m_e(std::forward<CTA>(e)), m_shape(std::forward<S>(s))
+    {
+        xt::broadcast_shape(m_e.shape(), m_shape);
+    }
+    //@}
+
+    /**
+     * @name Size and shape
+     */
+    /**
+     * Returns the size of the expression.
+     */
+    template <class CT, class X>
+    inline auto xbroadcast<CT, X>::size() const noexcept -> size_type
+    {
+        return compute_size(shape());
+    }
+
+    /**
+     * Returns the number of dimensions of the expression.
+     */
+    template <class CT, class X>
+    inline auto xbroadcast<CT, X>::dimension() const noexcept -> size_type
+    {
+        return m_shape.size();
+    }
+
+    /**
+     * Returns the shape of the expression.
+     */
+    template <class CT, class X>
+    inline auto xbroadcast<CT, X>::shape() const noexcept -> const inner_shape_type&
+    {
+        return m_shape;
+    }
+
+    /**
+     * Returns the layout_type of the expression.
+     */
+    template <class CT, class X>
+    inline layout_type xbroadcast<CT, X>::layout() const noexcept
+    {
+        return m_e.layout();
+    }
+    //@}
+
+    /**
+     * @name Data
+     */
+    /**
+     * Returns a constant reference to the element at the specified position in the expression.
+     * @param args a list of indices specifying the position in the function. Indices
+     * must be unsigned integers, the number of indices should be equal or greater than
+     * the number of dimensions of the expression.
+     */
+    template <class CT, class X>
+    template <class... Args>
+    inline auto xbroadcast<CT, X>::operator()(Args... args) const -> const_reference
+    {
+        return detail::get_element(m_e, args...);
+    }
+
+    /**
+     * Returns a constant reference to the element at the specified position in the expression.
+     * @param index a sequence of indices specifying the position in the function. Indices
+     * must be unsigned integers, the number of indices in the sequence should be equal or greater
+     * than the number of dimensions of the container.
+     */
+    template <class CT, class X>
+    inline auto xbroadcast<CT, X>::operator[](const xindex& index) const -> const_reference
+    {
+        return element(index.cbegin(), index.cend());
+    }
+
+    template <class CT, class X>
+    inline auto xbroadcast<CT, X>::operator[](size_type i) const -> const_reference
+    {
+        return operator()(i);
+    }
+
+    /**
+     * Returns a constant reference to the element at the specified position in the expression.
+     * @param first iterator starting the sequence of indices
+     * @param last iterator ending the sequence of indices
+     * The number of indices in the squence should be equal to or greater
+     * than the number of dimensions of the function.
+     */
+    template <class CT, class X>
+    template <class It>
+    inline auto xbroadcast<CT, X>::element(It, It last) const -> const_reference
+    {
+        return m_e.element(last - dimension(), last);
+    }
+    //@}
+
+    /**
+     * @name Broadcasting
+     */
+    //@{
+    /**
+     * Broadcast the shape of the function to the specified parameter.
+     * @param shape the result shape
+     * @return a boolean indicating whether the broadcasting is trivial
+     */
+    template <class CT, class X>
+    template <class S>
+    inline bool xbroadcast<CT, X>::broadcast_shape(S& shape) const
+    {
+        return xt::broadcast_shape(m_shape, shape);
+    }
+
+    /**
+     * Compares the specified strides with those of the container to see whether
+     * the broadcasting is trivial.
+     * @return a boolean indicating whether the broadcasting is trivial
+     */
+    template <class CT, class X>
+    template <class S>
+    inline bool xbroadcast<CT, X>::is_trivial_broadcast(const S& strides) const noexcept
+    {
+        return dimension() == m_e.dimension() &&
+            std::equal(m_shape.cbegin(), m_shape.cend(), m_e.shape().cbegin()) &&
+            m_e.is_trivial_broadcast(strides);
+    }
+    //@}
+
+    template <class CT, class X>
+    template <class S>
+    inline auto xbroadcast<CT, X>::stepper_begin(const S& shape) const noexcept -> const_stepper
+    {
+        // Could check if (broadcastable(shape, m_shape)
+        return m_e.stepper_begin(shape);
+    }
+
+    template <class CT, class X>
+    template <class S>
+    inline auto xbroadcast<CT, X>::stepper_end(const S& shape) const noexcept -> const_stepper
+    {
+        // Could check if (broadcastable(shape, m_shape)
+        return m_e.stepper_end(shape);
+    }
+}
+
+#endif

--- a/inst/include/xtensor/xbuffer_adaptor.hpp
+++ b/inst/include/xtensor/xbuffer_adaptor.hpp
@@ -1,0 +1,589 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XBUFFER_ADAPTOR_HPP
+#define XBUFFER_ADAPTOR_HPP
+
+#include <algorithm>
+#include <functional>
+#include <iterator>
+#include <memory>
+#include "xstorage.hpp"
+
+namespace xt
+{
+    struct no_ownership {};
+    struct acquire_ownership {};
+
+    namespace detail
+    {
+
+        template <class T, class A>
+        class xbuffer_storage
+        {
+
+        public:
+
+            using self_type = xbuffer_storage<T, A>;
+            using allocator_type = A;
+            using value_type = typename allocator_type::value_type;
+            using reference = typename allocator_type::reference;
+            using const_reference = typename allocator_type::const_reference;
+            using pointer = typename allocator_type::pointer;
+            using const_pointer = typename allocator_type::const_pointer;
+            using size_type = typename allocator_type::size_type;
+            using difference_type = typename allocator_type::difference_type;
+
+            xbuffer_storage();
+            xbuffer_storage(T*& data, size_type size, const allocator_type& alloc = allocator_type());
+
+            size_type size() const noexcept;
+            void resize(size_type size);
+
+            pointer data() noexcept;
+            const_pointer data() const noexcept;
+
+            void swap(self_type& rhs) noexcept;
+
+        private:
+
+            pointer p_data;
+            size_type m_size;
+        };
+
+        template <class T, class A>
+        class xbuffer_owner_storage
+        {
+
+        public:
+
+            using self_type = xbuffer_owner_storage<T, A>;
+            using allocator_type = A;
+            using value_type = typename allocator_type::value_type;
+            using reference = typename allocator_type::reference;
+            using const_reference = typename allocator_type::const_reference;
+            using pointer = typename allocator_type::pointer;
+            using const_pointer = typename allocator_type::const_pointer;
+            using size_type = typename allocator_type::size_type;
+            using difference_type = typename allocator_type::difference_type;
+
+            xbuffer_owner_storage();
+            xbuffer_owner_storage(T*& data, size_type size, const allocator_type& alloc = allocator_type());
+            ~xbuffer_owner_storage();
+
+            xbuffer_owner_storage(const self_type&) = delete;
+            self_type& operator=(const self_type&);
+
+            xbuffer_owner_storage(self_type&&);
+            self_type& operator=(self_type&&);
+
+            size_type size() const noexcept;
+            void resize(size_type size);
+
+            pointer data() noexcept;
+            const_pointer data() const noexcept;
+
+            allocator_type get_allocator() const noexcept;
+
+            void swap(self_type& rhs) noexcept;
+
+        private:
+
+            pointer* p_data;
+            size_type m_size;
+            allocator_type m_allocator;
+        };
+
+        template <class T, class A, class O>
+        struct get_buffer_storage
+        {
+            using type = xbuffer_storage<T, A>;
+        };
+
+        template <class T, class A>
+        struct get_buffer_storage<T, A, acquire_ownership>
+        {
+            using type = xbuffer_owner_storage<T, A>;
+        };
+
+        template <class T, class A, class O>
+        using buffer_storage_t = typename get_buffer_storage<T, A, O>::type;
+    }
+
+    template <class T, class O = no_ownership, class A = std::allocator<T>>
+    class xbuffer_adaptor : private detail::buffer_storage_t<T, A, O>
+    {
+
+    public:
+
+        using base_type = detail::buffer_storage_t<T, A, O>;
+        using allocator_type = typename base_type::allocator_type;
+        using value_type = typename base_type::value_type;
+        using reference = typename base_type::reference;
+        using const_reference = typename base_type::const_reference;
+        using pointer = typename base_type::pointer;
+        using const_pointer = typename base_type::const_pointer;
+
+        using size_type = typename base_type::size_type;
+        using difference_type = typename base_type::difference_type;
+
+        using iterator = pointer;
+        using const_iterator = const_pointer;
+        using reverse_iterator = std::reverse_iterator<iterator>;
+        using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+        xbuffer_adaptor() = default;
+
+        template <class OW = O, class = std::enable_if_t<std::is_same<OW, acquire_ownership>::value>>
+        xbuffer_adaptor(T*& data, size_type size, const allocator_type& alloc = allocator_type());
+
+        template <class OW = O, class = std::enable_if_t<std::is_same<OW, no_ownership>::value>>
+        xbuffer_adaptor(T* data, size_type size, const allocator_type& alloc = allocator_type());
+
+        bool empty() const noexcept;
+        using base_type::size;
+        using base_type::resize;
+
+        reference operator[](size_type i);
+        const_reference operator[](size_type i) const;
+
+        reference front();
+        const_reference front() const;
+
+        reference back();
+        const_reference back() const;
+
+        iterator begin();
+        iterator end();
+
+        const_iterator begin() const;
+        const_iterator end() const;
+        const_iterator cbegin() const;
+        const_iterator cend() const;
+
+        reverse_iterator rbegin();
+        reverse_iterator rend();
+
+        const_reverse_iterator rbegin() const;
+        const_reverse_iterator rend() const;
+        const_reverse_iterator crbegin() const;
+        const_reverse_iterator crend() const;
+
+        using base_type::data;
+        using base_type::swap;
+    };
+
+    template <class T, class O, class A>
+    bool operator==(const xbuffer_adaptor<T, O, A>& lhs,
+                    const xbuffer_adaptor<T, O, A>& rhs);
+
+    template <class T, class O, class A>
+    bool operator!=(const xbuffer_adaptor<T, O, A>& lhs,
+                    const xbuffer_adaptor<T, O, A>& rhs);
+
+    template <class T, class O, class A>
+    bool operator<(const xbuffer_adaptor<T, O, A>& lhs,
+                   const xbuffer_adaptor<T, O, A>& rhs);
+
+    template <class T, class O, class A>
+    bool operator<=(const xbuffer_adaptor<T, O, A>& lhs,
+                    const xbuffer_adaptor<T, O, A>& rhs);
+
+    template <class T, class O, class A>
+    bool operator>(const xbuffer_adaptor<T, O, A>& lhs,
+                   const xbuffer_adaptor<T, O, A>& rhs);
+
+    template <class T, class O, class A>
+    bool operator>=(const xbuffer_adaptor<T, O, A>& lhs,
+                    const xbuffer_adaptor<T, O, A>& rhs);
+
+    template <class T, class O, class A>
+    void swap(xbuffer_adaptor<T, O, A>& lhs,
+              xbuffer_adaptor<T, O, A>& rhs) noexcept;
+
+    /*******************
+     * adaptor_closure *
+     *******************/
+
+    namespace detail
+    {
+        template <class C>
+        struct adaptor_closure_impl
+        {
+            using type = C&;
+        };
+
+        template <class T, class O, class A>
+        struct adaptor_closure_impl<xbuffer_adaptor<T, O, A>>
+        {
+            using type = xbuffer_adaptor<T, O, A>;
+        };
+    }
+
+    template <class C>
+    using adaptor_closure_t = typename detail::adaptor_closure_impl<C>::type;
+
+    /**********************************
+     * xbuffer_storage implementation *
+     **********************************/
+
+    namespace detail
+    {
+        template <class T, class A>
+        inline xbuffer_storage<T, A>::xbuffer_storage()
+            : p_data(nullptr), m_size(0)
+        {
+        }
+
+        template <class T, class A>
+        inline xbuffer_storage<T, A>::xbuffer_storage(T*& data, size_type size, const allocator_type&)
+            : p_data(data), m_size(size)
+        {
+        }
+
+        template <class T, class A>
+        inline auto xbuffer_storage<T, A>::size() const noexcept -> size_type
+        {
+            return m_size;
+        }
+
+        template <class T, class A>
+        inline void xbuffer_storage<T, A>::resize(size_type size)
+        {
+            if (size != m_size)
+                throw std::runtime_error("xbuffer_storage not resizable");
+        }
+
+        template <class T, class A>
+        inline auto xbuffer_storage<T, A>::data() noexcept -> pointer
+        {
+            return p_data;
+        }
+
+        template <class T, class A>
+        inline auto xbuffer_storage<T, A>::data() const noexcept-> const_pointer
+        {
+            return p_data;
+        }
+
+        template <class T, class A>
+        inline void xbuffer_storage<T, A>::swap(self_type& rhs) noexcept
+        {
+            using std::swap;
+            swap(p_data, rhs.p_data);
+            swap(m_size, rhs.m_size);
+        }
+    }
+
+    /****************************************
+     * xbuffer_owner_storage implementation *
+     ****************************************/
+
+    namespace detail
+    {
+        template <class T, class A>
+        inline xbuffer_owner_storage<T, A>::xbuffer_owner_storage()
+            : p_data(nullptr), m_size(0), m_allocator()
+        {
+        }
+
+        template <class T, class A>
+        inline xbuffer_owner_storage<T, A>::xbuffer_owner_storage(T*& data, size_type size, const allocator_type& alloc)
+            : p_data(&data), m_size(size), m_allocator(alloc)
+        {
+        }
+
+        template <class T, class A>
+        inline xbuffer_owner_storage<T, A>::~xbuffer_owner_storage()
+        {
+            if (p_data != nullptr)
+            {
+                safe_destroy_deallocate(m_allocator, *p_data, m_size);
+                p_data = nullptr;
+                m_size = 0;
+            }
+        }
+
+        template <class T, class A>
+        inline auto xbuffer_owner_storage<T, A>::operator=(const self_type& rhs) -> self_type&
+        {
+            using std::swap;
+            if (this != &rhs)
+            {
+                allocator_type al = std::allocator_traits<allocator_type>::select_on_container_copy_construction(rhs.get_allocator());
+                pointer tmp = safe_init_allocate(al, rhs.m_size);
+                if (std::is_trivially_default_constructible<value_type>::value)
+                {
+                    std::uninitialized_copy(*(rhs.p_data), *(rhs.p_data) + rhs.m_size, tmp);
+                }
+                else
+                {
+                    std::copy(*(rhs.p_data), *(rhs.p_data) + rhs.m_size, tmp);
+                }
+                swap(*p_data, tmp);
+                m_size = rhs.m_size;
+                swap(m_allocator, al);
+                safe_destroy_deallocate(al, tmp, m_size);
+            }
+            return *this;
+        }
+
+        template <class T, class A>
+        inline xbuffer_owner_storage<T, A>::xbuffer_owner_storage(self_type&& rhs)
+            : p_data(rhs.p_data), m_size(rhs.m_size), m_allocator(std::move(rhs.m_allocator))
+        {
+            rhs.p_data = nullptr;
+            rhs.m_size = 0;
+        }
+
+        template <class T, class A>
+        inline auto xbuffer_owner_storage<T, A>::operator=(self_type&& rhs) -> self_type&
+        {
+            swap(rhs);
+            return *this;
+        }
+
+        template <class T, class A>
+        inline auto xbuffer_owner_storage<T, A>::size() const noexcept -> size_type
+        {
+            return m_size;
+        }
+
+        template <class T, class A>
+        void xbuffer_owner_storage<T, A>::resize(size_type size)
+        {
+            using std::swap;
+            if (size != m_size)
+            {
+                pointer tmp = safe_init_allocate(m_allocator, size);
+                swap(*p_data, tmp);
+                swap(m_size, size);
+                safe_destroy_deallocate(m_allocator, tmp, size);
+            }
+        }
+
+        template <class T, class A>
+        inline auto xbuffer_owner_storage<T, A>::data() noexcept -> pointer
+        {
+            return *p_data;
+        }
+
+        template <class T, class A>
+        inline auto xbuffer_owner_storage<T, A>::data() const noexcept -> const_pointer
+        {
+            return *p_data;
+        }
+
+        template <class T, class A>
+        inline auto xbuffer_owner_storage<T, A>::get_allocator() const noexcept -> allocator_type
+        {
+            return allocator_type(m_allocator);
+        }
+
+        template <class T, class A>
+        inline void xbuffer_owner_storage<T, A>::swap(self_type& rhs) noexcept
+        {
+            using std::swap;
+            swap(p_data, rhs.p_data);
+            swap(m_size, rhs.m_size);
+            swap(m_allocator, rhs.m_allocator);
+        }
+    }
+
+    /**********************************
+     * xbuffer_adaptor implementation *
+     **********************************/
+
+    template <class T, class O, class A>
+    template <class OW, class>
+    inline xbuffer_adaptor<T, O, A>::xbuffer_adaptor(T*& data, size_type size, const allocator_type& alloc)
+        : base_type(data, size, alloc)
+    {
+    }
+
+    template <class T, class O, class A>
+    template <class OW, class>
+    inline xbuffer_adaptor<T, O, A>::xbuffer_adaptor(T* data, size_type size, const allocator_type& alloc)
+        : base_type(data, size, alloc)
+    {
+    }
+
+    template <class T, class O, class A>
+    bool xbuffer_adaptor<T, O, A>::empty() const noexcept
+    {
+        return size() == 0;
+    }
+
+    template <class T, class O, class A>
+    inline auto xbuffer_adaptor<T, O, A>::operator[](size_type i) -> reference
+    {
+        return data()[i];
+    }
+
+    template <class T, class O, class A>
+    inline auto xbuffer_adaptor<T, O, A>::operator[](size_type i) const -> const_reference
+    {
+        return data()[i];
+    }
+
+    template <class T, class O, class A>
+    inline auto xbuffer_adaptor<T, O, A>::front() -> reference
+    {
+        return data()[0];
+    }
+
+    template <class T, class O, class A>
+    inline auto xbuffer_adaptor<T, O, A>::front() const -> const_reference
+    {
+        return data()[0];
+    }
+
+    template <class T, class O, class A>
+    inline auto xbuffer_adaptor<T, O, A>::back() -> reference
+    {
+        return data()[size() - 1];
+    }
+
+    template <class T, class O, class A>
+    inline auto xbuffer_adaptor<T, O, A>::back() const -> const_reference
+    {
+        return data()[size() - 1];
+    }
+
+    template <class T, class O, class A>
+    inline auto xbuffer_adaptor<T, O, A>::begin() -> iterator
+    {
+        return data();
+    }
+
+    template <class T, class O, class A>
+    inline auto xbuffer_adaptor<T, O, A>::end() -> iterator
+    {
+        return data() + size();
+    }
+
+    template <class T, class O, class A>
+    inline auto xbuffer_adaptor<T, O, A>::begin() const -> const_iterator
+    {
+        return data();
+    }
+
+    template <class T, class O, class A>
+    inline auto xbuffer_adaptor<T, O, A>::end() const -> const_iterator
+    {
+        return data() + size();
+    }
+
+    template <class T, class O, class A>
+    inline auto xbuffer_adaptor<T, O, A>::cbegin() const->const_iterator
+    {
+        return begin();
+    }
+
+    template <class T, class O, class A>
+    inline auto xbuffer_adaptor<T, O, A>::cend() const -> const_iterator
+    {
+        return end();
+    }
+
+    template <class T, class O, class A>
+    inline auto xbuffer_adaptor<T, O, A>::rbegin() -> reverse_iterator
+    {
+        return reverse_iterator(end());
+    }
+
+    template <class T, class O, class A>
+    inline auto xbuffer_adaptor<T, O, A>::rend() -> reverse_iterator
+    {
+        return reverse_iterator(begin());
+    }
+
+    template <class T, class O, class A>
+    inline auto xbuffer_adaptor<T, O, A>::rbegin() const -> const_reverse_iterator
+    {
+        return const_reverse_iterator(end());
+    }
+
+    template <class T, class O, class A>
+    inline auto xbuffer_adaptor<T, O, A>::rend() const -> const_reverse_iterator
+    {
+        return const_reverse_iterator(begin());
+    }
+
+    template <class T, class O, class A>
+    inline auto xbuffer_adaptor<T, O, A>::crbegin() const -> const_reverse_iterator
+    {
+        return rbegin();
+    }
+
+    template <class T, class O, class A>
+    inline auto xbuffer_adaptor<T, O, A>::crend() const -> const_reverse_iterator
+    {
+        return rend();
+    }
+
+    template <class T, class O, class A>
+    inline bool operator==(const xbuffer_adaptor<T, O, A>& lhs,
+                           const xbuffer_adaptor<T, O, A>& rhs)
+    {
+        return lhs.size() == rhs.size() && std::equal(lhs.begin(), lhs.end(), rhs.begin());
+    }
+
+    template <class T, class O, class A>
+    inline bool operator!=(const xbuffer_adaptor<T, O, A>& lhs,
+                           const xbuffer_adaptor<T, O, A>& rhs)
+    {
+        return !(lhs == rhs);
+    }
+
+    template <class T, class O, class A>
+    inline bool operator<(const xbuffer_adaptor<T, O, A>& lhs,
+                          const xbuffer_adaptor<T, O, A>& rhs)
+    {
+        return std::lexicographical_compare(lhs.begin(), lhs.end(),
+                                            rhs.begin(), rhs.end(),
+                                            std::less<T>());
+    }
+
+    template <class T, class O, class A>
+    inline bool operator<=(const xbuffer_adaptor<T, O, A>& lhs,
+                           const xbuffer_adaptor<T, O, A>& rhs)
+    {
+        return std::lexicographical_compare(lhs.begin(), lhs.end(),
+                                            rhs.begin(), rhs.end(),
+                                            std::less_equal<T>());
+    }
+
+    template <class T, class O, class A>
+    inline bool operator>(const xbuffer_adaptor<T, O, A>& lhs,
+                          const xbuffer_adaptor<T, O, A>& rhs)
+    {
+        return std::lexicographical_compare(lhs.begin(), lhs.end(),
+                                            rhs.begin(), rhs.end(),
+                                            std::greater<T>());
+    }
+
+    template <class T, class O, class A>
+    inline bool operator>=(const xbuffer_adaptor<T, O, A>& lhs,
+                           const xbuffer_adaptor<T, O, A>& rhs)
+    {
+        return std::lexicographical_compare(lhs.begin(), lhs.end(),
+                                            rhs.begin(), rhs.end(),
+                                            std::greater_equal<T>());
+    }
+
+    template <class T, class O, class A>
+    inline void swap(xbuffer_adaptor<T, O, A>& lhs,
+        xbuffer_adaptor<T, O, A>& rhs) noexcept
+    {
+        lhs.swap(rhs);
+    }
+
+}
+
+#endif

--- a/inst/include/xtensor/xbuilder.hpp
+++ b/inst/include/xtensor/xbuilder.hpp
@@ -1,0 +1,849 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+/**
+ * @brief standard mathematical functions for xexpressions
+ */
+
+#ifndef XBUILDER_HPP
+#define XBUILDER_HPP
+
+#include <cmath>
+#include <functional>
+#include <utility>
+
+#include "xbroadcast.hpp"
+#include "xfunction.hpp"
+#include "xgenerator.hpp"
+
+#ifdef X_OLD_CLANG
+    #include <initializer_list>
+    #include <vector>
+#else
+    #include <array>
+#endif
+
+namespace xt
+{
+
+    /********
+     * ones *
+     ********/
+
+    /**
+     * Returns an \ref xexpression containing ones of the specified shape.
+     * @tparam shape the shape of the returned expression.
+     */
+    template <class T, class S>
+    inline auto ones(S shape) noexcept
+    {
+        return broadcast(T(1), std::forward<S>(shape));
+    }
+
+#ifdef X_OLD_CLANG
+    template <class T, class I>
+    inline auto ones(std::initializer_list<I> shape) noexcept
+    {
+        return broadcast(T(1), shape);
+    }
+#else
+    template <class T, class I, std::size_t L>
+    inline auto ones(const I (&shape)[L]) noexcept
+    {
+        return broadcast(T(1), shape);
+    }
+#endif
+
+    /*********
+     * zeros *
+     *********/
+
+    /**
+     * Returns an \ref xexpression containing zeros of the specified shape.
+     * @tparam shape the shape of the returned expression.
+     */
+    template <class T, class S>
+    inline auto zeros(S shape) noexcept
+    {
+        return broadcast(T(0), std::forward<S>(shape));
+    }
+
+#ifdef X_OLD_CLANG
+    template <class T, class I>
+    inline auto zeros(std::initializer_list<I> shape) noexcept
+    {
+        return broadcast(T(0), shape);
+    }
+#else
+    template <class T, class I, std::size_t L>
+    inline auto zeros(const I (&shape)[L]) noexcept
+    {
+        return broadcast(T(0), shape);
+    }
+#endif
+
+    namespace detail
+    {
+        template <class T>
+        class arange_impl
+        {
+        public:
+
+            using value_type = T;
+
+            arange_impl(T start, T stop, T step)
+                : m_start(start), m_stop(stop), m_step(step)
+            {
+            }
+
+            template <class... Args>
+            inline T operator()(Args... args) const
+            {
+                return access_impl(args...);
+            }
+
+            template <class It>
+            inline T element(It first, It) const
+            {
+                return m_start + m_step * T(*first);
+            }
+
+        private:
+
+            value_type m_start;
+            value_type m_stop;
+            value_type m_step;
+
+            template <class T1, class... Args>
+            inline T access_impl(T1 t, Args...) const
+            {
+                return m_start + m_step * T(t);
+            }
+
+            inline T access_impl() const
+            {
+                return m_start;
+            }
+        };
+
+        template <class F>
+        class fn_impl
+        {
+        public:
+
+            using value_type = typename F::value_type;
+            using size_type = std::size_t;
+
+            fn_impl(F&& f)
+                : m_ft(f)
+            {
+            }
+
+            inline value_type operator()() const
+            {
+                size_type idx[1] = {0ul};
+                return access_impl(std::begin(idx), std::end(idx));
+            }
+
+            template <class... Args>
+            inline value_type operator()(Args... args) const
+            {
+                size_type idx[sizeof...(Args)] = {static_cast<size_type>(args)...};
+                return access_impl(std::begin(idx), std::end(idx));
+            }
+
+            template <class It>
+            inline value_type element(It first, It last) const
+            {
+                return access_impl(first, last);
+            }
+
+        private:
+            F m_ft;
+            template <class It>
+            inline value_type access_impl(const It& begin, const It& end) const
+            {
+                return m_ft(begin, end);
+            }
+        };
+
+        template <class T>
+        class eye_fn
+        {
+        public:
+
+            using value_type = T;
+
+            eye_fn(int k)
+                : m_k(k)
+            {
+            }
+
+            template <class It>
+            inline T operator()(const It& /*begin*/, const It& end) const
+            {
+                return *(end - 1) == *(end - 2) + m_k ? T(1) : T(0);
+            }
+
+        private:
+            int m_k;
+        };
+    }
+
+    /**
+     * Generates an array with ones on the diagonal.
+     * @param shape shape of the resulting expression
+     * @param k index of the diagonal. 0 (default) refers to the main diagonal,
+     *          a positive value refers to an upper diagonal, and a negative
+     *          value to a lower diagonal.
+     * @tparam T value_type of xexpression
+     * @return xgenerator that generates the values on access
+     */
+    template <class T = bool>
+    inline auto eye(const std::vector<std::size_t>& shape, int k = 0)
+    {
+        return detail::make_xgenerator(detail::fn_impl<detail::eye_fn<T>>(detail::eye_fn<T>(k)), shape);
+    }
+
+    /**
+     * Generates a (n x n) array with ones on the diagonal.
+     * @param n length of the diagonal.
+     * @param k index of the diagonal. 0 (default) refers to the main diagonal,
+     *          a positive value refers to an upper diagonal, and a negative
+     *          value to a lower diagonal.
+     * @tparam T value_type of xexpression
+     * @return xgenerator that generates the values on access
+     */
+    template <class T = bool>
+    inline auto eye(std::size_t n, int k = 0)
+    {
+        return eye<T>({n, n}, k);
+    }
+
+    /**
+     * Generates numbers evenly spaced within given half-open interval [start, stop).
+     * @param start start of the interval
+     * @param stop stop of the interval
+     * @param step stepsize
+     * @tparam T value_type of xexpression
+     * @return xgenerator that generates the values on access
+     */
+    template <class T>
+    inline auto arange(T start, T stop, T step = 1) noexcept
+    {
+        std::size_t shape = static_cast<std::size_t>(std::ceil((stop - start) / step));
+        return detail::make_xgenerator(detail::arange_impl<T>(start, stop, step), {shape});
+    }
+
+    /**
+     * Generate numbers evenly spaced within given half-open interval [0, stop)
+     * with a step size of 1.
+     * @param stop stop of the interval
+     * @tparam T value_type of xexpression
+     * @return xgenerator that generates the values on access
+     */
+    template <class T>
+    inline auto arange(T stop) noexcept
+    {
+        return arange<T>(T(0), stop, T(1));
+    }
+
+    /**
+     * Generates @a num_samples evenly spaced numbers over given interval
+     * @param start start of interval
+     * @param stop stop of interval
+     * @param num_samples number of samples (defaults to 50)
+     * @param endpoint if true, include endpoint (defaults to true)
+     * @tparam T value_type of xexpression
+     * @return xgenerator that generates the values on access
+     */
+    template <class T>
+    inline auto linspace(T start, T stop, std::size_t num_samples = 50, bool endpoint = true) noexcept
+    {
+        T step = (stop - start) / T(num_samples - (endpoint ? 1 : 0));
+        return detail::make_xgenerator(detail::arange_impl<T>(start, stop, step), {num_samples});
+    }
+
+    /**
+     * Generates @a num_samples numbers evenly spaced on a log scale over given interval
+     * @param start start of interval (pow(base, start) is the first value).
+     * @param stop stop of interval (pow(base, stop) is the final value, except if endpoint = false)
+     * @param num_samples number of samples (defaults to 50)
+     * @param base the base of the log space.
+     * @param endpoint if true, include endpoint (defaults to true)
+     * @tparam T value_type of xexpression
+     * @return xgenerator that generates the values on access
+     */
+    template <class T>
+    inline auto logspace(T start, T stop, std::size_t num_samples, T base = 10, bool endpoint = true) noexcept
+    {
+        return pow(std::forward<T>(base), linspace(start, stop, num_samples, endpoint));
+    }
+
+    namespace detail
+    {
+        template <class... CT>
+        class concatenate_impl
+        {
+        public:
+
+            using size_type = std::size_t;
+            using value_type = std::common_type_t<typename std::decay_t<CT>::value_type...>;
+
+            inline concatenate_impl(std::tuple<CT...>&& t, std::size_t axis)
+                : m_t(t), m_axis(axis)
+            {
+            }
+
+            template <class... Args>
+            inline value_type operator()(Args... args) const
+            {
+                // TODO: avoid memory allocation
+                return access_impl(xindex({{static_cast<size_type>(args)...}}));
+            }
+
+            template <class It>
+            inline value_type element(It first, It last) const
+            {
+                // TODO: avoid memory allocation
+                return access_impl(xindex(first, last));
+            }
+
+        private:
+
+            inline value_type access_impl(xindex idx) const
+            {
+                auto match = [this, &idx](auto& arr)
+                {
+                    if (idx[this->m_axis] >= arr.shape()[this->m_axis])
+                    {
+                        idx[this->m_axis] -= arr.shape()[this->m_axis];
+                        return false;
+                    }
+                    return true;
+                };
+
+                auto get = [&idx](auto& arr)
+                {
+                    return arr[idx];
+                };
+
+                std::size_t i = 0;
+                for (; i < sizeof...(CT); ++i)
+                {
+                    if (apply<bool>(i, match, m_t))
+                    {
+                        break;
+                    }
+                }
+                return apply<value_type>(i, get, m_t);
+            }
+
+            std::tuple<CT...> m_t;
+            size_type m_axis;
+        };
+
+        template <class... CT>
+        class stack_impl
+        {
+        public:
+
+            using size_type = std::size_t;
+            using value_type = std::common_type_t<typename std::decay_t<CT>::value_type...>;
+
+            inline stack_impl(std::tuple<CT...>&& t, std::size_t axis)
+                : m_t(t), m_axis(axis)
+            {
+            }
+
+            template <class... Args>
+            inline value_type operator()(Args... args) const
+            {
+                // TODO: avoid memory allocation
+                return access_impl(xindex({{static_cast<size_type>(args)...}}));
+            }
+
+            template <class It>
+            inline value_type element(It first, It last) const
+            {
+                // TODO: avoid memory allocation
+                return access_impl(xindex(first, last));
+            }
+
+        private:
+
+            inline value_type access_impl(xindex idx) const
+            {
+                auto get_item = [&idx](auto& arr)
+                {
+                    return arr[idx];
+                };
+                std::size_t i = idx[m_axis];
+                idx.erase(idx.begin() + m_axis);
+                return apply<value_type>(i, get_item, m_t);
+            }
+
+            const std::tuple<CT...> m_t;
+            const size_type m_axis;
+        };
+
+        template <class CT>
+        class repeat_impl
+        {
+        public:
+
+            using xexpression_type = std::decay_t<CT>;
+            using size_type = typename xexpression_type::size_type;
+            using value_type = typename xexpression_type::value_type;
+
+            template <class CTA>
+            repeat_impl(CTA&& source, size_type axis)
+                : m_source(std::forward<CTA>(source)), m_axis(axis)
+            {
+            }
+
+            template <class... Args>
+            value_type operator()(Args... args) const
+            {
+                std::array<size_type, sizeof...(Args)> args_arr({static_cast<size_type>(args)...});
+                return m_source(args_arr[m_axis]);
+            }
+
+            template <class It>
+            inline value_type element(It first, It) const
+            {
+                return m_source(*(first + m_axis));
+            }
+
+        private:
+
+            CT m_source;
+            size_type m_axis;
+        };
+    }
+
+    /**
+     * @brief Creates tuples from arguments for \ref concatenate and \ref stack.
+     *        Very similar to std::make_tuple.
+     */
+    template <class... Types>
+    inline auto xtuple(Types&&... args)
+    {
+        return std::tuple<const_closure_t<Types>...>(std::forward<Types>(args)...);
+    }
+
+    /**
+     * @brief Concatenates xexpressions along \em axis.
+     *
+     * @param t \ref xtuple of xexpressions to concatenate
+     * @param axis axis along which elements are concatenated
+     * @returns xgenerator evaluating to concatenated elements
+     *
+     * \code{.cpp}
+     * xt::xarray<double> a = {{1, 2, 3}};
+     * xt::xarray<double> b = {{2, 3, 4}};
+     * xt::xarray<double> c = xt::concatenate(xt::xtuple(a, b)); // => {{1, 2, 3},
+     *                                                                  {2, 3, 4}}
+     * xt::xarray<double> d = xt::concatenate(xt::xtuple(a, b), 1); // => {{1, 2, 3, 2, 3, 4}}
+     * \endcode
+     */
+    template <class... CT>
+    inline auto concatenate(std::tuple<CT...>&& t, std::size_t axis = 0)
+    {
+        using shape_type = promote_shape_t<typename std::decay_t<CT>::shape_type...>;
+        shape_type new_shape = forward_sequence<shape_type>(std::get<0>(t).shape());
+        auto shape_at_axis = [&axis](std::size_t prev, auto& arr) -> std::size_t {
+            return prev + arr.shape()[axis];
+        };
+        new_shape[axis] += accumulate(shape_at_axis, std::size_t(0), t) - new_shape[axis];
+        return detail::make_xgenerator(detail::concatenate_impl<CT...>(std::forward<std::tuple<CT...>>(t), axis), new_shape);
+    }
+
+    namespace detail
+    {
+        template <class T, std::size_t N>
+        inline std::array<T, N + 1> add_axis(std::array<T, N> arr, std::size_t axis, std::size_t value)
+        {
+            std::array<T, N + 1> temp;
+            std::copy(arr.begin(), arr.begin() + axis, temp.begin());
+            temp[axis] = value;
+            std::copy(arr.begin() + axis, arr.end(), temp.begin() + axis + 1);
+            return temp;
+        }
+
+        template <class T>
+        inline T add_axis(T arr, std::size_t axis, std::size_t value)
+        {
+            T temp(arr);
+            temp.insert(temp.begin() + axis, value);
+            return temp;
+        }
+    }
+
+    /**
+     * @brief Stack xexpressions along \em axis.
+     *        Stacking always creates a new dimension along which elements are stacked.
+     *
+     * @param t \ref xtuple of xexpressions to concatenate
+     * @param axis axis along which elements are stacked
+     * @returns xgenerator evaluating to stacked elements
+     *
+     * \code{.cpp}
+     * xt::xarray<double> a = {1, 2, 3};
+     * xt::xarray<double> b = {5, 6, 7};
+     * xt::xarray<double> s = xt::stack(xt::xtuple(a, b)); // => {{1, 2, 3},
+     *                                                            {5, 6, 7}}
+     * xt::xarray<double> t = xt::stack(xt::xtuple(a, b), 1); // => {{1, 5},
+     *                                                               {2, 6},
+     *                                                               {3, 7}}
+     * \endcode
+     */
+    template <class... CT>
+    inline auto stack(std::tuple<CT...>&& t, std::size_t axis = 0)
+    {
+        using shape_type = promote_shape_t<typename std::decay_t<CT>::shape_type...>;
+        auto new_shape = detail::add_axis(forward_sequence<shape_type>(std::get<0>(t).shape()), axis, sizeof...(CT));
+        return detail::make_xgenerator(detail::stack_impl<CT...>(std::forward<std::tuple<CT...>>(t), axis), new_shape);
+    }
+
+    namespace detail
+    {
+
+        template <std::size_t... I, class... E>
+        inline auto meshgrid_impl(std::index_sequence<I...>, E&&... e) noexcept
+        {
+#if defined X_OLD_CLANG || defined _MSC_VER
+            const std::array<std::size_t, sizeof...(E)> shape { e.shape()[0]... };
+            return std::make_tuple(
+                detail::make_xgenerator(
+                    detail::repeat_impl<xclosure_t<E>>(std::forward<E>(e), I),
+                    shape
+                )...
+            );
+#else
+            return std::make_tuple(
+                detail::make_xgenerator(
+                    detail::repeat_impl<xclosure_t<E>>(std::forward<E>(e), I),
+                    { e.shape()[0]... }
+                )...
+            );
+#endif
+        }
+    }
+
+    /**
+     * @brief Return coordinate tensors from coordinate vectors.
+     *        Make N-D coordinate tensor expressions for vectorized evaluations of N-D scalar/vector
+     *        fields over N-D grids, given one-dimensional coordinate arrays x1, x2,..., xn.
+     *
+     * @param e xexpressions to concatenate
+     * @returns tuple of xgenerator expressions.
+     */
+    template <class... E>
+    inline auto meshgrid(E&&... e) noexcept
+    {
+        return detail::meshgrid_impl(std::make_index_sequence<sizeof...(E)>(), std::forward<E>(e)...);
+    }
+
+    namespace detail
+    {
+        template <class CT>
+        class diagonal_fn
+        {
+        public:
+
+            using xexpression_type = std::decay_t<CT>;
+            using value_type = typename xexpression_type::value_type;
+
+            template <class CTA>
+            diagonal_fn(CTA&& source, int offset, std::size_t axis_1, std::size_t axis_2)
+                : m_source(std::forward<CTA>(source)), m_offset(offset), m_axis_1(axis_1), m_axis_2(axis_2)
+            {
+            }
+
+            template <class It>
+            inline value_type operator()(It begin, It) const
+            {
+                xindex idx(m_source.shape().size());
+
+                for (std::size_t i = 0; i < idx.size(); i++)
+                {
+                    if (i != m_axis_1 && i != m_axis_2)
+                    {
+                        idx[i] = *begin++;
+                    }
+                }
+                if (m_offset >= 0)
+                {
+                    idx[m_axis_1] = *(begin);
+                    idx[m_axis_2] = *(begin) + m_offset;
+                }
+                else
+                {
+                    idx[m_axis_1] = *(begin) - m_offset;
+                    idx[m_axis_2] = *(begin);
+                }
+                return m_source[idx];
+            }
+
+        private:
+
+            CT m_source;
+            const int m_offset;
+            const std::size_t m_axis_1;
+            const std::size_t m_axis_2;
+        };
+
+        template <class CT>
+        class diag_fn
+        {
+        public:
+
+            using xexpression_type = std::decay_t<CT>;
+            using value_type = typename xexpression_type::value_type;
+
+            template <class CTA>
+            diag_fn(CTA&& source, int k)
+                : m_source(std::forward<CTA>(source)), m_k(k)
+            {
+            }
+
+            template <class It>
+            inline value_type operator()(It begin, It) const
+            {
+                if (m_k > 0)
+                {
+                    return *begin + m_k == *(begin + 1) ? m_source(*begin) : value_type(0);
+                }
+                else
+                {
+                    return *begin + m_k == *(begin + 1) ? m_source(*begin + m_k) : value_type(0);
+                }
+            }
+
+        private:
+
+            CT m_source;
+            const int m_k;
+        };
+
+        template <class CT>
+        class flip_impl
+        {
+        public:
+
+            using xexpression_type = std::decay_t<CT>;
+            using value_type = typename xexpression_type::value_type;
+            using size_type = typename xexpression_type::size_type;
+
+            template <class CTA>
+            flip_impl(CTA&& source, std::size_t axis)
+                : m_source(std::forward<CTA>(source)), m_axis(axis), m_shape_at_axis(m_source.shape()[m_axis] - 1)
+            {
+            }
+
+            template <class... Args>
+            inline value_type operator()(Args... args) const
+            {
+                std::array<size_type, sizeof...(Args)> idx({static_cast<size_type>(args)...});
+                return access_impl(idx.begin(), idx.end());
+            }
+
+            template <class It>
+            inline value_type element(It first, It last) const
+            {
+                // TODO: avoid memory allocation
+                xindex idx(first, last);
+                return access_impl(idx.begin(), idx.end());
+            }
+
+        private:
+
+            template <class It>
+            inline value_type access_impl(It begin, It end) const
+            {
+                auto it = begin + m_axis;
+                *it = m_shape_at_axis - *it;
+                return m_source.element(begin, end);
+            }
+
+            CT m_source;
+            const size_type m_axis;
+            const size_type m_shape_at_axis;
+        };
+
+        template <class CT, class Comp>
+        class trilu_fn
+        {
+        public:
+
+            using xexpression_type = std::decay_t<CT>;
+            using value_type = typename xexpression_type::value_type;
+            using signed_idx_type = long int;
+
+            template <class CTA>
+            trilu_fn(CTA&& source, int k, Comp comp)
+                : m_source(std::forward<CTA>(source)), m_k(k), m_comp(comp)
+            {
+            }
+
+            template <class It>
+            inline value_type operator()(It begin, It end) const
+            {
+                // have to cast to signed int otherwise -1 can lead to overflow
+                return m_comp(signed_idx_type(*begin) + m_k, signed_idx_type(*(begin + 1))) ? m_source.element(begin, end) : value_type(0);
+            }
+
+        private:
+
+            CT m_source;
+            const signed_idx_type m_k;
+            const Comp m_comp;
+        };
+    }
+
+    /**
+     * @brief Returns the elements on the diagonal of arr
+     * If arr has more than two dimensions, then the axes specified by 
+     * axis_1 and axis_2 are used to determine the 2-D sub-array whose 
+     * diagonal is returned. The shape of the resulting array can be 
+     * determined by removing axis1 and axis2 and appending an index 
+     * to the right equal to the size of the resulting diagonals.
+     *
+     * @param arr the input array
+     * @param offset offset of the diagonal from the main diagonal. Can
+     *               be positive or negative.
+     * @param axis_1 Axis to be used as the first axis of the 2-D sub-arrays 
+     *               from which the diagonals should be taken. 
+     * @param axis_2 Axis to be used as the second axis of the 2-D sub-arrays 
+     *               from which the diagonals should be taken. 
+     * @returns xexpression with values of the diagonal
+     *
+     * \code{.cpp}
+     * xt::xarray<double> a = {{1, 2, 3},
+     *                         {4, 5, 6}
+     *                         {7, 8, 9}};
+     * auto b = xt::diagonal(a); // => {1, 5, 9}
+     * \endcode
+     */
+    template <class E>
+    inline auto diagonal(E&& arr, int offset = 0, std::size_t axis_1 = 0, std::size_t axis_2 = 1)
+    {
+        using CT = xclosure_t<E>;
+        auto shape = arr.shape();
+
+        // the following shape calculation code is an almost verbatim adaptation of numpy:
+        // https://github.com/numpy/numpy/blob/2aabeafb97bea4e1bfa29d946fbf31e1104e7ae0/numpy/core/src/multiarray/item_selection.c#L1799
+
+        auto ret_shape = std::vector<std::size_t>(arr.dimension());
+
+        std::size_t dim_1 = shape[axis_1];
+        std::size_t dim_2 = shape[axis_2];
+        std::size_t n_dim = arr.dimension();
+
+        offset >= 0 ? dim_2 -= offset : dim_1 += offset;
+
+        auto diag_size = dim_2 < dim_1 ? dim_2 : dim_1;
+
+        std::size_t i = 0;
+        for (std::size_t idim = 0; idim < n_dim; ++idim)
+        {
+            if (idim != axis_1 && idim != axis_2)
+            {
+                ret_shape[i++] = shape[idim];
+            }
+        }
+
+        ret_shape[n_dim - 2] = diag_size;
+        ret_shape.pop_back();
+
+        return detail::make_xgenerator(detail::fn_impl<detail::diagonal_fn<CT>>(detail::diagonal_fn<CT>(std::forward<E>(arr), offset, axis_1, axis_2)),
+                                       ret_shape);
+    }
+
+    /**
+     * @brief xexpression with values of arr on the diagonal, zeroes otherwise
+     *
+     * @param arr the 1D input array of length n
+     * @param k the offset of the considered diagonal
+     * @returns xexpression function with shape n x n and arr on the diagonal
+     *
+     * \code{.cpp}
+     * xt::xarray<double> a = {1, 5, 9};
+     * auto b = xt::diag(a); // => {{1, 0, 0},
+     *                       //     {0, 5, 0},
+     *                       //     {0, 0, 9}}
+     * \endcode
+     */
+    template <class E>
+    inline auto diag(E&& arr, int k = 0)
+    {
+        using CT = xclosure_t<E>;
+        std::size_t s = arr.shape()[0] + std::abs(k);
+        return detail::make_xgenerator(detail::fn_impl<detail::diag_fn<CT>>(detail::diag_fn<CT>(std::forward<E>(arr), k)),
+                                       {s, s});
+    }
+
+    /**
+     * @brief Reverse the order of elements in an xexpression along the given axis.
+     * Note: A NumPy/Matlab style `flipud(arr)` is equivalent to `xt::flip(arr, 0)`,
+     * `fliplr(arr)` to `xt::flip(arr, 1)`.
+     * 
+     * @param arr the input xexpression
+     * @param axis the axis along which elements should be reversed
+     *
+     * @return xexpression evaluating to reversed array
+     */
+    template <class E>
+    inline auto flip(E&& arr, std::size_t axis)
+    {
+        using CT = xclosure_t<E>;
+        auto shape = arr.shape();
+        return detail::make_xgenerator(detail::flip_impl<CT>(std::forward<E>(arr), axis),
+                                       shape);
+    }
+
+    /**
+     * @brief Extract lower triangular matrix from xexpression. The parameter k selects the
+     *        offset of the diagonal.
+     *
+     * @param arr the input array
+     * @param k the diagonal above which to zero elements. 0 (default) selects the main diagonal,
+     *          k < 0 is below the main diagonal, k > 0 above.
+     * @returns xexpression containing lower triangle from arr, 0 otherwise
+     */
+    template <class E>
+    inline auto tril(E&& arr, int k = 0)
+    {
+        using CT = xclosure_t<E>;
+        auto shape = arr.shape();
+        return detail::make_xgenerator(detail::fn_impl<detail::trilu_fn<CT, std::greater_equal<long int>>>(
+                                           detail::trilu_fn<CT, std::greater_equal<long int>>(std::forward<E>(arr), k, std::greater_equal<long int>())),
+                                       shape);
+    }
+
+    /**
+     * @brief Extract upper triangular matrix from xexpression. The parameter k selects the
+     *        offset of the diagonal.
+     *
+     * @param arr the input array
+     * @param k the diagonal below which to zero elements. 0 (default) selects the main diagonal,
+     *          k < 0 is below the main diagonal, k > 0 above.
+     * @returns xexpression containing lower triangle from arr, 0 otherwise
+     */
+    template <class E>
+    inline auto triu(E&& arr, int k = 0)
+    {
+        using CT = xclosure_t<E>;
+        auto shape = arr.shape();
+        return detail::make_xgenerator(detail::fn_impl<detail::trilu_fn<CT, std::less_equal<long int>>>(
+                                           detail::trilu_fn<CT, std::less_equal<long int>>(std::forward<E>(arr), k, std::less_equal<long int>())),
+                                       shape);
+    }
+}
+#endif

--- a/inst/include/xtensor/xcomplex.hpp
+++ b/inst/include/xtensor/xcomplex.hpp
@@ -1,0 +1,242 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XCOMPLEX_HPP
+#define XCOMPLEX_HPP
+
+#include <type_traits>
+#include <utility>
+
+#include "xtensor/xbuilder.hpp"
+#include "xtensor/xexpression.hpp"
+#include "xtensor/xoffsetview.hpp"
+
+namespace xt
+{
+
+    /******************************
+     * real and imag declarations *
+     ******************************/
+
+    template <class E>
+    decltype(auto) real(E&& e) noexcept;
+
+    template <class E>
+    decltype(auto) imag(E&& e) noexcept;
+
+    /********************************
+     * real and imag implementation *
+     ********************************/
+
+    namespace detail
+    {
+        template <bool iscomplex = true>
+        struct complex_helper
+        {
+            template <class E>
+            static inline auto real(E&& e) noexcept
+            {
+                using real_type = typename std::decay_t<E>::value_type::value_type;
+                return xoffsetview<xclosure_t<E>, real_type, 0>(std::forward<E>(e));
+            }
+
+            template <class E>
+            static inline auto imag(E&& e) noexcept
+            {
+                using real_type = typename std::decay_t<E>::value_type::value_type;
+                return xoffsetview<xclosure_t<E>, real_type, sizeof(real_type)>(std::forward<E>(e));
+            }
+        };
+
+        template <>
+        struct complex_helper<false>
+        {
+            template <class E>
+            static inline decltype(auto) real(E&& e) noexcept
+            {
+                return e;
+            }
+
+            template <class E>
+            static inline auto imag(E&& e) noexcept
+            {
+                return zeros<typename std::decay_t<E>::value_type>(e.shape());
+            }
+        };
+
+        template <bool isexpression = true>
+        struct complex_expression_helper
+        {
+            template <class E>
+            static inline auto real(E&& e) noexcept
+            {
+                return detail::complex_helper<is_complex<typename std::decay_t<E>::value_type>::value>::real(e);
+            }
+
+            template <class E>
+            static inline auto imag(E&& e) noexcept
+            {
+                return detail::complex_helper<is_complex<typename std::decay_t<E>::value_type>::value>::imag(e);
+            }
+        };
+
+        template <>
+        struct complex_expression_helper<false>
+        {
+            template <class E>
+            static inline decltype(auto) real(E&& e) noexcept
+            {
+                return forward_real(std::forward<E>(e));
+            }
+
+            template <class E>
+            static inline decltype(auto) imag(E&& e) noexcept
+            {
+                return forward_imag(std::forward<E>(e));
+            }
+        };
+    }
+
+    /**
+     * @brief Returns an \ref xexpression representing the real part of the given expression.
+     *
+     * @tparam e the \ref xexpression
+     *
+     * The returned expression either hold a const reference to \p e or a copy
+     * depending on whether \p e is an lvalue or an rvalue.
+     */
+    template <class E>
+    inline decltype(auto) real(E&& e) noexcept
+    {
+        return detail::complex_expression_helper<is_xexpression<std::decay_t<E>>::value>::real(std::forward<E>(e));
+    }
+
+    /**
+     * @brief Returns an \ref xexpression representing the imaginary part of the given expression.
+     *
+     * @tparam e the \ref xexpression
+     *
+     * The returned expression either hold a const reference to \p e or a copy
+     * depending on whether \p e is an lvalue or an rvalue.
+     */
+    template <class E>
+    inline decltype(auto) imag(E&& e) noexcept
+    {
+        return detail::complex_expression_helper<is_xexpression<std::decay_t<E>>::value>::imag(std::forward<E>(e));
+    }
+
+#define UNARY_COMPLEX_FUNCTOR(NAME)\
+    template <class T>\
+    struct NAME##_fun {\
+        using argument_type = T;\
+        using result_type = decltype(std::NAME(std::declval<T>()));\
+        constexpr result_type operator()(const T& t) const {\
+            using std::NAME;\
+            return NAME(t);\
+        }\
+    }
+
+    namespace math
+    {
+        UNARY_COMPLEX_FUNCTOR(norm);
+        UNARY_COMPLEX_FUNCTOR(arg);
+
+        namespace detail
+        {
+            // libc++ (OSX) conj is unfortunately broken and returns 
+            // std::complex<T> instead of T.
+            template <class T>
+            constexpr T conj(const T& c)
+            {
+                return c;
+            }
+
+            template <class T>
+            constexpr std::complex<T> conj(const std::complex<T>& c)
+            {
+                return std::complex<T>(c.real(), -c.imag());
+            }
+        }
+
+        template <class T>
+        struct conj_fun
+        {
+            using argument_type = T;
+            using result_type = decltype(detail::conj(std::declval<T>()));
+            constexpr result_type operator()(const T& t) const
+            {
+                return detail::conj(t);
+            }
+        };
+    }
+
+#undef UNARY_COMPLEX_FUNCTOR
+
+    /**
+     * @brief Returns an \ref xfunction evaluating to the complex conjugate of the given expression.
+     *
+     * @param e the \ref xexpression
+     */
+    template <class E>
+    inline auto conj(E&& e) noexcept
+    {
+        using value_type = typename std::decay_t<E>::value_type;
+        using functor = math::conj_fun<value_type>;
+        using result_type = typename functor::result_type;
+        using type = xfunction<functor, result_type, const_xclosure_t<E>>;
+        return type(functor(), std::forward<E>(e));
+    }
+
+    /**
+     * @brief Calculates the phase angle (in radians) elementwise for the complex numbers in e.
+     * @param e the \ref xexpression
+     */
+    template <class E>
+    inline auto arg(E&& e) noexcept
+    {
+        using value_type = typename std::decay_t<E>::value_type;
+        using functor = math::arg_fun<value_type>;
+        using result_type = typename functor::result_type;
+        using type = xfunction<functor, result_type, const_xclosure_t<E>>;
+        return type(functor(), std::forward<E>(e));
+    }
+
+    /**
+     * @brief Calculates the phase angle elementwise for the complex numbers in e.
+     * Note that this function might be slightly less perfomant than \ref arg.
+     * @param e the \ref xexpression
+     * @param deg calculate angle in degrees instead of radians
+     */
+    template <class E>
+    inline auto angle(E&& e, bool deg = false) noexcept
+    {
+        using value_type = complex_value_type_t<typename std::decay_t<E>::value_type>;
+        value_type multiplier = 1.0;
+        if (deg)
+        {
+            multiplier = value_type(180) / numeric_constants<value_type>::PI;
+        }
+        return arg(std::forward<E>(e)) * std::move(multiplier);
+    }
+
+    /**
+     * Calculates the squared magnitude elementwise for the complex numbers in e.
+     * Equivalent to pow(real(e), 2) + pow(imag(e), 2).
+     * @param e the \ref xexpression
+     */
+    template <class E>
+    inline auto norm(E&& e) noexcept
+    {
+        using value_type = typename std::decay_t<E>::value_type;
+        using functor = math::norm_fun<value_type>;
+        using result_type = typename functor::result_type;
+        using type = xfunction<functor, result_type, const_xclosure_t<E>>;
+        return type(functor(), std::forward<E>(e));
+    }
+}
+#endif

--- a/inst/include/xtensor/xcontainer.hpp
+++ b/inst/include/xtensor/xcontainer.hpp
@@ -1,0 +1,844 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XCONTAINER_HPP
+#define XCONTAINER_HPP
+
+#include <functional>
+#include <numeric>
+#include <stdexcept>
+
+#include "xiterable.hpp"
+#include "xiterator.hpp"
+#include "xmath.hpp"
+#include "xoperation.hpp"
+#include "xstrides.hpp"
+#include "xtensor_forward.hpp"
+
+namespace xt
+{
+    template <class D>
+    struct xcontainer_iterable_types
+    {
+        using inner_shape_type = typename xcontainer_inner_types<D>::inner_shape_type;
+        using container_type = typename xcontainer_inner_types<D>::container_type;
+        using iterator = typename container_type::iterator;
+        using const_iterator = typename container_type::const_iterator;
+        using reverse_iterator = typename container_type::reverse_iterator;
+        using const_reverse_iterator = typename container_type::const_reverse_iterator;
+        using stepper = xstepper<D>;
+        using const_stepper = xstepper<const D>;
+    };
+
+    /**
+     * @class xcontainer
+     * @brief Base class for dense multidimensional containers.
+     *
+     * The xcontainer class defines the interface for dense multidimensional
+     * container classes. It does not embed any data container, this responsibility
+     * is delegated to the inheriting classes.
+     *
+     * @tparam D The derived type, i.e. the inheriting class for which xcontainer
+     *           provides the interface.
+     */
+    template <class D>
+    class xcontainer : public xiterable<D>
+    {
+
+    public:
+
+        using derived_type = D;
+
+        using inner_types = xcontainer_inner_types<D>;
+        using container_type = typename inner_types::container_type;
+        using value_type = typename container_type::value_type;
+        using reference = typename container_type::reference;
+        using const_reference = typename container_type::const_reference;
+        using pointer = typename container_type::pointer;
+        using const_pointer = typename container_type::const_pointer;
+        using size_type = typename container_type::size_type;
+        using difference_type = typename container_type::difference_type;
+
+        using shape_type = typename inner_types::shape_type;
+        using strides_type = typename inner_types::strides_type;
+        using backstrides_type = typename inner_types::backstrides_type;
+
+        using inner_shape_type = typename inner_types::inner_shape_type;
+        using inner_strides_type = typename inner_types::inner_strides_type;
+        using inner_backstrides_type = typename inner_types::inner_backstrides_type;
+
+        using iterable_base = xiterable<D>;
+
+        using iterator = typename iterable_base::iterator;
+        using const_iterator = typename iterable_base::const_iterator;
+
+        using stepper = typename iterable_base::stepper;
+        using const_stepper = typename iterable_base::const_stepper;
+
+        using reverse_iterator = typename iterable_base::reverse_iterator;
+        using const_reverse_iterator = typename iterable_base::const_reverse_iterator;
+
+        size_type size() const noexcept;
+
+        size_type dimension() const noexcept;
+
+        const inner_shape_type& shape() const noexcept;
+        const inner_strides_type& strides() const noexcept;
+        const inner_backstrides_type& backstrides() const noexcept;
+
+        template <class... Args>
+        reference operator()(Args... args);
+
+        template <class... Args>
+        const_reference operator()(Args... args) const;
+
+        reference operator[](const xindex& index);
+        reference operator[](size_type i);
+        const_reference operator[](const xindex& index) const;
+        const_reference operator[](size_type i) const;
+
+        template <class It>
+        reference element(It first, It last);
+        template <class It>
+        const_reference element(It first, It last) const;
+
+        container_type& data() noexcept;
+        const container_type& data() const noexcept;
+
+        value_type* raw_data() noexcept;
+        const value_type* raw_data() const noexcept;
+        const size_type raw_data_offset() const noexcept;
+
+        template <class S>
+        bool broadcast_shape(S& shape) const;
+
+        template <class S>
+        bool is_trivial_broadcast(const S& strides) const noexcept;
+
+        iterator begin() noexcept;
+        iterator end() noexcept;
+
+        const_iterator begin() const noexcept;
+        const_iterator end() const noexcept;
+        const_iterator cbegin() const noexcept;
+        const_iterator cend() const noexcept;
+
+        reverse_iterator rbegin() noexcept;
+        reverse_iterator rend() noexcept;
+
+        const_reverse_iterator rbegin() const noexcept;
+        const_reverse_iterator rend() const noexcept;
+        const_reverse_iterator crbegin() const noexcept;
+        const_reverse_iterator crend() const noexcept;
+
+        template <class S>
+        stepper stepper_begin(const S& shape) noexcept;
+        template <class S>
+        stepper stepper_end(const S& shape) noexcept;
+
+        template <class S>
+        const_stepper stepper_begin(const S& shape) const noexcept;
+        template <class S>
+        const_stepper stepper_end(const S& shape) const noexcept;
+
+        using container_iterator = typename container_type::iterator;
+        using const_container_iterator = typename container_type::const_iterator;
+
+        container_iterator data_xbegin() noexcept;
+        const_container_iterator data_xbegin() const noexcept;
+
+        container_iterator data_xend() noexcept;
+        const_container_iterator data_xend() const noexcept;
+
+    protected:
+
+        xcontainer() = default;
+        ~xcontainer() = default;
+
+        xcontainer(const xcontainer&) = default;
+        xcontainer& operator=(const xcontainer&) = default;
+
+        xcontainer(xcontainer&&) = default;
+        xcontainer& operator=(xcontainer&&) = default;
+
+    private:
+
+        template <class It>
+        It data_xend_impl(It end) const noexcept;
+
+        inner_shape_type& mutable_shape();
+        inner_strides_type& mutable_strides();
+        inner_backstrides_type& mutable_backstrides();
+
+        derived_type& derived_cast();
+        const derived_type& derived_cast() const;
+    };
+
+    /**
+     * @class xstrided_container
+     * @brief Partial implementation of xcontainer that embeds the strides and the shape
+     *
+     * The xstrided_container class is a partial implementation of the xcontainer interface
+     * that embed the strides and the shape of the multidimensional container. It does
+     * not embed the data container, this responsibility is delegated to the inheriting
+     * classes.
+     *
+     * @tparam D The derived type, i.e. the inheriting class for which xstrided_container
+     *           provides the partial imlpementation of xcontainer.
+     * @tparam L The layout_type of the xstrided_container.
+     */
+    template <class D, layout_type L>
+    class xstrided_container : public xcontainer<D>
+    {
+
+    public:
+
+        using base_type = xcontainer<D>;
+        using container_type = typename base_type::container_type;
+        using value_type = typename base_type::value_type;
+        using reference = typename base_type::reference;
+        using const_reference = typename base_type::const_reference;
+        using pointer = typename base_type::pointer;
+        using const_pointer = typename base_type::const_pointer;
+        using size_type = typename base_type::size_type;
+        using shape_type = typename base_type::shape_type;
+        using strides_type = typename base_type::strides_type;
+        using inner_shape_type = typename base_type::inner_shape_type;
+        using inner_strides_type = typename base_type::inner_strides_type;
+        using inner_backstrides_type = typename base_type::inner_backstrides_type;
+
+        static constexpr layout_type static_layout = L;
+        static constexpr bool contiguous_layout = static_layout != layout_type::dynamic;
+
+        template <class S = shape_type>
+        void reshape(const S& shape, bool force = false);
+        template <class S = shape_type>
+        void reshape(const S& shape, layout_type l);
+        template <class S = shape_type>
+        void reshape(const S& shape, const strides_type& strides);
+
+        layout_type layout() const noexcept;
+
+    protected:
+
+        xstrided_container() noexcept;
+        ~xstrided_container() = default;
+
+        xstrided_container(const xstrided_container&) = default;
+        xstrided_container& operator=(const xstrided_container&) = default;
+
+        xstrided_container(xstrided_container&&) = default;
+        xstrided_container& operator=(xstrided_container&&) = default;
+
+        explicit xstrided_container(inner_shape_type&&, inner_strides_type&&) noexcept;
+
+        inner_shape_type& shape_impl() noexcept;
+        const inner_shape_type& shape_impl() const noexcept;
+
+        inner_strides_type& strides_impl() noexcept;
+        const inner_strides_type& strides_impl() const noexcept;
+
+        inner_backstrides_type& backstrides_impl() noexcept;
+        const inner_backstrides_type& backstrides_impl() const noexcept;
+
+    private:
+
+        inner_shape_type m_shape;
+        inner_strides_type m_strides;
+        inner_backstrides_type m_backstrides;
+        layout_type m_layout = L;
+    };
+
+    /******************************
+     * xcontainer implementation *
+     ******************************/
+
+    template <class D>
+    template <class It>
+    inline It xcontainer<D>::data_xend_impl(It end) const noexcept
+    {
+        return strides().size() != 0 ? end - 1 + strides().back() : end;
+    }
+
+    template <class D>
+    inline auto xcontainer<D>::mutable_shape() -> inner_shape_type&
+    {
+        return derived_cast().shape_impl();
+    }
+
+    template <class D>
+    inline auto xcontainer<D>::mutable_strides() -> inner_strides_type&
+    {
+        return derived_cast().strides_impl();
+    }
+
+    template <class D>
+    inline auto xcontainer<D>::mutable_backstrides() -> inner_backstrides_type&
+    {
+        return derived_cast().backstrides_impl();
+    }
+
+    template <class D>
+    inline auto xcontainer<D>::derived_cast() -> derived_type&
+    {
+        return *static_cast<derived_type*>(this);
+    }
+
+    template <class D>
+    inline auto xcontainer<D>::derived_cast() const -> const derived_type&
+    {
+        return *static_cast<const derived_type*>(this);
+    }
+
+    /**
+     * @name Size and shape
+     */
+    //@{
+    /**
+     * Returns the number of element in the container.
+     */
+    template <class D>
+    inline auto xcontainer<D>::size() const noexcept -> size_type
+    {
+        return data().size();
+    }
+
+    /**
+     * Returns the number of dimensions of the container.
+     */
+    template <class D>
+    inline auto xcontainer<D>::dimension() const noexcept -> size_type
+    {
+        return shape().size();
+    }
+
+    /**
+     * Returns the shape of the container.
+     */
+    template <class D>
+    inline auto xcontainer<D>::shape() const noexcept -> const inner_shape_type&
+    {
+        return derived_cast().shape_impl();
+    }
+
+    /**
+     * Returns the strides of the container.
+     */
+    template <class D>
+    inline auto xcontainer<D>::strides() const noexcept -> const inner_strides_type&
+    {
+        return derived_cast().strides_impl();
+    }
+
+    /**
+     * Returns the backstrides of the container.
+     */
+    template <class D>
+    inline auto xcontainer<D>::backstrides() const noexcept -> const inner_backstrides_type&
+    {
+        return derived_cast().backstrides_impl();
+    }
+    //@}
+
+
+    /**
+     * @name Data
+     */
+    //@{
+    /**
+     * Returns a reference to the element at the specified position in the container.
+     * @param args a list of indices specifying the position in the container. Indices
+     * must be unsigned integers, the number of indices should be equal or greater than
+     * the number of dimensions of the container.
+     */
+    template <class D>
+    template <class... Args>
+    inline auto xcontainer<D>::operator()(Args... args) -> reference
+    {
+        XTENSOR_ASSERT(check_index(shape(), args...));
+        size_type index = data_offset<size_type>(strides(), static_cast<size_type>(args)...);
+        return data()[index];
+    }
+
+    /**
+     * Returns a constant reference to the element at the specified position in the container.
+     * @param args a list of indices specifying the position in the container. Indices
+     * must be unsigned integers, the number of indices should be equal or greater than
+     * the number of dimensions of the container.
+     */
+    template <class D>
+    template <class... Args>
+    inline auto xcontainer<D>::operator()(Args... args) const -> const_reference
+    {
+        XTENSOR_ASSERT(check_index(shape(), args...));
+        size_type index = data_offset<size_type>(strides(), static_cast<size_type>(args)...);
+        return data()[index];
+    }
+
+    /**
+     * Returns a reference to the element at the specified position in the container.
+     * @param index a sequence of indices specifying the position in the container. Indices
+     * must be unsigned integers, the number of indices in the list should be equal or greater
+     * than the number of dimensions of the container.
+     */
+    template <class D>
+    inline auto xcontainer<D>::operator[](const xindex& index) -> reference
+    {
+        return element(index.cbegin(), index.cend());
+    }
+
+    template <class D>
+    inline auto xcontainer<D>::operator[](size_type i) -> reference
+    {
+        return operator()(i);
+    }
+
+    /**
+     * Returns a constant reference to the element at the specified position in the container.
+     * @param index a sequence of indices specifying the position in the container. Indices
+     * must be unsigned integers, the number of indices in the list should be equal or greater
+     * than the number of dimensions of the container.
+     */
+    template <class D>
+    inline auto xcontainer<D>::operator[](const xindex& index) const -> const_reference
+    {
+        return element(index.cbegin(), index.cend());
+    }
+
+    template <class D>
+    inline auto xcontainer<D>::operator[](size_type i) const -> const_reference
+    {
+        return operator()(i);
+    }
+
+    /**
+     * Returns a reference to the element at the specified position in the container.
+     * @param first iterator starting the sequence of indices
+     * @param last iterator ending the sequence of indices
+     * The number of indices in the squence should be equal to or greater
+     * than the number of dimensions of the container.
+     */
+    template <class D>
+    template <class It>
+    inline auto xcontainer<D>::element(It first, It last) -> reference
+    {
+        XTENSOR_ASSERT(check_element_index(shape(), first, last));
+        return data()[element_offset<size_type>(strides(), first, last)];
+    }
+
+    /**
+     * Returns a reference to the element at the specified position in the container.
+     * @param first iterator starting the sequence of indices
+     * @param last iterator ending the sequence of indices
+     * The number of indices in the squence should be equal to or greater
+     * than the number of dimensions of the container.
+     */
+    template <class D>
+    template <class It>
+    inline auto xcontainer<D>::element(It first, It last) const -> const_reference
+    {
+        XTENSOR_ASSERT(check_element_index(shape(), first, last));
+        return data()[element_offset<size_type>(strides(), first, last)];
+    }
+
+    /**
+     * Returns a reference to the buffer containing the elements of the container.
+     */
+    template <class D>
+    inline auto xcontainer<D>::data() noexcept -> container_type&
+    {
+        return derived_cast().data_impl();
+    }
+
+    /**
+     * Returns a constant reference to the buffer containing the elements of the
+     * container.
+     */
+    template <class D>
+    inline auto xcontainer<D>::data() const noexcept -> const container_type&
+    {
+        return derived_cast().data_impl();
+    }
+
+    /**
+     * Returns the offset to the first element in the container.
+     */
+    template <class D>
+    inline auto xcontainer<D>::raw_data() noexcept -> value_type*
+    {
+        return data().data();
+    }
+
+    template <class D>
+    inline auto xcontainer<D>::raw_data() const noexcept -> const value_type*
+    {
+        return data().data();
+    }
+
+    /**
+     * Returns the offset to the first element in the container.
+     */
+    template <class D>
+    inline auto xcontainer<D>::raw_data_offset() const noexcept -> const size_type
+    {
+        return size_type(0);
+    }
+    //@}
+
+    /**
+     * @name Broadcasting
+     */
+    //@{
+    /**
+     * Broadcast the shape of the container to the specified parameter.
+     * @param shape the result shape
+     * @return a boolean indicating whether the broadcasting is trivial
+     */
+    template <class D>
+    template <class S>
+    inline bool xcontainer<D>::broadcast_shape(S& shape) const
+    {
+        return xt::broadcast_shape(this->shape(), shape);
+    }
+
+    /**
+     * Compares the specified strides with those of the container to see whether
+     * the broadcasting is trivial.
+     * @return a boolean indicating whether the broadcasting is trivial
+     */
+    template <class D>
+    template <class S>
+    inline bool xcontainer<D>::is_trivial_broadcast(const S& str) const noexcept
+    {
+        return str.size() == strides().size() &&
+            std::equal(str.cbegin(), str.cend(), strides().begin());
+    }
+    //@}
+
+    /****************
+     * iterator api *
+     ****************/
+
+    /**
+     * @name Iterators
+     */
+    //@{
+    /**
+     * Returns an iterator to the first element of the buffer containing
+     * the elements of the container.
+     */
+    template <class D>
+    inline auto xcontainer<D>::begin() noexcept -> iterator
+    {
+        return data().begin();
+    }
+
+    /**
+     * Returns an iterator to the element following the last element of
+     * the buffer containing the elements of the container.
+     */
+    template <class D>
+    inline auto xcontainer<D>::end() noexcept -> iterator
+    {
+        return data().end();
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the buffer
+     * containing the elements of the container.
+     */
+    template <class D>
+    inline auto xcontainer<D>::begin() const noexcept -> const_iterator
+    {
+        return cbegin();
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last
+     * element of the buffer containing the elements of the container.
+     */
+    template <class D>
+    inline auto xcontainer<D>::end() const noexcept -> const_iterator
+    {
+        return cend();
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the buffer
+     * containing the elements of the container.
+     */
+    template <class D>
+    inline auto xcontainer<D>::cbegin() const noexcept -> const_iterator
+    {
+        return data().cbegin();
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last
+     * element of the buffer containing the elements of the container.
+     */
+    template <class D>
+    inline auto xcontainer<D>::cend() const noexcept -> const_iterator
+    {
+        return data().cend();
+    }
+    //@}
+
+    /**
+     * @name Reverse iterators
+     */
+    //@{
+    /**
+     * Returns an iterator to the first element of the reversed buffer containing
+     * the elements of the container.
+     */
+    template <class D>
+    inline auto xcontainer<D>::rbegin() noexcept -> reverse_iterator
+    {
+        return data().rbegin();
+    }
+
+    /**
+     * Returns an iterator to the element following the last element of
+     * the reversed buffer containing the elements of the container.
+     */
+    template <class D>
+    inline auto xcontainer<D>::rend() noexcept -> reverse_iterator
+    {
+        return data().rend();
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the reversed
+     * buffer containing the elements of the container.
+     */
+    template <class D>
+    inline auto xcontainer<D>::rbegin() const noexcept -> const_reverse_iterator
+    {
+        return data().rbegin();
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last
+     * element of the reversed buffer containing the elements of the container.
+     */
+    template <class D>
+    inline auto xcontainer<D>::rend() const noexcept -> const_reverse_iterator
+    {
+        return data().rend();
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the reversed
+     * buffer containing the elements of the container.
+     */
+    template <class D>
+    inline auto xcontainer<D>::crbegin() const noexcept -> const_reverse_iterator
+    {
+        return data().crbegin();
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last
+     * element of the reversed buffer containing the elements of the container.
+     */
+    template <class D>
+    inline auto xcontainer<D>::crend() const noexcept -> const_reverse_iterator
+    {
+        return data().crend();
+    }
+    //@}
+
+    /***************
+     * stepper api *
+     ***************/
+
+    template <class D>
+    template <class S>
+    inline auto xcontainer<D>::stepper_begin(const S& shape) noexcept -> stepper
+    {
+        size_type offset = shape.size() - dimension();
+        return stepper(static_cast<derived_type*>(this), data().begin(), offset);
+    }
+
+    template <class D>
+    template <class S>
+    inline auto xcontainer<D>::stepper_end(const S& shape) noexcept -> stepper
+    {
+        size_type offset = shape.size() - dimension();
+        return stepper(static_cast<derived_type*>(this), data_xend(), offset);
+    }
+
+    template <class D>
+    template <class S>
+    inline auto xcontainer<D>::stepper_begin(const S& shape) const noexcept -> const_stepper
+    {
+        size_type offset = shape.size() - dimension();
+        return const_stepper(static_cast<const derived_type*>(this), data().begin(), offset);
+    }
+
+    template <class D>
+    template <class S>
+    inline auto xcontainer<D>::stepper_end(const S& shape) const noexcept -> const_stepper
+    {
+        size_type offset = shape.size() - dimension();
+        return const_stepper(static_cast<const derived_type*>(this), data_xend(), offset);
+    }
+
+    template <class D>
+    inline auto xcontainer<D>::data_xbegin() noexcept -> container_iterator
+    {
+        return data().begin();
+    }
+
+    template <class D>
+    inline auto xcontainer<D>::data_xbegin() const noexcept -> const_container_iterator
+    {
+        return data().begin();
+    }
+
+    template <class D>
+    inline auto xcontainer<D>::data_xend() noexcept -> container_iterator
+    {
+        return data_xend_impl(data().end());
+    }
+
+    template <class D>
+    inline auto xcontainer<D>::data_xend() const noexcept -> const_container_iterator
+    {
+        return data_xend_impl(data().end());
+    }
+
+    /*************************************
+     * xstrided_container implementation *
+     *************************************/
+
+    template <class D, layout_type L>
+    inline xstrided_container<D, L>::xstrided_container() noexcept
+        : base_type()
+    {
+        m_shape = make_sequence<inner_shape_type>(base_type::dimension(), 1);
+    }
+
+    template <class D, layout_type L>
+    inline xstrided_container<D, L>::xstrided_container(inner_shape_type&& shape, inner_strides_type&& strides) noexcept
+        : base_type(), m_shape(std::move(shape)), m_strides(std::move(strides))
+    {
+        m_backstrides = make_sequence<inner_backstrides_type>(m_shape.size(), 0);
+        adapt_strides(m_shape, m_strides, m_backstrides);
+    }
+
+    template <class D, layout_type L>
+    inline auto xstrided_container<D, L>::shape_impl() noexcept -> inner_shape_type&
+    {
+        return m_shape;
+    }
+
+    template <class D, layout_type L>
+    inline auto xstrided_container<D, L>::shape_impl() const noexcept -> const inner_shape_type&
+    {
+        return m_shape;
+    }
+
+    template <class D, layout_type L>
+    inline auto xstrided_container<D, L>::strides_impl() noexcept -> inner_strides_type&
+    {
+        return m_strides;
+    }
+
+    template <class D, layout_type L>
+    inline auto xstrided_container<D, L>::strides_impl() const noexcept -> const inner_strides_type&
+    {
+        return m_strides;
+    }
+
+    template <class D, layout_type L>
+    inline auto xstrided_container<D, L>::backstrides_impl() noexcept -> inner_backstrides_type&
+    {
+        return m_backstrides;
+    }
+
+    template <class D, layout_type L>
+    inline auto xstrided_container<D, L>::backstrides_impl() const noexcept -> const inner_backstrides_type&
+    {
+        return m_backstrides;
+    }
+
+    /**
+     * Return the layout_type of the container
+     * @return layout_type of the container
+     */
+    template <class D, layout_type L>
+    layout_type xstrided_container<D, L>::layout() const noexcept
+    {
+        return m_layout;
+    }
+
+    /**
+     * Reshapes the container.
+     * @param shape the new shape
+     * @param force force reshaping, even if the shape stays the same (default: false)
+     */
+    template <class D, layout_type L>
+    template <class S>
+    inline void xstrided_container<D, L>::reshape(const S& shape, bool force)
+    {
+        if (m_shape.size() != shape.size() || !std::equal(std::begin(shape), std::end(shape), std::begin(m_shape)) || force)
+        {
+            if (m_layout == layout_type::dynamic || m_layout == layout_type::any)
+            {
+                m_layout = layout_type::row_major;  // fall back to row major
+            }
+            m_shape = forward_sequence<shape_type>(shape);
+            resize_container(m_strides, m_shape.size());
+            resize_container(m_backstrides, m_shape.size());
+            size_type data_size = compute_strides(m_shape, m_layout, m_strides, m_backstrides);
+            this->data().resize(data_size);
+        }
+    }
+
+    /**
+     * Reshapes the container.
+     * @param shape the new shape
+     * @param l the new layout_type
+     */
+    template <class D, layout_type L>
+    template <class S>
+    inline void xstrided_container<D, L>::reshape(const S& shape, layout_type l)
+    {
+        if (L != layout_type::dynamic && l != L)
+        {
+            throw std::runtime_error("Cannot change layout_type if template parameter not layout_type::dynamic.");
+        }
+        m_layout = l;
+        reshape(shape, true);
+    }
+
+    /**
+     * Reshapes the container.
+     * @param shape the new shape
+     * @param strides the new strides
+     */
+    template <class D, layout_type L>
+    template <class S>
+    inline void xstrided_container<D, L>::reshape(const S& shape, const strides_type& strides)
+    {
+        if (L != layout_type::dynamic)
+        {
+            throw std::runtime_error("Cannot reshape with custom strides when layout() is != layout_type::dynamic.");
+        }
+        m_shape = forward_sequence<shape_type>(shape);
+        m_strides = strides;
+        resize_container(m_backstrides, m_strides.size());
+        adapt_strides(m_shape, m_strides, m_backstrides);
+        m_layout = layout_type::dynamic;
+        this->data().resize(compute_size(m_shape));
+    }
+}
+
+#endif

--- a/inst/include/xtensor/xcsv.hpp
+++ b/inst/include/xtensor/xcsv.hpp
@@ -1,0 +1,166 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XCSV_HPP
+#define XCSV_HPP
+
+#include <istream>
+#include <iterator>
+#include <string>
+#include <sstream>
+#include <exception>
+#include <utility>
+
+#include "xtensor.hpp"
+
+namespace xt
+{
+
+    /**************************************
+     * load_csv and dump_csv declarations *
+     **************************************/
+
+    template <class T, class A = std::allocator<T>>
+    xtensor_container<std::vector<T, A>, 2> load_csv(std::istream& stream);
+
+    template <class E>
+    void dump_csv(std::ostream& stream, const xexpression<E>& e);
+
+    /*****************************************
+     * load_csv and dump_csv implementations *
+     *****************************************/
+
+    namespace detail
+    {
+        template <class T>
+        inline T lexical_cast(const std::string& cell)
+        {
+            T res;
+            std::istringstream iss(cell);
+            iss >> res;
+            return res;
+        }
+
+        template <>
+        inline float lexical_cast<float>(const std::string& cell) { return std::stof(cell); }
+
+        template <>
+        inline double lexical_cast<double>(const std::string& cell) { return std::stod(cell); }
+
+        template <>
+        inline long double lexical_cast<long double>(const std::string& cell) { return std::stold(cell); }
+
+        template <>
+        inline int lexical_cast<int>(const std::string& cell) { return std::stoi(cell); }
+
+        template <>
+        inline long lexical_cast<long>(const std::string& cell) { return std::stol(cell); }
+
+        template <>
+        inline long long lexical_cast<long long>(const std::string& cell) { return std::stoll(cell); }
+
+        template <>
+        inline unsigned int lexical_cast<unsigned int>(const std::string& cell) { return static_cast<unsigned int>(std::stoul(cell)); }
+
+        template <>
+        inline unsigned long lexical_cast<unsigned long>(const std::string& cell) { return std::stoul(cell); }
+
+        template <>
+        inline unsigned long long lexical_cast<unsigned long long>(const std::string& cell) { return std::stoull(cell); }
+
+        template <class ST, class T, class OI>
+        ST load_csv_row(std::istream& row_stream, OI output, std::string cell)
+        {
+            ST length = 0;
+            while (std::getline(row_stream, cell, ','))
+            {
+                *output++ = lexical_cast<T>(cell);
+                ++length;
+            }
+            return length;
+        }
+    }
+
+    /**
+     * @brief Load tensor from CSV.
+     * 
+     * Returns an \ref xexpression for the parsed CSV
+     * @param stream the input stream containing the CSV encoded values
+     */
+    template <class T, class A>
+    xtensor_container<std::vector<T, A>, 2> load_csv(std::istream& stream)
+    {
+         using container_type = typename std::vector<T, A>;
+         using tensor_type = xtensor_container<container_type, 2>;
+         using size_type = typename tensor_type::size_type;
+         using inner_shape_type = typename tensor_type::inner_shape_type;
+         using inner_strides_type = typename tensor_type::inner_strides_type;
+         using output_iterator = std::back_insert_iterator<container_type>;
+ 
+         container_type data;
+         size_type nbrow = 0, nbcol = 0;
+         {
+             output_iterator output(data);
+             std::string row, cell;
+             while (std::getline(stream, row))
+             {
+                 std::stringstream row_stream(row);
+                 nbcol = detail::load_csv_row<size_type, T, output_iterator>(row_stream, output, cell);
+                 ++nbrow;
+             }
+         }
+         inner_shape_type shape = { nbrow, nbcol };
+         inner_strides_type strides; // no need for initializer list for stack-allocated strides_type
+         size_type data_size = compute_strides(shape, layout_type::row_major, strides);
+         // Sanity check for data size.
+         if (data.size() != data_size)
+         {
+              throw std::runtime_error("Inconsistent row lengths in CSV");
+         }
+         return tensor_type(std::move(data), std::move(shape), std::move(strides));
+    }
+
+    /**
+     * @brief Dump tensor to CSV.
+     * 
+     * @param stream the output stream to write the CSV encoded values
+     * @param e the tensor expression to serialize
+     */
+    template <class E>
+    void dump_csv(std::ostream& stream, const xexpression<E>& e)
+    {
+        using size_type = typename E::size_type;
+        const E& ex = e.derived_cast();
+        if (ex.dimension() != 2)
+        {
+             throw std::runtime_error("Only 2-D expressions can be serialized to CSV");
+        }
+        size_type nbrows = ex.shape()[0], nbcols = ex.shape()[1];
+        auto st = ex.stepper_begin(ex.shape());
+        for (size_type r = 0; r != nbrows; ++r)
+        {
+            for (size_type c = 0; c != nbcols; ++c)
+            {
+                stream << *st;
+                if (c != nbcols - 1)
+                {
+                    st.step(1);
+                    stream << ',';
+                }
+                else
+                {
+                    st.reset(1);
+                    st.step(0);
+                    stream << std::endl;
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/inst/include/xtensor/xeval.hpp
+++ b/inst/include/xtensor/xeval.hpp
@@ -1,0 +1,57 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XEVAL_HPP
+#define XEVAL_HPP
+
+#include "xarray.hpp"
+#include "xtensor.hpp"
+
+namespace xt
+{
+
+    namespace detail
+    {
+        template <class T>
+        using is_container = std::is_base_of<xcontainer<std::remove_const_t<T>>, T>;
+    }
+    /**
+     * Force evaluation of xexpression.
+     * @return xarray or xtensor depending on shape type
+     * 
+     * \code{.cpp}
+     * xarray<double> a = {1,2,3,4};
+     * auto&& b = xt::eval(a); // b is a reference to a, no copy!
+     * auto&& c = xt::eval(a + b); // c is xarray<double>, not an xexpression
+     * \endcode
+     */
+    template <class T>
+    inline auto eval(T&& t)
+        -> std::enable_if_t<detail::is_container<std::decay_t<T>>::value, T&&>
+    {
+        return std::forward<T>(t);
+    }
+
+    /// @cond DOXYGEN_INCLUDE_SFINAE
+    template <class T, class I = std::decay_t<T>>
+    inline auto eval(T&& t)
+        -> std::enable_if_t<!detail::is_container<I>::value && detail::is_array<typename I::shape_type>::value, xtensor<typename I::value_type, std::tuple_size<typename I::shape_type>::value>>
+    {
+        return xtensor<typename I::value_type, std::tuple_size<typename I::shape_type>::value>(std::forward<T>(t));
+    }
+
+    template <class T, class I = std::decay_t<T>>
+    inline auto eval(T&& t)
+        -> std::enable_if_t<!detail::is_container<I>::value && !detail::is_array<typename I::shape_type>::value, xt::xarray<typename I::value_type>>
+    {
+        return xarray<typename I::value_type>(std::forward<T>(t));
+    }
+    /// @endcond
+}
+
+#endif

--- a/inst/include/xtensor/xexception.hpp
+++ b/inst/include/xtensor/xexception.hpp
@@ -1,0 +1,171 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XEXCEPTION_HPP
+#define XEXCEPTION_HPP
+
+#include <exception>
+#include <iterator>
+#include <sstream>
+#include <string>
+
+namespace xt
+{
+
+    /*******************
+     * broadcast_error *
+     *******************/
+
+    class broadcast_error : public std::exception
+    {
+
+    public:
+
+        template <class S1, class S2>
+        broadcast_error(const S1& lhs, const S2& rhs);
+
+        virtual const char* what() const noexcept;
+
+    private:
+
+        std::string m_message;
+    };
+
+    /**********************************
+     * broadcast_error implementation *
+     **********************************/
+
+    template <class S1, class S2>
+    inline broadcast_error::broadcast_error(const S1& lhs, const S2& rhs)
+    {
+        std::ostringstream buf("Incompatible dimension of arrays:", std::ios_base::ate);
+
+        buf << "\n LHS shape = (";
+        using size_type1 = typename S1::value_type;
+        std::ostream_iterator<size_type1> iter1(buf, ", ");
+        std::copy(lhs.cbegin(), lhs.cend(), iter1);
+
+        buf << ")\n RHS shape = (";
+        using size_type2 = typename S2::value_type;
+        std::ostream_iterator<size_type2> iter2(buf, ", ");
+        std::copy(rhs.cbegin(), rhs.cend(), iter2);
+        buf << ")";
+
+        m_message = buf.str();
+    }
+
+    inline const char* broadcast_error::what() const noexcept
+    {
+        return m_message.c_str();
+    }
+
+    /*******************
+     * transpose_error *
+     *******************/
+
+    class transpose_error : public std::exception
+    {
+
+    public:
+
+        transpose_error(const std::string& msg);
+
+        virtual const char* what() const noexcept;
+
+    private:
+
+        std::string m_message;
+    };
+
+    /**********************************
+     * transpose_error implementation *
+     **********************************/
+
+    inline transpose_error::transpose_error(const std::string& msg)
+        : m_message(msg){}
+
+    inline const char* transpose_error::what() const noexcept
+    {
+        return m_message.c_str();
+    }
+
+    /***************
+     * check_index *
+     ***************/
+
+    template <class S, class... Args>
+    void check_index(const S& shape, Args... args);
+
+    template <class S, class It>
+    void check_element_index(const S& shape, It first, It last);
+
+    namespace detail
+    {
+        template <class S, size_t dim>
+        inline void check_index_impl(const S&)
+        {
+        }
+
+        template <class S, size_t dim, class... Args>
+        inline void check_index_impl(const S& shape, size_t i, Args... args)
+        {
+            if (sizeof...(Args) + 1 > shape.size())
+            {
+                check_index_impl<S, dim>(shape, args...);
+            }
+            else
+            {
+                if (i >= shape[dim] && shape[dim] != 1)
+                {
+                    throw std::out_of_range("index " + std::to_string(i) + " is out of bounds for axis "
+                        + std::to_string(dim) + " with size " + std::to_string(shape[dim]));
+                }
+                check_index_impl<S, dim + 1>(shape, args...);
+            }
+        }
+    }
+
+    template <class S, class... Args>
+    inline void check_index(const S& shape, Args... args)
+    {
+        detail::check_index_impl<S, 0>(shape, args...);
+    }
+
+    template <class S, class It>
+    inline void check_element_index(const S& shape, It first, It last)
+    {
+        auto dst = static_cast<typename S::size_type>(last - first);
+        It efirst = last - std::min(shape.size(), dst);
+        size_t axis = 0;
+        while (efirst != last)
+        {
+            if (*efirst >= shape[axis] && shape[axis] != 1)
+            {
+                throw std::out_of_range("index " + std::to_string(*efirst) + " is out of bounds for axis "
+                    + std::to_string(axis) + " with size " + std::to_string(shape[axis]));
+            }
+            ++efirst, ++axis;
+        }
+    }
+
+#ifdef XTENSOR_ENABLE_ASSERT
+#define XTENSOR_ASSERT(expr) XTENSOR_ASSERT_IMPL(expr, __FILE__, __LINE__)
+#define XTENSOR_ASSERT_IMPL(expr, file, line)\
+    try {\
+        expr;\
+    }\
+    catch (std::exception& e)\
+    {\
+        throw std::runtime_error(std::string(file) + ':' + std::to_string(line)\
+            + ": check failed\n\t" + std::string(e.what()));\
+    }
+#else
+#define XTENSOR_ASSERT(expr)
+#endif
+}
+#endif

--- a/inst/include/xtensor/xexpression.hpp
+++ b/inst/include/xtensor/xexpression.hpp
@@ -1,0 +1,219 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XEXPRESSION_HPP
+#define XEXPRESSION_HPP
+
+#include <cstddef>
+#include <type_traits>
+#include <vector>
+
+#include "xutils.hpp"
+
+namespace xt
+{
+
+    using xindex = std::vector<std::size_t>;
+
+    /***************************
+     * xexpression declaration *
+     ***************************/
+
+    /**
+     * @class xexpression
+     * @brief Base class for xexpressions
+     *
+     * The xexpression class is the base class for all classes representing an expression
+     * that can be evaluated to a multidimensional container with tensor semantic.
+     * Functions that can apply to any xexpression regardless of its specific type should take a
+     * xexpression argument.
+     *
+     * \tparam E The derived type.
+     *
+     */
+    template <class D>
+    class xexpression
+    {
+
+    public:
+
+        using derived_type = D;
+
+        derived_type& derived_cast() & noexcept;
+        const derived_type& derived_cast() const & noexcept;
+        derived_type derived_cast() && noexcept;
+
+    protected:
+
+        xexpression() = default;
+        ~xexpression() = default;
+
+        xexpression(const xexpression&) = default;
+        xexpression& operator=(const xexpression&) = default;
+
+        xexpression(xexpression&&) = default;
+        xexpression& operator=(xexpression&&) = default;
+    };
+
+    /******************************
+     * xexpression implementation *
+     ******************************/
+
+    /**
+     * @name Downcast functions
+     */
+    //@{
+    /**
+     * Returns a reference to the actual derived type of the xexpression.
+     */
+    template <class D>
+    inline auto xexpression<D>::derived_cast() & noexcept -> derived_type&
+    {
+        return *static_cast<derived_type*>(this);
+    }
+
+    /**
+     * Returns a constant reference to the actual derived type of the xexpression.
+     */
+    template <class D>
+    inline auto xexpression<D>::derived_cast() const & noexcept -> const derived_type&
+    {
+        return *static_cast<const derived_type*>(this);
+    }
+
+    /**
+     * Returns a constant reference to the actual derived type of the xexpression.
+     */
+    template <class D>
+    inline auto xexpression<D>::derived_cast() && noexcept->derived_type
+    {
+        return *static_cast<derived_type*>(this);
+    }
+    //@}
+
+    namespace detail
+    {
+        template <class E>
+        struct is_xexpression_impl : std::is_base_of<xexpression<E>, E>
+        {
+        };
+
+        template <class E>
+        struct is_xexpression_impl<xexpression<E>> : std::true_type
+        {
+        };
+    }
+
+    template <class E>
+    using is_xexpression = detail::is_xexpression_impl<E>;
+
+    template <class E, class R = void>
+    using disable_xexpression = typename std::enable_if<!is_xexpression<E>::value, R>::type;
+
+    template <class... E>
+    using has_xexpression = or_<is_xexpression<E>...>;
+
+    /************
+     * xclosure *
+     ************/
+
+    template <class T>
+    class xscalar;
+
+    template <class E, class EN = void>
+    struct xclosure
+    {
+        using type = closure_t<E>;
+    };
+
+    template <class E>
+    struct xclosure<E, disable_xexpression<std::decay_t<E>>>
+    {
+        using type = xscalar<closure_t<E>>;
+    };
+
+    template <class E>
+    using xclosure_t = typename xclosure<E>::type;
+
+    template <class E, class EN = void>
+    struct const_xclosure
+    {
+        using type = const_closure_t<E>;
+    };
+
+    template <class E>
+    struct const_xclosure<E, disable_xexpression<std::decay_t<E>>>
+    {
+        using type = xscalar<const_closure_t<E>>;
+    };
+
+    template <class E>
+    using const_xclosure_t = typename const_xclosure<E>::type;
+
+    /***************
+     * xvalue_type *
+     ***************/
+
+    namespace detail
+    {
+        template <class E, class enable = void>
+        struct xvalue_type_impl
+        {
+            using type = E;
+        };
+
+        template <class E>
+        struct xvalue_type_impl<E, std::enable_if_t<is_xexpression<E>::value>>
+        {
+            using type = typename E::value_type;
+        };
+    }
+
+    template <class E>
+    using xvalue_type = detail::xvalue_type_impl<E>;
+
+    template <class E>
+    using xvalue_type_t = typename xvalue_type<E>::type;
+
+    /***************
+     * get_element *
+     ***************/
+
+    namespace detail
+    {
+        template <class E>
+        inline typename E::reference get_element(E& e)
+        {
+            return e();
+        }
+
+        template <class E, class S, class... Args>
+        inline typename E::reference get_element(E& e, S i, Args... args)
+        {
+            if (sizeof...(Args) >= e.dimension())
+                return get_element(e, args...);
+            return e(i, args...);
+        }
+
+        template <class E>
+        inline typename E::const_reference get_element(const E& e)
+        {
+            return e();
+        }
+
+        template <class E, class S, class... Args>
+        inline typename E::const_reference get_element(const E& e, S i, Args... args)
+        {
+            if (sizeof...(Args) >= e.dimension())
+                return get_element(e, args...);
+            return e(i, args...);
+        }
+    }
+}
+
+#endif

--- a/inst/include/xtensor/xfunction.hpp
+++ b/inst/include/xtensor/xfunction.hpp
@@ -1,0 +1,815 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XFUNCTION_HPP
+#define XFUNCTION_HPP
+
+#include <algorithm>
+#include <cstddef>
+#include <iterator>
+#include <numeric>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+#include "xexpression.hpp"
+#include "xiterable.hpp"
+#include "xlayout.hpp"
+#include "xscalar.hpp"
+#include "xutils.hpp"
+
+namespace xt
+{
+
+    namespace detail
+    {
+
+        /********************
+         * common_size_type *
+         ********************/
+
+        template <class... Args>
+        struct common_size_type
+        {
+            using type = std::common_type_t<typename Args::size_type...>;
+        };
+
+        template <>
+        struct common_size_type<>
+        {
+            using type = std::size_t;
+        };
+
+        template <class... Args>
+        using common_size_type_t = typename common_size_type<Args...>::type;
+
+        /**************************
+         * common_difference type *
+         **************************/
+
+        template <class... Args>
+        struct common_difference_type
+        {
+            using type = std::common_type_t<typename Args::difference_type...>;
+        };
+
+        template <>
+        struct common_difference_type<>
+        {
+            using type = std::size_t;
+        };
+
+        template <class... Args>
+        using common_difference_type_t = typename common_difference_type<Args...>::type;
+
+        /*********************
+         * common_value_type *
+         *********************/
+
+        template <class... Args>
+        struct common_value_type
+        {
+            using type = std::common_type_t<xvalue_type_t<Args>...>;
+        };
+
+        template <class... Args>
+        using common_value_type_t = typename common_value_type<Args...>::type;
+    }
+
+    template <class F, class R, class... CT>
+    class xfunction_iterator;
+
+    template <class F, class R, class... CT>
+    class xfunction_stepper;
+
+    template <class F, class R, class... CT>
+    class xfunction;
+
+    template <class F, class R, class... CT>
+    struct xiterable_inner_types<xfunction<F, R, CT...>>
+    {
+        using inner_shape_type = promote_shape_t<typename std::decay_t<CT>::shape_type...>;
+        using const_iterator = xfunction_iterator<F, R, CT...>;
+        using iterator = const_iterator;
+        using const_stepper = xfunction_stepper<F, R, CT...>;
+        using stepper = const_stepper;
+        using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+        using reverse_iterator = std::reverse_iterator<iterator>;
+    };
+
+    /*************
+     * xfunction *
+     *************/
+
+    /**
+     * @class xfunction
+     * @brief Multidimensional function operating on xexpression.
+     *
+     * Th xfunction class implements a multidimensional function
+     * operating on xexpression.
+     *
+     * @tparam F the function type
+     * @tparam R the return type of the function
+     * @tparam CT the closure types for arguments of the function
+     */
+    template <class F, class R, class... CT>
+    class xfunction : public xexpression<xfunction<F, R, CT...>>,
+                      public xconst_iterable<xfunction<F, R, CT...>>
+    {
+
+    public:
+
+        using self_type = xfunction<F, R, CT...>;
+        using functor_type = typename std::remove_reference<F>::type;
+
+        using value_type = R;
+        using reference = value_type;
+        using const_reference = value_type;
+        using pointer = value_type*;
+        using const_pointer = const value_type*;
+        using size_type = detail::common_size_type_t<std::decay_t<CT>...>;
+        using difference_type = detail::common_difference_type_t<std::decay_t<CT>...>;
+
+        using iterable_base = xconst_iterable<xfunction<F, R, CT...>>;
+        using inner_shape_type = typename iterable_base::inner_shape_type;
+        using shape_type = inner_shape_type;
+
+        using iterator = typename iterable_base::iterator;
+        using const_iterator = typename iterable_base::const_iterator;
+
+        using stepper = typename iterable_base::stepper;
+        using const_stepper = typename iterable_base::const_stepper;
+
+        using reverse_iterator = typename iterable_base::reverse_iterator;
+        using const_reverse_iterator = typename iterable_base::const_reverse_iterator;
+
+        static constexpr layout_type static_layout = compute_layout(std::decay_t<CT>::static_layout...);
+        static constexpr bool contiguous_layout = and_c<std::decay_t<CT>::contiguous_layout...>::value;
+
+        template <class Func>
+        xfunction(Func&& f, CT... e) noexcept;
+
+        size_type size() const noexcept;
+        size_type dimension() const noexcept;
+        const shape_type& shape() const;
+        layout_type layout() const noexcept;
+
+        template <class... Args>
+        const_reference operator()(Args... args) const;
+
+        const_reference operator[](const xindex& index) const;
+        const_reference operator[](size_type i) const;
+
+        template <class It>
+        const_reference element(It first, It last) const;
+
+        template <class S>
+        bool broadcast_shape(S& shape) const;
+
+        template <class S>
+        bool is_trivial_broadcast(const S& strides) const noexcept;
+
+        const_iterator begin() const noexcept;
+        const_iterator end() const noexcept;
+        const_iterator cbegin() const noexcept;
+        const_iterator cend() const noexcept;
+
+        const_reverse_iterator rbegin() const noexcept;
+        const_reverse_iterator rend() const noexcept;
+        const_reverse_iterator crbegin() const noexcept;
+        const_reverse_iterator crend() const noexcept;
+
+        template <class S>
+        const_stepper stepper_begin(const S& shape) const noexcept;
+        template <class S>
+        const_stepper stepper_end(const S& shape) const noexcept;
+
+    private:
+
+        template <std::size_t... I>
+        layout_type layout_impl(std::index_sequence<I...>) const noexcept;
+
+        template <std::size_t... I, class... Args>
+        const_reference access_impl(std::index_sequence<I...>, Args... args) const;
+
+        template <std::size_t... I, class It>
+        const_reference element_access_impl(std::index_sequence<I...>, It first, It last) const;
+
+        template <class Func, std::size_t... I>
+        const_stepper build_stepper(Func&& f, std::index_sequence<I...>) const noexcept;
+
+        template <class Func, std::size_t... I>
+        const_iterator build_iterator(Func&& f, std::index_sequence<I...>) const noexcept;
+
+        size_type compute_dimension() const noexcept;
+
+        std::tuple<CT...> m_e;
+        functor_type m_f;
+        mutable shape_type m_shape;
+        mutable bool m_shape_computed;
+
+        friend class xfunction_iterator<F, R, CT...>;
+        friend class xfunction_stepper<F, R, CT...>;
+    };
+
+    /**********************
+     * xfunction_iterator *
+     **********************/
+
+    template <class CT>
+    class xscalar;
+
+    namespace detail
+    {
+        template <class C>
+        struct get_iterator_impl
+        {
+            using type = typename C::iterator;
+        };
+
+        template <class C>
+        struct get_iterator_impl<const C>
+        {
+            using type = typename C::const_iterator;
+        };
+
+        template <class CT>
+        struct get_iterator_impl<xscalar<CT>>
+        {
+            using type = typename xscalar<CT>::dummy_iterator;
+        };
+
+        template <class CT>
+        struct get_iterator_impl<const xscalar<CT>>
+        {
+            using type = typename xscalar<CT>::const_dummy_iterator;
+        };
+    }
+
+    template <class C>
+    using get_iterator = typename detail::get_iterator_impl<C>::type;
+
+    template <class F, class R, class... CT>
+    class xfunction_iterator
+    {
+
+    public:
+
+        using self_type = xfunction_iterator<F, R, CT...>;
+        using functor_type = typename std::remove_reference<F>::type;
+        using xfunction_type = xfunction<F, R, CT...>;
+
+        using value_type = typename xfunction_type::value_type;
+        using reference = typename xfunction_type::value_type;
+        using pointer = typename xfunction_type::const_pointer;
+        using difference_type = typename xfunction_type::difference_type;
+        using iterator_category = std::forward_iterator_tag;
+
+        template <class... It>
+        xfunction_iterator(const xfunction_type* func, It&&... it) noexcept;
+
+        self_type& operator++();
+        self_type operator++(int);
+
+        self_type& operator--();
+        self_type operator--(int);
+
+        reference operator*() const;
+
+        bool equal(const self_type& rhs) const;
+
+    private:
+
+        template <std::size_t... I>
+        reference deref_impl(std::index_sequence<I...>) const;
+
+        const xfunction_type* p_f;
+        std::tuple<get_iterator<const std::decay_t<CT>>...> m_it;
+    };
+
+    template <class F, class R, class... CT>
+    bool operator==(const xfunction_iterator<F, R, CT...>& it1,
+                    const xfunction_iterator<F, R, CT...>& it2);
+
+    template <class F, class R, class... CT>
+    bool operator!=(const xfunction_iterator<F, R, CT...>& it1,
+                    const xfunction_iterator<F, R, CT...>& it2);
+
+    /*********************
+     * xfunction_stepper *
+     *********************/
+
+    template <class F, class R, class... CT>
+    class xfunction_stepper
+    {
+
+    public:
+
+        using self_type = xfunction_stepper<F, R, CT...>;
+        using functor_type = typename std::remove_reference<F>::type;
+        using xfunction_type = xfunction<F, R, CT...>;
+
+        using value_type = typename xfunction_type::value_type;
+        using reference = typename xfunction_type::value_type;
+        using pointer = typename xfunction_type::const_pointer;
+        using size_type = typename xfunction_type::size_type;
+        using difference_type = typename xfunction_type::difference_type;
+
+        using shape_type = typename xfunction_type::shape_type;
+
+        template <class... It>
+        xfunction_stepper(const xfunction_type* func, It&&... it) noexcept;
+
+        void step(size_type dim, size_type n = 1);
+        void step_back(size_type dim, size_type n = 1);
+        void reset(size_type dim);
+        void reset_back(size_type dim);
+
+        void to_begin();
+        void to_end();
+
+        reference operator*() const;
+
+        bool equal(const self_type& rhs) const;
+
+    private:
+
+        template <std::size_t... I>
+        reference deref_impl(std::index_sequence<I...>) const;
+
+        const xfunction_type* p_f;
+        std::tuple<typename std::decay_t<CT>::const_stepper...> m_it;
+    };
+
+    template <class F, class R, class... CT>
+    bool operator==(const xfunction_stepper<F, R, CT...>& it1,
+                    const xfunction_stepper<F, R, CT...>& it2);
+
+    template <class F, class R, class... CT>
+    bool operator!=(const xfunction_stepper<F, R, CT...>& it1,
+                    const xfunction_stepper<F, R, CT...>& it2);
+
+    /****************************
+     * xfunction implementation *
+     ****************************/
+
+    /**
+     * @name Constructor
+     */
+    //@{
+    /**
+     * Constructs an xfunction applying the specified function to the given
+     * arguments.
+     * @param f the function to apply
+     * @param e the \ref xexpression arguments
+     */
+    template <class F, class R, class... CT>
+    template <class Func>
+    inline xfunction<F, R, CT...>::xfunction(Func&& f, CT... e) noexcept
+        : m_e(e...), m_f(std::forward<Func>(f)), m_shape(make_sequence<shape_type>(0, size_type(1))),
+          m_shape_computed(false)
+    {
+    }
+    //@}
+
+    /**
+     * @name Size and shape
+     */
+    //@{
+    /**
+     * Returns the size of the expression.
+     */
+    template <class F, class R, class... CT>
+    inline auto xfunction<F, R, CT...>::size() const noexcept -> size_type
+    {
+        return compute_size(shape());
+    }
+
+    /**
+     * Returns the number of dimensions of the function.
+     */
+    template <class F, class R, class... CT>
+    inline auto xfunction<F, R, CT...>::dimension() const noexcept -> size_type
+    {
+        size_type dimension = m_shape_computed ? m_shape.size() : compute_dimension();
+        return dimension;
+    }
+
+    /**
+     * Returns the shape of the xfunction.
+     */
+    template <class F, class R, class... CT>
+    inline auto xfunction<F, R, CT...>::shape() const -> const shape_type&
+    {
+        if (!m_shape_computed)
+        {
+            m_shape = make_sequence<shape_type>(compute_dimension(), size_type(1));
+            broadcast_shape(m_shape);
+            m_shape_computed = true;
+        }
+        return m_shape;
+    }
+
+    /**
+     * Returns the layout_type of the xfunction.
+     */
+    template <class F, class R, class... CT>
+    inline layout_type xfunction<F, R, CT...>::layout() const noexcept
+    {
+        return layout_impl(std::make_index_sequence<sizeof...(CT)>());
+    }
+    //@}
+
+    /**
+     * @name Data
+     */
+    /**
+     * Returns a constant reference to the element at the specified position in the function.
+     * @param args a list of indices specifying the position in the function. Indices
+     * must be unsigned integers, the number of indices should be equal or greater than
+     * the number of dimensions of the function.
+     */
+    template <class F, class R, class... CT>
+    template <class... Args>
+    inline auto xfunction<F, R, CT...>::operator()(Args... args) const -> const_reference
+    {
+        return access_impl(std::make_index_sequence<sizeof...(CT)>(), args...);
+    }
+
+    template <class F, class R, class... CT>
+    inline auto xfunction<F, R, CT...>::operator[](const xindex& index) const -> const_reference
+    {
+        return element(index.cbegin(), index.cend());
+    }
+
+    template <class F, class R, class... CT>
+    inline auto xfunction<F, R, CT...>::operator[](size_type i) const -> const_reference
+    {
+        return operator()(i);
+    }
+
+    /**
+     * Returns a constant reference to the element at the specified position in the function.
+     * @param first iterator starting the sequence of indices
+     * @param last iterator ending the sequence of indices
+     * The number of indices in the squence should be equal to or greater
+     * than the number of dimensions of the container.
+     */
+    template <class F, class R, class... CT>
+    template <class It>
+    inline auto xfunction<F, R, CT...>::element(It first, It last) const -> const_reference
+    {
+        return element_access_impl(std::make_index_sequence<sizeof...(CT)>(), first, last);
+    }
+    //@}
+
+    /**
+     * @name Broadcasting
+     */
+    //@{
+    /**
+     * Broadcast the shape of the function to the specified parameter.
+     * @param shape the result shape
+     * @return a boolean indicating whether the broadcasting is trivial
+     */
+    template <class F, class R, class... CT>
+    template <class S>
+    inline bool xfunction<F, R, CT...>::broadcast_shape(S& shape) const
+    {
+        // e.broadcast_shape must be evaluated even if b is false
+        auto func = [&shape](bool b, auto&& e) { return e.broadcast_shape(shape) && b; };
+        return accumulate(func, true, m_e);
+    }
+
+    /**
+     * Compares the specified strides with those of the container to see whether
+     * the broadcasting is trivial.
+     * @return a boolean indicating whether the broadcasting is trivial
+     */
+    template <class F, class R, class... CT>
+    template <class S>
+    inline bool xfunction<F, R, CT...>::is_trivial_broadcast(const S& strides) const noexcept
+    {
+        auto func = [&strides](bool b, auto&& e) { return b && e.is_trivial_broadcast(strides); };
+        return accumulate(func, true, m_e);
+    }
+    //@}
+
+    /**
+     * @name Iterators
+     */
+    /**
+     * Returns an iterator to the first element of the buffer
+     * containing the elements of the function.
+     */
+    template <class F, class R, class... CT>
+    inline auto xfunction<F, R, CT...>::begin() const noexcept -> const_iterator
+    {
+        auto f = [](const auto& e) noexcept { return detail::trivial_begin(e); };
+        return build_iterator(f, std::make_index_sequence<sizeof...(CT)>());
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last
+     * element of the buffer containing the elements of the function.
+     */
+    template <class F, class R, class... CT>
+    inline auto xfunction<F, R, CT...>::end() const noexcept -> const_iterator
+    {
+        auto f = [](const auto& e) noexcept { return detail::trivial_end(e); };
+        return build_iterator(f, std::make_index_sequence<sizeof...(CT)>());
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the buffer
+     * containing the elements of the function.
+     */
+    template <class F, class R, class... CT>
+    inline auto xfunction<F, R, CT...>::cbegin() const noexcept -> const_iterator
+    {
+        return begin();
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last
+     * element of the buffer containing the elements of the function.
+     */
+    template <class F, class R, class... CT>
+    inline auto xfunction<F, R, CT...>::cend() const noexcept -> const_iterator
+    {
+        return end();
+    }
+    //@}
+
+    /**
+     * @name Reverse iterators
+     */
+    //@{
+    /**
+     * Returns an iterator to the first element of the reversed buffer
+     * containing the elements of the function.
+     */
+    template <class F, class R, class... CT>
+    inline auto xfunction<F, R, CT...>::rbegin() const noexcept -> const_reverse_iterator
+    {
+        return crbegin();
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last
+     * element of the reversed buffer containing the elements of the function.
+     */
+    template <class F, class R, class... CT>
+    inline auto xfunction<F, R, CT...>::rend() const noexcept -> const_reverse_iterator
+    {
+        return crend();
+    }
+
+    /**
+     * Returns an iterator to the first element of the reversed buffer
+     * containing the elements of the function.
+     */
+    template <class F, class R, class... CT>
+    inline auto xfunction<F, R, CT...>::crbegin() const noexcept -> const_reverse_iterator
+    {
+        return const_reverse_iterator(cend());
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last
+     * element of the reversed buffer containing the elements of the function.
+     */
+    template <class F, class R, class... CT>
+    inline auto xfunction<F, R, CT...>::crend() const noexcept -> const_reverse_iterator
+    {
+        return const_reverse_iterator(cbegin());
+    }
+    //@}
+
+    template <class F, class R, class... CT>
+    template <class S>
+    inline auto xfunction<F, R, CT...>::stepper_begin(const S& shape) const noexcept -> const_stepper
+    {
+        auto f = [&shape](const auto& e) noexcept { return e.stepper_begin(shape); };
+        return build_stepper(f, std::make_index_sequence<sizeof...(CT)>());
+    }
+
+    template <class F, class R, class... CT>
+    template <class S>
+    inline auto xfunction<F, R, CT...>::stepper_end(const S& shape) const noexcept -> const_stepper
+    {
+        auto f = [&shape](const auto& e) noexcept { return e.stepper_end(shape); };
+        return build_stepper(f, std::make_index_sequence<sizeof...(CT)>());
+    }
+
+    template <class F, class R, class... CT>
+    template <std::size_t... I>
+    inline layout_type xfunction<F, R, CT...>::layout_impl(std::index_sequence<I...>) const noexcept
+    {
+        return compute_layout(std::get<I>(m_e).layout()...);
+    }
+
+    template <class F, class R, class... CT>
+    template <std::size_t... I, class... Args>
+    inline auto xfunction<F, R, CT...>::access_impl(std::index_sequence<I...>, Args... args) const -> const_reference
+    {
+        return m_f(detail::get_element(std::get<I>(m_e), args...)...);
+    }
+
+    template <class F, class R, class... CT>
+    template <std::size_t... I, class It>
+    inline auto xfunction<F, R, CT...>::element_access_impl(std::index_sequence<I...>, It first, It last) const -> const_reference
+    {
+        return m_f((std::get<I>(m_e).element(first, last))...);
+    }
+
+    template <class F, class R, class... CT>
+    template <class Func, std::size_t... I>
+    inline auto xfunction<F, R, CT...>::build_stepper(Func&& f, std::index_sequence<I...>) const noexcept -> const_stepper
+    {
+        return const_stepper(this, f(std::get<I>(m_e))...);
+    }
+
+    template <class F, class R, class... CT>
+    template <class Func, std::size_t... I>
+    inline auto xfunction<F, R, CT...>::build_iterator(Func&& f, std::index_sequence<I...>) const noexcept -> const_iterator
+    {
+        return const_iterator(this, f(std::get<I>(m_e))...);
+    }
+
+    template <class F, class R, class... CT>
+    inline auto xfunction<F, R, CT...>::compute_dimension() const noexcept -> size_type
+    {
+        auto func = [](size_type d, auto&& e) noexcept { return std::max(d, e.dimension()); };
+        return accumulate(func, size_type(0), m_e);
+    }
+
+    /*************************************
+     * xfunction_iterator implementation *
+     *************************************/
+
+    template <class F, class R, class... CT>
+    template <class... It>
+    inline xfunction_iterator<F, R, CT...>::xfunction_iterator(const xfunction_type* func, It&&... it) noexcept
+        : p_f(func), m_it(std::forward<It>(it)...)
+    {
+    }
+
+    template <class F, class R, class... CT>
+    inline auto xfunction_iterator<F, R, CT...>::operator++() -> self_type&
+    {
+        auto f = [](auto& it) { ++it; };
+        for_each(f, m_it);
+        return *this;
+    }
+
+    template <class F, class R, class... CT>
+    inline auto xfunction_iterator<F, R, CT...>::operator++(int) -> self_type
+    {
+        self_type tmp(*this);
+        ++(*this);
+        return tmp;
+    }
+
+    template <class F, class R, class... CT>
+    inline auto xfunction_iterator<F, R, CT...>::operator--() -> self_type&
+    {
+        auto f = [](auto& it) { return --it; };
+        for_each(f, m_it);
+        return *this;
+    }
+
+    template <class F, class R, class... CT>
+    inline auto xfunction_iterator<F, R, CT...>::operator--(int) -> self_type
+    {
+        self_type tmp(*this);
+        --(*this);
+        return tmp;
+    }
+
+    template <class F, class R, class... CT>
+    inline auto xfunction_iterator<F, R, CT...>::operator*() const -> reference
+    {
+        return deref_impl(std::make_index_sequence<sizeof...(CT)>());
+    }
+
+    template <class F, class R, class... CT>
+    inline bool xfunction_iterator<F, R, CT...>::equal(const self_type& rhs) const
+    {
+        return p_f == rhs.p_f && m_it == rhs.m_it;
+    }
+
+    template <class F, class R, class... CT>
+    template <std::size_t... I>
+    inline auto xfunction_iterator<F, R, CT...>::deref_impl(std::index_sequence<I...>) const -> reference
+    {
+        return (p_f->m_f)(*std::get<I>(m_it)...);
+    }
+
+    template <class F, class R, class... CT>
+    inline bool operator==(const xfunction_iterator<F, R, CT...>& it1,
+                           const xfunction_iterator<F, R, CT...>& it2)
+    {
+        return it1.equal(it2);
+    }
+
+    template <class F, class R, class... CT>
+    inline bool operator!=(const xfunction_iterator<F, R, CT...>& it1,
+                           const xfunction_iterator<F, R, CT...>& it2)
+    {
+        return !(it1.equal(it2));
+    }
+
+    /************************************
+     * xfunction_stepper implementation *
+     ************************************/
+
+    template <class F, class R, class... CT>
+    template <class... It>
+    inline xfunction_stepper<F, R, CT...>::xfunction_stepper(const xfunction_type* func, It&&... it) noexcept
+        : p_f(func), m_it(std::forward<It>(it)...)
+    {
+    }
+
+    template <class F, class R, class... CT>
+    inline void xfunction_stepper<F, R, CT...>::step(size_type dim, size_type n)
+    {
+        auto f = [dim, n](auto& it) { it.step(dim, n); };
+        for_each(f, m_it);
+    }
+
+    template <class F, class R, class... CT>
+    inline void xfunction_stepper<F, R, CT...>::step_back(size_type dim, size_type n)
+    {
+        auto f = [dim, n](auto& it) { it.step_back(dim, n); };
+        for_each(f, m_it);
+    }
+
+    template <class F, class R, class... CT>
+    inline void xfunction_stepper<F, R, CT...>::reset(size_type dim)
+    {
+        auto f = [dim](auto& it) { it.reset(dim); };
+        for_each(f, m_it);
+    }
+
+    template <class F, class R, class... CT>
+    inline void xfunction_stepper<F, R, CT...>::reset_back(size_type dim)
+    {
+        auto f = [dim](auto& it) { it.reset_back(dim); };
+        for_each(f, m_it);
+    }
+
+    template <class F, class R, class... CT>
+    inline void xfunction_stepper<F, R, CT...>::to_begin()
+    {
+        auto f = [](auto& it) { it.to_begin(); };
+        for_each(f, m_it);
+    }
+
+    template <class F, class R, class... CT>
+    inline void xfunction_stepper<F, R, CT...>::to_end()
+    {
+        auto f = [](auto& it) { it.to_end(); };
+        for_each(f, m_it);
+    }
+
+    template <class F, class R, class... CT>
+    inline auto xfunction_stepper<F, R, CT...>::operator*() const -> reference
+    {
+        return deref_impl(std::make_index_sequence<sizeof...(CT)>());
+    }
+
+    template <class F, class R, class... CT>
+    inline bool xfunction_stepper<F, R, CT...>::equal(const self_type& rhs) const
+    {
+        return p_f == rhs.p_f && m_it == rhs.m_it;
+    }
+
+    template <class F, class R, class... CT>
+    template <std::size_t... I>
+    inline auto xfunction_stepper<F, R, CT...>::deref_impl(std::index_sequence<I...>) const -> reference
+    {
+        return (p_f->m_f)(*std::get<I>(m_it)...);
+    }
+
+    template <class F, class R, class... CT>
+    inline bool operator==(const xfunction_stepper<F, R, CT...>& it1,
+                           const xfunction_stepper<F, R, CT...>& it2)
+    {
+        return it1.equal(it2);
+    }
+
+    template <class F, class R, class... CT>
+    inline bool operator!=(const xfunction_stepper<F, R, CT...>& it1,
+                           const xfunction_stepper<F, R, CT...>& it2)
+    {
+        return !(it1.equal(it2));
+    }
+}
+
+#endif

--- a/inst/include/xtensor/xfunctorview.hpp
+++ b/inst/include/xtensor/xfunctorview.hpp
@@ -1,0 +1,1221 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XFUNCTORVIEW_HPP
+#define XFUNCTORVIEW_HPP
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+
+#include "xtensor/xexpression.hpp"
+#include "xtensor/xiterator.hpp"
+#include "xtensor/xsemantic.hpp"
+#include "xtensor/xutils.hpp"
+
+#include "xtensor/xarray.hpp"
+#include "xtensor/xtensor.hpp"
+
+namespace xt
+{
+
+    /****************************
+     * xfunctorview declaration *
+     ****************************/
+
+    template <class F, class IT>
+    class xfunctor_iterator;
+
+    template <class F, class ST>
+    class xfunctor_stepper;
+
+    template <class F, class CT>
+    class xfunctorview;
+
+    /*****************************
+     * xfunctorview_temporary_type *
+     *****************************/
+
+    namespace detail
+    {
+        template <class F, class S, layout_type L>
+        struct functorview_temporary_type_impl
+        {
+            using type = xarray<typename F::value_type, L>;
+        };
+
+        template <class F, class T, std::size_t N, layout_type L>
+        struct functorview_temporary_type_impl<F, std::array<T, N>, L>
+        {
+            using type = xtensor<typename F::value_type, N, L>;
+        };
+    }
+
+    template <class F, class E>
+    struct xfunctorview_temporary_type
+    {
+        using type = typename detail::functorview_temporary_type_impl<F, typename E::shape_type, E::static_layout>::type;
+    };
+
+    template <class F, class CT>
+    struct xcontainer_inner_types<xfunctorview<F, CT>>
+    {
+        using xexpression_type = std::decay_t<CT>;
+        using temporary_type = typename xfunctorview_temporary_type<F, xexpression_type>::type;
+    };
+
+#define DL DEFAULT_LAYOUT
+    /**
+     * @class xfunctorview
+     * @brief View of an xexpression .
+     *
+     * The xfunctorview class is an expression addressing its elements by applying a functor to the
+     * corresponding element of an underlying expression. Unlike e.g. xgenerator, an xfunctorview is
+     * an lvalue. It is used e.g. to access real and imaginary parts of complex expressions.
+     * expressions.
+     * xfunctorview is not meant to be used directly, but through helper functions such
+     * as \ref real or \ref imag.
+     *
+     * @tparam F the functor type to be applied to the elements of specified expression.
+     * @tparam CT the closure type of the \ref xexpression type underlying this view
+     *
+     * @sa real, imag
+     */
+    template <class F, class CT>
+    class xfunctorview : public xview_semantic<xfunctorview<F, CT>>
+    {
+    public:
+
+        using self_type = xfunctorview<F, CT>;
+        using xexpression_type = std::decay_t<CT>;
+        using semantic_base = xview_semantic<self_type>;
+        using functor_type = typename std::decay_t<F>;
+
+        using value_type = typename functor_type::value_type;
+        using reference = typename functor_type::reference;
+        using const_reference = typename functor_type::const_reference;
+        using pointer = typename functor_type::pointer;
+        using const_pointer = typename functor_type::const_pointer;
+        using size_type = typename xexpression_type::size_type;
+        using difference_type = typename xexpression_type::difference_type;
+
+        using shape_type = typename xexpression_type::shape_type;
+
+        using stepper = xfunctor_stepper<functor_type, typename xexpression_type::stepper>;
+        using const_stepper = xfunctor_stepper<functor_type, typename xexpression_type::const_stepper>;
+
+        using iterator = xfunctor_iterator<functor_type, typename xexpression_type::iterator>;
+        using const_iterator = xfunctor_iterator<functor_type, typename xexpression_type::const_iterator>;
+
+        template <layout_type L>
+        using broadcast_iterator = xfunctor_iterator<functor_type, typename xexpression_type::template broadcast_iterator<L>>;
+        template <layout_type L>
+        using const_broadcast_iterator = xfunctor_iterator<functor_type, typename xexpression_type::template const_broadcast_iterator<L>>;
+
+        template <class S, layout_type L>
+        using shaped_xiterator = xfunctor_iterator<functor_type, xiterator<typename xexpression_type::stepper, S, L>>;
+        template <class S, layout_type L>
+        using const_shaped_xiterator = xfunctor_iterator<functor_type, xiterator<typename xexpression_type::const_stepper, S, L>>;
+
+        using reverse_iterator = xfunctor_iterator<functor_type, typename xexpression_type::reverse_iterator>;
+        using const_reverse_iterator = xfunctor_iterator<functor_type, typename xexpression_type::const_reverse_iterator>;
+
+        template <layout_type L>
+        using reverse_broadcast_iterator = xfunctor_iterator<functor_type, typename xexpression_type::template reverse_broadcast_iterator<L>>;
+        template <layout_type L>
+        using const_reverse_broadcast_iterator = xfunctor_iterator<functor_type, typename xexpression_type::template const_reverse_broadcast_iterator<L>>;
+
+        template <class S, layout_type L>
+        using reverse_shaped_xiterator = xfunctor_iterator<functor_type, typename xexpression_type::template reverse_shaped_xiterator<S, L>>;
+        template <class S, layout_type L>
+        using const_reverse_shaped_xiterator = xfunctor_iterator<functor_type, typename xexpression_type::template const_reverse_shaped_xiterator<S, L>>;
+
+        static constexpr layout_type static_layout = xexpression_type::static_layout;
+        static constexpr bool contiguous_layout = false;
+
+        xfunctorview(CT) noexcept;
+
+        template <class Func, class E>
+        xfunctorview(Func&&, E&&) noexcept;
+
+        template <class E>
+        self_type& operator=(const xexpression<E>& e);
+
+        template <class E>
+        disable_xexpression<E, self_type>& operator=(const E& e);
+
+        size_type size() const noexcept;
+        size_type dimension() const noexcept;
+        const shape_type& shape() const noexcept;
+        layout_type layout() const noexcept;
+
+        template <class... Args>
+        reference operator()(Args... args);
+        reference operator[](const xindex& index);
+        reference operator[](size_type i);
+
+        template <class IT>
+        reference element(IT first, IT last);
+
+        template <class... Args>
+        const_reference operator()(Args... args) const;
+        const_reference operator[](const xindex& index) const;
+        const_reference operator[](size_type i) const;
+
+        template <class IT>
+        const_reference element(IT first, IT last) const;
+
+        template <class S>
+        bool broadcast_shape(S& shape) const;
+
+        template <class S>
+        bool is_trivial_broadcast(const S& strides) const;
+
+        iterator begin() noexcept;
+        iterator end() noexcept;
+
+        const_iterator begin() const noexcept;
+        const_iterator end() const noexcept;
+        const_iterator cbegin() const noexcept;
+        const_iterator cend() const noexcept;
+
+        template <layout_type L = DL>
+        broadcast_iterator<L> xbegin() noexcept;
+        template <layout_type L = DL>
+        broadcast_iterator<L> xend() noexcept;
+
+        template <layout_type L = DL>
+        const_broadcast_iterator<L> xbegin() const noexcept;
+        template <layout_type L = DL>
+        const_broadcast_iterator<L> xend() const noexcept;
+        template <layout_type L = DL>
+        const_broadcast_iterator<L> cxbegin() const noexcept;
+        template <layout_type L = DL>
+        const_broadcast_iterator<L> cxend() const noexcept;
+
+        template <class S, layout_type L = DL>
+        shaped_xiterator<S, L> xbegin(const S& shape) noexcept;
+        template <class S, layout_type L = DL>
+        shaped_xiterator<S, L> xend(const S& shape) noexcept;
+
+        template <class S, layout_type L = DL>
+        const_shaped_xiterator<S, L> xbegin(const S& shape) const noexcept;
+        template <class S, layout_type L = DL>
+        const_shaped_xiterator<S, L> xend(const S& shape) const noexcept;
+        template <class S, layout_type L = DL>
+        const_shaped_xiterator<S, L> cxbegin(const S& shape) const noexcept;
+        template <class S, layout_type L = DL>
+        const_shaped_xiterator<S, L> cxend(const S& shape) const noexcept;
+
+        reverse_iterator rbegin() noexcept;
+        reverse_iterator rend() noexcept;
+
+        const_reverse_iterator rbegin() const noexcept;
+        const_reverse_iterator rend() const noexcept;
+        const_reverse_iterator crbegin() const noexcept;
+        const_reverse_iterator crend() const noexcept;
+
+        template <layout_type L = DL>
+        reverse_broadcast_iterator<L> xrbegin() noexcept;
+        template <layout_type L = DL>
+        reverse_broadcast_iterator<L> xrend() noexcept;
+
+        template <layout_type L = DL>
+        const_reverse_broadcast_iterator<L> xrbegin() const noexcept;
+        template <layout_type L = DL>
+        const_reverse_broadcast_iterator<L> xrend() const noexcept;
+        template <layout_type L = DL>
+        const_reverse_broadcast_iterator<L> cxrbegin() const noexcept;
+        template <layout_type L = DL>
+        const_reverse_broadcast_iterator<L> cxrend() const noexcept;
+
+        template <class S, layout_type L = DL>
+        reverse_shaped_xiterator<S, L> xrbegin(const S& shape) noexcept;
+        template <class S, layout_type L = DL>
+        reverse_shaped_xiterator<S, L> xrend(const S& shape) noexcept;
+
+        template <class S, layout_type L = DL>
+        const_reverse_shaped_xiterator<S, L> xrbegin(const S& shape) const noexcept;
+        template <class S, layout_type L = DL>
+        const_reverse_shaped_xiterator<S, L> xrend(const S& shape) const noexcept;
+        template <class S, layout_type L = DL>
+        const_reverse_shaped_xiterator<S, L> cxrbegin(const S& shape) const noexcept;
+        template <class S, layout_type L = DL>
+        const_reverse_shaped_xiterator<S, L> cxrend(const S& shape) const noexcept;
+
+        template <class S>
+        stepper stepper_begin(const S& shape) noexcept;
+        template <class S>
+        stepper stepper_end(const S& shape) noexcept;
+        template <class S>
+        const_stepper stepper_begin(const S& shape) const noexcept;
+        template <class S>
+        const_stepper stepper_end(const S& shape) const noexcept;
+
+    private:
+
+        CT m_e;
+        functor_type m_functor;
+
+        using temporary_type = typename xcontainer_inner_types<self_type>::temporary_type;
+        void assign_temporary_impl(temporary_type& tmp);
+        friend class xview_semantic<xfunctorview<F, CT>>;
+    };
+
+#undef DL
+
+    /*********************************
+     * xfunctor_iterator declaration *
+     *********************************/
+
+    template <class F, class IT>
+    class xfunctor_iterator
+    {
+    public:
+
+        using functor_type = std::decay_t<F>;
+        using value_type = typename functor_type::value_type;
+
+        using subiterator_traits = std::iterator_traits<IT>;
+
+        using reference = apply_cv_t<typename subiterator_traits::reference, value_type>;
+        using pointer = std::remove_reference_t<reference>*;
+        using difference_type = typename subiterator_traits::difference_type;
+        using iterator_category = typename subiterator_traits::iterator_category;
+
+        using self_type = xfunctor_iterator<F, IT>;
+
+        xfunctor_iterator(const IT&, const functor_type*);
+
+        self_type& operator++();
+        self_type operator++(int);
+
+        reference operator*() const;
+        pointer operator->() const;
+
+        bool equal(const xfunctor_iterator& rhs) const;
+
+    private:
+
+        IT m_it;
+        const functor_type* p_functor;
+
+        template <class F_, class IT_>
+        friend xfunctor_iterator<F_, IT_> operator+(xfunctor_iterator<F_, IT_>, xfunctor_iterator<F_, IT_>);
+
+        template <class F_, class IT_>
+        friend typename xfunctor_iterator<F_, IT_>::difference_type operator-(xfunctor_iterator<F_, IT_>, xfunctor_iterator<F_, IT_>);
+    };
+
+    template <class F, class IT>
+    bool operator==(const xfunctor_iterator<F, IT>& lhs,
+                    const xfunctor_iterator<F, IT>& rhs);
+
+    template <class F, class IT>
+    bool operator!=(const xfunctor_iterator<F, IT>& lhs,
+                    const xfunctor_iterator<F, IT>& rhs);
+
+    template <class F, class IT>
+    xfunctor_iterator<F, IT> operator+(xfunctor_iterator<F, IT> it1, xfunctor_iterator<F, IT> it2)
+    {
+        return xfunctor_iterator<F, IT>(it1.m_it + it2.m_it);
+    }
+
+    template <class F, class IT>
+    typename xfunctor_iterator<F, IT>::difference_type operator-(xfunctor_iterator<F, IT> it1, xfunctor_iterator<F, IT> it2)
+    {
+        return it1.m_it - it2.m_it;
+    }
+
+    /********************************
+     * xfunctor_stepper declaration *
+     ********************************/
+
+    template <class F, class ST>
+    class xfunctor_stepper
+    {
+    public:
+
+        using functor_type = std::decay_t<F>;
+
+        using value_type = typename functor_type::value_type;
+        using reference = apply_cv_t<typename ST::reference, value_type>;
+        using pointer = std::remove_reference_t<reference>*;
+        using size_type = typename ST::size_type;
+        using difference_type = typename ST::difference_type;
+
+        xfunctor_stepper() = default;
+        xfunctor_stepper(const ST&, const functor_type*);
+
+        reference operator*() const;
+
+        void step(size_type dim, size_type n = 1);
+        void step_back(size_type dim, size_type n = 1);
+        void reset(size_type dim);
+        void reset_back(size_type dim);
+
+        void to_begin();
+        void to_end();
+
+        bool equal(const xfunctor_stepper& rhs) const;
+
+    private:
+
+        ST m_stepper;
+        const functor_type* p_functor;
+    };
+
+    template <class F, class ST>
+    bool operator==(const xfunctor_stepper<F, ST>& lhs,
+                    const xfunctor_stepper<F, ST>& rhs);
+
+    template <class F, class ST>
+    bool operator!=(const xfunctor_stepper<F, ST>& lhs,
+                    const xfunctor_stepper<F, ST>& rhs);
+
+    /*******************************
+     * xfunctorview implementation *
+     *******************************/
+
+    /**
+     * @name Constructors
+     */
+    //@{
+
+    /**
+     * Constructs an xfunctorview expression wrappering the specified \ref xexpression.
+     *
+     * @param e the underlying expression
+     */
+    template <class F, class CT>
+    inline xfunctorview<F, CT>::xfunctorview(CT e) noexcept
+        : m_e(e), m_functor(functor_type())
+    {
+    }
+
+    /**
+    * Constructs an xfunctorview expression wrappering the specified \ref xexpression.
+    *
+    * @param func the functor to be applied to the elements of the underlying expression.
+    * @param e the underlying expression
+    */
+    template <class F, class CT>
+    template <class Func, class E>
+    inline xfunctorview<F, CT>::xfunctorview(Func&& func, E&& e) noexcept
+        : m_e(std::forward<E>(e)), m_functor(std::forward<Func>(func))
+    {
+    }
+    //@}
+
+    /**
+     * @name Extended copy semantic
+     */
+    //@{
+    /**
+     * The extended assignment operator.
+     */
+    template <class F, class CT>
+    template <class E>
+    inline auto xfunctorview<F, CT>::operator=(const xexpression<E>& e) -> self_type&
+    {
+        bool cond = (e.derived_cast().shape().size() == dimension()) && std::equal(shape().begin(), shape().end(), e.derived_cast().shape().begin());
+        if (!cond)
+        {
+            semantic_base::operator=(broadcast(e.derived_cast(), shape()));
+        }
+        else
+        {
+            semantic_base::operator=(e);
+        }
+        return *this;
+    }
+    //@}
+
+    template <class F, class CT>
+    template <class E>
+    inline auto xfunctorview<F, CT>::operator=(const E& e) -> disable_xexpression<E, self_type>&
+    {
+        std::fill(begin(), end(), e);
+        return *this;
+    }
+
+    template <class F, class CT>
+    inline void xfunctorview<F, CT>::assign_temporary_impl(temporary_type& tmp)
+    {
+        std::copy(tmp.cbegin(), tmp.cend(), xbegin());
+    }
+
+    /**
+     * @name Size and shape
+     */
+    /**
+     * Returns the size of the expression.
+     */
+    template <class F, class CT>
+    inline auto xfunctorview<F, CT>::size() const noexcept -> size_type
+    {
+        return m_e.size();
+    }
+
+    /**
+     * Returns the number of dimensions of the expression.
+     */
+    template <class F, class CT>
+    inline auto xfunctorview<F, CT>::dimension() const noexcept -> size_type
+    {
+        return m_e.dimension();
+    }
+
+    /**
+     * Returns the shape of the expression.
+     */
+    template <class F, class CT>
+    inline auto xfunctorview<F, CT>::shape() const noexcept -> const shape_type&
+    {
+        return m_e.shape();
+    }
+
+    /**
+     * Returns the layout_type of the expression.
+     */
+    template <class F, class CT>
+    inline layout_type xfunctorview<F, CT>::layout() const noexcept
+    {
+        return m_e.layout();
+    }
+    //@}
+
+    /**
+     * @name Data
+     */
+    /**
+     * Returns a reference to the element at the specified position in the expression.
+     * @param args a list of indices specifying the position in the function. Indices
+     * must be unsigned integers, the number of indices should be equal or greater than
+     * the number of dimensions of the expression.
+     */
+    template <class F, class CT>
+    template <class... Args>
+    inline auto xfunctorview<F, CT>::operator()(Args... args) -> reference
+    {
+        return m_functor(m_e(args...));
+    }
+
+    /**
+     * Returns a reference to the element at the specified position in the expression.
+     * @param index a sequence of indices specifying the position in the function. Indices
+     * must be unsigned integers, the number of indices in the sequence should be equal or greater
+     * than the number of dimensions of the container.
+     */
+    template <class F, class CT>
+    inline auto xfunctorview<F, CT>::operator[](const xindex& index) -> reference
+    {
+        return m_functor(m_e[index]);
+    }
+
+    template <class F, class CT>
+    inline auto xfunctorview<F, CT>::operator[](size_type i) -> reference
+    {
+        return operator()(i);
+    }
+
+    /**
+     * Returns a reference to the element at the specified position in the expression.
+     * @param first iterator starting the sequence of indices
+     * @param last iterator ending the sequence of indices
+     * The number of indices in the squence should be equal to or greater
+     * than the number of dimensions of the function.
+     */
+    template <class F, class CT>
+    template <class IT>
+    inline auto xfunctorview<F, CT>::element(IT first, IT last) -> reference
+    {
+        return m_functor(m_e.element(first, last));
+    }
+
+    /**
+     * Returns a constant reference to the element at the specified position in the expression.
+     * @param args a list of indices specifying the position in the function. Indices
+     * must be unsigned integers, the number of indices should be equal or greater than
+     * the number of dimensions of the expression.
+     */
+    template <class F, class CT>
+    template <class... Args>
+    inline auto xfunctorview<F, CT>::operator()(Args... args) const -> const_reference
+    {
+        return m_functor(m_e(args...));
+    }
+
+    /**
+     * Returns a constant reference to the element at the specified position in the expression.
+     * @param index a sequence of indices specifying the position in the function. Indices
+     * must be unsigned integers, the number of indices in the sequence should be equal or greater
+     * than the number of dimensions of the container.
+     */
+    template <class F, class CT>
+    inline auto xfunctorview<F, CT>::operator[](const xindex& index) const -> const_reference
+    {
+        return m_functor(m_e[index]);
+    }
+
+    template <class F, class CT>
+    inline auto xfunctorview<F, CT>::operator[](size_type i) const -> const_reference
+    {
+        return operator()(i);
+    }
+
+    /**
+     * Returns a constant reference to the element at the specified position in the expression.
+     * @param first iterator starting the sequence of indices
+     * @param last iterator ending the sequence of indices
+     * The number of indices in the squence should be equal to or greater
+     * than the number of dimensions of the function.
+     */
+    template <class F, class CT>
+    template <class IT>
+    inline auto xfunctorview<F, CT>::element(IT first, IT last) const -> const_reference
+    {
+        return m_functor(m_e.element(first, last));
+    }
+    //@}
+
+    /**
+     * @name Broadcasting
+     */
+    //@{
+    /**
+     * Broadcast the shape of the function to the specified parameter.
+     * @param shape the result shape
+     * @return a boolean indicating whether the broadcasting is trivial
+     */
+    template <class F, class CT>
+    template <class S>
+    inline bool xfunctorview<F, CT>::broadcast_shape(S& shape) const
+    {
+        return m_e.broadcast_shape(shape);
+    }
+
+    /**
+     * Compares the specified strides with those of the container to see whether
+     * the broadcasting is trivial.
+     * @return a boolean indicating whether the broadcasting is trivial
+     */
+    template <class F, class CT>
+    template <class S>
+    inline bool xfunctorview<F, CT>::is_trivial_broadcast(const S& strides) const
+    {
+        return m_e.is_trivial_broadcast(strides);
+    }
+    //@}
+
+    /**
+     * @name Iterators
+     */
+    //@{
+    /**
+     * Returns an iterator to the first element of the expression.
+     */
+    template <class F, class CT>
+    inline auto xfunctorview<F, CT>::begin() noexcept -> iterator
+    {
+        return iterator(m_e.begin(), &m_functor);
+    }
+
+    /**
+     * Returns an iterator to the element following the last element
+     * of the expression.
+     */
+    template <class F, class CT>
+    inline auto xfunctorview<F, CT>::end() noexcept -> iterator
+    {
+        return iterator(m_e.end(), &m_functor);
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the expression.
+     */
+    template <class F, class CT>
+    inline auto xfunctorview<F, CT>::begin() const noexcept -> const_iterator
+    {
+        return const_iterator(m_e.cbegin(), &m_functor);
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element
+     * of the expression.
+     */
+    template <class F, class CT>
+    inline auto xfunctorview<F, CT>::end() const noexcept -> const_iterator
+    {
+        return const_iterator(m_e.cend(), &m_functor);
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the expression.
+     */
+    template <class F, class CT>
+    inline auto xfunctorview<F, CT>::cbegin() const noexcept -> const_iterator
+    {
+        return const_iterator(m_e.cbegin(), &m_functor);
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element
+     * of the expression.
+     */
+    template <class F, class CT>
+    inline auto xfunctorview<F, CT>::cend() const noexcept -> const_iterator
+    {
+        return const_iterator(m_e.cend(), &m_functor);
+    }
+    //@}
+
+    /**
+     * @name Broadcast iterators
+     */
+    //@{
+    /**
+     * Returns an iterator to the first element of the expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class F, class CT>
+    template <layout_type L>
+    inline auto xfunctorview<F, CT>::xbegin() noexcept -> broadcast_iterator<L>
+    {
+        return broadcast_iterator<L>(m_e.template xbegin<L>(), &m_functor);
+    }
+
+    /**
+     * Returns an iterator to the element following the last element
+     * of the expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class F, class CT>
+    template <layout_type L>
+    inline auto xfunctorview<F, CT>::xend() noexcept -> broadcast_iterator<L>
+    {
+        return broadcast_iterator<L>(m_e.template xend<L>(), &m_functor);
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class F, class CT>
+    template <layout_type L>
+    inline auto xfunctorview<F, CT>::xbegin() const noexcept -> const_broadcast_iterator<L>
+    {
+        return cxbegin<L>();
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element
+     * of the expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class F, class CT>
+    template <layout_type L>
+    inline auto xfunctorview<F, CT>::xend() const noexcept -> const_broadcast_iterator<L>
+    {
+        return cxend<L>();
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class F, class CT>
+    template <layout_type L>
+    inline auto xfunctorview<F, CT>::cxbegin() const noexcept -> const_broadcast_iterator<L>
+    {
+        return const_broadcast_iterator<L>(m_e.template cxbegin<L>(), &m_functor);
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element
+     * of the expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class F, class CT>
+    template <layout_type L>
+    inline auto xfunctorview<F, CT>::cxend() const noexcept -> const_broadcast_iterator<L>
+    {
+        return const_broadcast_iterator<L>(m_e.template cxend<L>(), &m_functor);
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the expression. The
+     * iteration is broadcasted to the specified shape.
+     * @param shape the shape used for broadcasting
+     * @tparam S type of the \c shape parameter.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class F, class CT>
+    template <class S, layout_type L>
+    inline auto xfunctorview<F, CT>::xbegin(const S& shape) noexcept -> shaped_xiterator<S, L>
+    {
+        return shaped_xiterator<S, L>(m_e.template xbegin<S, L>(shape), &m_functor);
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element of the
+     * expression. The iteration is broadcasted to the specified shape.
+     * @param shape the shape used for broadcasting
+     * @tparam S type of the \c shape parameter.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class F, class CT>
+    template <class S, layout_type L>
+    inline auto xfunctorview<F, CT>::xend(const S& shape) noexcept -> shaped_xiterator<S, L>
+    {
+        return shaped_xiterator<S, L>(m_e.template xend<S, L>(shape), &m_functor);
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the expression. The
+     * iteration is broadcasted to the specified shape.
+     * @param shape the shape used for broadcasting
+     * @tparam S type of the \c shape parameter.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class F, class CT>
+    template <class S, layout_type L>
+    inline auto xfunctorview<F, CT>::xbegin(const S& shape) const noexcept -> const_shaped_xiterator<S, L>
+    {
+        return cxbegin<S, L>(shape);
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element of the
+     * expression. The iteration is broadcasted to the specified shape.
+     * @param shape the shape used for broadcasting
+     * @tparam S type of the \c shape parameter.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class F, class CT>
+    template <class S, layout_type L>
+    inline auto xfunctorview<F, CT>::xend(const S& shape) const noexcept -> const_shaped_xiterator<S, L>
+    {
+        return cxend<S, L>(shape);
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the expression. The
+     * iteration is broadcasted to the specified shape.
+     * @param shape the shape used for broadcasting
+     * @tparam S type of the \c shape parameter.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class F, class CT>
+    template <class S, layout_type L>
+    inline auto xfunctorview<F, CT>::cxbegin(const S& shape) const noexcept -> const_shaped_xiterator<S, L>
+    {
+        return const_shaped_xiterator<S, L>(m_e.template cxbegin<S, L>(shape), &m_functor);
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element of the
+     * expression. The iteration is broadcasted to the specified shape.
+     * @param shape the shape used for broadcasting
+     * @tparam S type of the \c shape parameter.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class F, class CT>
+    template <class S, layout_type L>
+    inline auto xfunctorview<F, CT>::cxend(const S& shape) const noexcept -> const_shaped_xiterator<S, L>
+    {
+        return const_shaped_xiterator<S, L>(m_e.template cxend<S, L>(shape), &m_functor);
+    }
+    //@}
+
+    /**
+     * @name Reverse iterators
+     */
+    //@{
+    /**
+     * Returns an iterator to the first element of the reversed expression.
+     */
+    template <class F, class CT>
+    inline auto xfunctorview<F, CT>::rbegin() noexcept -> reverse_iterator
+    {
+        return reverse_iterator(m_e.rbegin(), &m_functor);
+    }
+
+    /**
+     * Returns an iterator to the element following the last element
+     * of the reversed expression.
+     */
+    template <class F, class CT>
+    inline auto xfunctorview<F, CT>::rend() noexcept -> reverse_iterator
+    {
+        return reverse_iterator(m_e.rend(), &m_functor);
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the reversed expression.
+     */
+    template <class F, class CT>
+    inline auto xfunctorview<F, CT>::rbegin() const noexcept -> const_reverse_iterator
+    {
+        return crbegin();
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element
+     * of the reversed expression.
+     */
+    template <class F, class CT>
+    inline auto xfunctorview<F, CT>::rend() const noexcept -> const_reverse_iterator
+    {
+        return crend();
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the reversed expression.
+     */
+    template <class F, class CT>
+    inline auto xfunctorview<F, CT>::crbegin() const noexcept -> const_reverse_iterator
+    {
+        return const_reverse_iterator(m_e.crbegin(), &m_functor);
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element
+     * of the reversed expression.
+     */
+    template <class F, class CT>
+    inline auto xfunctorview<F, CT>::crend() const noexcept -> const_reverse_iterator
+    {
+        return const_reverse_iterator(m_e.crend(), &m_functor);
+    }
+    //@}
+
+    /**
+     * @name Reverse broadcast iterators
+     */
+    //@{
+    /**
+     * Returns an iterator to the first element of the reversed expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class F, class CT>
+    template <layout_type L>
+    inline auto xfunctorview<F, CT>::xrbegin() noexcept -> reverse_broadcast_iterator<L>
+    {
+        return reverse_broadcast_iterator<L>(m_e.template xrbegin<L>(), &m_functor);
+    }
+
+    /**
+     * Returns an iterator to the element following the last element
+     * of the reversed expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class F, class CT>
+    template <layout_type L>
+    inline auto xfunctorview<F, CT>::xrend() noexcept -> reverse_broadcast_iterator<L>
+    {
+        return reverse_broadcast_iterator<L>(m_e.template xrend<L>(), &m_functor);
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the reversed expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class F, class CT>
+    template <layout_type L>
+    inline auto xfunctorview<F, CT>::xrbegin() const noexcept -> const_reverse_broadcast_iterator<L>
+    {
+        return cxrbegin<L>();
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element
+     * of the reversed expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class F, class CT>
+    template <layout_type L>
+    inline auto xfunctorview<F, CT>::xrend() const noexcept -> const_reverse_broadcast_iterator<L>
+    {
+        return cxrend<L>();
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the reversed expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class F, class CT>
+    template <layout_type L>
+    inline auto xfunctorview<F, CT>::cxrbegin() const noexcept -> const_reverse_broadcast_iterator<L>
+    {
+        return const_reverse_broadcast_iterator<L>(m_e.template cxrbegin<L>(), &m_functor);
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element
+     * of the reversed expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class F, class CT>
+    template <layout_type L>
+    inline auto xfunctorview<F, CT>::cxrend() const noexcept -> const_reverse_broadcast_iterator<L>
+    {
+        return const_reverse_broadcast_iterator<L>(m_e.template cxrend<L>(), &m_functor);
+    }
+
+    /**
+     * Returns an iterator to the first element of the expression. The
+     * iteration is broadcasted to the specified shape.
+     * @param shape the shape used for broadcasting
+     * @tparam S type of the \c shape parameter.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class F, class CT>
+    template <class S, layout_type L>
+    inline auto xfunctorview<F, CT>::xrbegin(const S& shape) noexcept -> reverse_shaped_xiterator<S, L>
+    {
+        return reverse_shaped_xiterator<S, L>(m_e.template xrbegin<S, L>(shape), &m_functor);
+    }
+
+    /**
+     * Returns an iterator to the element following the last element of the
+     * reversed expression. The iteration is broadcasted to the specified shape.
+     * @param shape the shape used for broadcasting
+     * @tparam S type of the \c shape parameter.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class F, class CT>
+    template <class S, layout_type L>
+    inline auto xfunctorview<F, CT>::xrend(const S& shape) noexcept -> reverse_shaped_xiterator<S, L>
+    {
+        return reverse_shaped_xiterator<S, L>(m_e.template xrend<S, L>(shape), &m_functor);
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the reversed expression.
+     * The iteration is broadcasted to the specified shape.
+     * @param shape the shape used for broadcasting
+     * @tparam S type of the \c shape parameter.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class F, class CT>
+    template <class S, layout_type L>
+    inline auto xfunctorview<F, CT>::xrbegin(const S& shape) const noexcept -> const_reverse_shaped_xiterator<S, L>
+    {
+        return cxrbegin<S, L>(shape);
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element
+     * of the reversed expression.
+     * @param shape the shape used for broadcasting
+     * @tparam S type of the \c shape parameter.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class F, class CT>
+    template <class S, layout_type L>
+    inline auto xfunctorview<F, CT>::xrend(const S& shape) const noexcept -> const_reverse_shaped_xiterator<S, L>
+    {
+        return cxrend<S, L>();
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the reversed expression.
+     * The iteration is broadcasted to the specified shape.
+     * @param shape the shape used for broadcasting
+     * @tparam S type of the \c shape parameter.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class F, class CT>
+    template <class S, layout_type L>
+    inline auto xfunctorview<F, CT>::cxrbegin(const S& shape) const noexcept -> const_reverse_shaped_xiterator<S, L>
+    {
+        return const_reverse_shaped_xiterator<S, L>(m_e.template cxrbegin<S, L>(), &m_functor);
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element
+     * of the reversed expression.
+     * @param shape the shape used for broadcasting
+     * @tparam S type of the \c shape parameter.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class F, class CT>
+    template <class S, layout_type L>
+    inline auto xfunctorview<F, CT>::cxrend(const S& shape) const noexcept -> const_reverse_shaped_xiterator<S, L>
+    {
+        return const_reverse_shaped_xiterator<S, L>(m_e.template cxrend<S, L>(shape), &m_functor);
+    }
+    //@}
+
+    /***************
+     * stepper api *
+     ***************/
+
+    template <class F, class CT>
+    template <class S>
+    inline auto xfunctorview<F, CT>::stepper_begin(const S& shape) noexcept -> stepper
+    {
+        return stepper(m_e.stepper_begin(shape), &m_functor);
+    }
+
+    template <class F, class CT>
+    template <class S>
+    inline auto xfunctorview<F, CT>::stepper_end(const S& shape) noexcept -> stepper
+    {
+        return stepper(m_e.stepper_end(shape), &m_functor);
+    }
+
+    template <class F, class CT>
+    template <class S>
+    inline auto xfunctorview<F, CT>::stepper_begin(const S& shape) const noexcept -> const_stepper
+    {
+        const xexpression_type& const_m_e = m_e;
+        return const_stepper(const_m_e.stepper_begin(shape), &m_functor);
+    }
+
+    template <class F, class CT>
+    template <class S>
+    inline auto xfunctorview<F, CT>::stepper_end(const S& shape) const noexcept -> const_stepper
+    {
+        const xexpression_type& const_m_e = m_e;
+        return const_stepper(const_m_e.stepper_end(shape), &m_functor);
+    }
+
+    /************************************
+     * xfunctor_iterator implementation *
+     ************************************/
+
+    template <class F, class IT>
+    xfunctor_iterator<F, IT>::xfunctor_iterator(const IT& it, const functor_type* pf)
+        : m_it(it), p_functor(pf)
+    {
+    }
+
+    template <class F, class IT>
+    auto xfunctor_iterator<F, IT>::operator++() -> self_type&
+    {
+        ++m_it;
+        return *this;
+    }
+
+    template <class F, class IT>
+    auto xfunctor_iterator<F, IT>::operator++(int) -> self_type
+    {
+        self_type tmp(*this);
+        ++m_it;
+        return tmp;
+    }
+
+    template <class F, class IT>
+    auto xfunctor_iterator<F, IT>::operator*() const -> reference
+    {
+        return (*p_functor)(*m_it);
+    }
+
+    template <class F, class IT>
+    auto xfunctor_iterator<F, IT>::operator->() const -> pointer
+    {
+        return &((*p_functor)(*m_it));
+    }
+
+    template <class F, class IT>
+    auto xfunctor_iterator<F, IT>::equal(const xfunctor_iterator& rhs) const -> bool
+    {
+        return m_it == rhs.m_it;
+    }
+
+    template <class F, class IT>
+    bool operator==(const xfunctor_iterator<F, IT>& lhs,
+                    const xfunctor_iterator<F, IT>& rhs)
+    {
+        return lhs.equal(rhs);
+    }
+
+    template <class F, class IT>
+    bool operator!=(const xfunctor_iterator<F, IT>& lhs,
+                    const xfunctor_iterator<F, IT>& rhs)
+    {
+        return !lhs.equal(rhs);
+    }
+
+    /***********************************
+     * xfunctor_stepper implementation *
+     ***********************************/
+
+    template <class F, class ST>
+    xfunctor_stepper<F, ST>::xfunctor_stepper(const ST& stepper, const functor_type* pf)
+        : m_stepper(stepper), p_functor(pf)
+    {
+    }
+
+    template <class F, class ST>
+    auto xfunctor_stepper<F, ST>::operator*() const -> reference
+    {
+        return (*p_functor)(*m_stepper);
+    }
+
+    template <class F, class ST>
+    void xfunctor_stepper<F, ST>::step(size_type dim, size_type n)
+    {
+        m_stepper.step(dim, n);
+    }
+
+    template <class F, class ST>
+    void xfunctor_stepper<F, ST>::step_back(size_type dim, size_type n)
+    {
+        m_stepper.step_back(dim, n);
+    }
+
+    template <class F, class ST>
+    void xfunctor_stepper<F, ST>::reset(size_type dim)
+    {
+        m_stepper.reset(dim);
+    }
+
+    template <class F, class ST>
+    void xfunctor_stepper<F, ST>::reset_back(size_type dim)
+    {
+        m_stepper.reset_back(dim);
+    }
+
+    template <class F, class ST>
+    void xfunctor_stepper<F, ST>::to_begin()
+    {
+        m_stepper.to_begin();
+    }
+
+    template <class F, class ST>
+    void xfunctor_stepper<F, ST>::to_end()
+    {
+        m_stepper.to_end();
+    }
+
+    template <class F, class ST>
+    auto xfunctor_stepper<F, ST>::equal(const xfunctor_stepper& rhs) const -> bool
+    {
+        return m_stepper == rhs.m_stepper;
+    }
+
+    template <class F, class ST>
+    bool operator==(const xfunctor_stepper<F, ST>& lhs,
+                    const xfunctor_stepper<F, ST>& rhs)
+    {
+        return lhs.equal(rhs);
+    }
+
+    template <class F, class ST>
+    bool operator!=(const xfunctor_stepper<F, ST>& lhs,
+                    const xfunctor_stepper<F, ST>& rhs)
+    {
+        return !lhs.equal(rhs);
+    }
+}
+#endif

--- a/inst/include/xtensor/xgenerator.hpp
+++ b/inst/include/xtensor/xgenerator.hpp
@@ -1,0 +1,299 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XGENERATOR_HPP
+#define XGENERATOR_HPP
+
+#include <algorithm>
+#include <cstddef>
+#include <numeric>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+#include "xexpression.hpp"
+#include "xiterable.hpp"
+#include "xstrides.hpp"
+#include "xutils.hpp"
+
+namespace xt
+{
+
+    /**************
+     * xgenerator *
+     **************/
+
+    template <class F, class R, class S>
+    class xgenerator;
+
+    template <class C, class R, class S>
+    struct xiterable_inner_types<xgenerator<C, R, S>>
+    {
+        using inner_shape_type = S;
+        using const_stepper = xindexed_stepper<xgenerator<C, R, S>>;
+        using stepper = const_stepper;
+        using const_iterator = xiterator<const_stepper, inner_shape_type*, DEFAULT_LAYOUT>;
+        using iterator = const_iterator;
+        using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+        using reverse_iterator = std::reverse_iterator<iterator>;
+    };
+
+    /**
+     * @class xgenerator
+     * @brief Multidimensional function operating on indices.
+     *
+     * The xgenerator class implements a multidimensional function,
+     * generating a value from the supplied indices.
+     *
+     * @tparam F the function type
+     * @tparam R the return type of the function
+     * @tparam S the shape type of the generator
+     */
+    template <class F, class R, class S>
+    class xgenerator : public xexpression<xgenerator<F, R, S>>,
+                       public xexpression_const_iterable<xgenerator<F, R, S>>
+    {
+
+    public:
+
+        using self_type = xgenerator<F, R, S>;
+        using functor_type = typename std::remove_reference<F>::type;
+
+        using value_type = R;
+        using reference = value_type;
+        using const_reference = value_type;
+        using pointer = value_type*;
+        using const_pointer = const value_type*;
+        using size_type = std::size_t;
+        using difference_type = std::ptrdiff_t;
+
+        using iterable_base = xexpression_const_iterable<self_type>;
+        using inner_shape_type = typename iterable_base::inner_shape_type;
+        using shape_type = inner_shape_type;
+        using strides_type = S;
+
+        using stepper = typename iterable_base::stepper;
+        using const_stepper = typename iterable_base::const_stepper;
+
+        static constexpr layout_type static_layout = layout_type::any;
+        static constexpr bool contiguous_layout = true;
+        
+        template <class Func>
+        xgenerator(Func&& f, const S& shape) noexcept;
+
+        size_type size() const noexcept;
+        size_type dimension() const noexcept;
+        const inner_shape_type& shape() const noexcept;
+        layout_type layout() const noexcept;
+
+        template <class... Args>
+        const_reference operator()(Args... args) const;
+        const_reference operator[](const xindex& index) const;
+        const_reference operator[](size_type i) const;
+
+        template <class It>
+        const_reference element(It first, It last) const;
+
+        template <class O>
+        bool broadcast_shape(O& shape) const;
+
+        template <class O>
+        bool is_trivial_broadcast(const O& /*strides*/) const noexcept;
+
+        template <class O>
+        const_stepper stepper_begin(const O& shape) const noexcept;
+        template <class O>
+        const_stepper stepper_end(const O& shape) const noexcept;
+
+    private:
+
+        functor_type m_f;
+        inner_shape_type m_shape;
+    };
+
+    /*****************************
+     * xgenerator implementation *
+     *****************************/
+
+    /**
+     * @name Constructor
+     */
+    //@{
+    /**
+     * Constructs an xgenerator applying the specified function over the 
+     * given shape.
+     * @param f the function to apply
+     * @param shape the shape of the xgenerator
+     */
+    template <class F, class R, class S>
+    template <class Func>
+    inline xgenerator<F, R, S>::xgenerator(Func&& f, const S& shape) noexcept
+        : m_f(std::forward<Func>(f)), m_shape(shape)
+    {
+    }
+    //@}
+
+    /**
+     * @name Size and shape
+     */
+    //@{
+    /**
+     * Returns the size of the expression.
+     */
+    template <class F, class R, class S>
+    inline auto xgenerator<F, R, S>::size() const noexcept -> size_type
+    {
+        return compute_size(shape());
+    }
+
+    /**
+     * Returns the number of dimensions of the function.
+     */
+    template <class F, class R, class S>
+    inline auto xgenerator<F, R, S>::dimension() const noexcept -> size_type
+    {
+        return m_shape.size();
+    }
+
+    /**
+     * Returns the shape of the xgenerator.
+     */
+    template <class F, class R, class S>
+    inline auto xgenerator<F, R, S>::shape() const noexcept -> const inner_shape_type&
+    {
+        return m_shape;
+    }
+
+    template <class F, class R, class S>
+    inline layout_type xgenerator<F, R, S>::layout() const noexcept
+    {
+        return static_layout;
+    }
+
+    //@}
+
+    /**
+     * @name Data
+     */
+    /**
+     * Returns the evaluated element at the specified position in the function.
+     * @param args a list of indices specifying the position in the function. Indices
+     * must be unsigned integers, the number of indices should be equal or greater than
+     * the number of dimensions of the function.
+     */
+    template <class F, class R, class S>
+    template <class... Args>
+    inline auto xgenerator<F, R, S>::operator()(Args... args) const -> const_reference
+    {
+        XTENSOR_ASSERT(check_index(shape(), args...));
+        return m_f(args...);
+    }
+
+    template <class F, class R, class S>
+    inline auto xgenerator<F, R, S>::operator[](const xindex& index) const -> const_reference
+    {
+        return element(index.begin(), index.end());
+    }
+
+    template <class F, class R, class S>
+    inline auto xgenerator<F, R, S>::operator[](size_type i) const -> const_reference
+    {
+        return operator()(i);
+    }
+
+    /**
+     * Returns a constant reference to the element at the specified position in the function.
+     * @param first iterator starting the sequence of indices
+     * @param last iterator ending the sequence of indices
+     * The number of indices in the squence should be equal to or greater
+     * than the number of dimensions of the container.
+     */
+    template <class F, class R, class S>
+    template <class It>
+    inline auto xgenerator<F, R, S>::element(It first, It last) const -> const_reference
+    {
+        XTENSOR_ASSERT(check_element_index(shape(), first, last));
+        return m_f.element(first, last);
+    }
+    //@}
+
+    /**
+     * @name Broadcasting
+     */
+    //@{
+    /**
+     * Broadcast the shape of the function to the specified parameter.
+     * @param shape the result shape
+     * @return a boolean indicating whether the broadcasting is trivial
+     */
+    template <class F, class R, class S>
+    template <class O>
+    inline bool xgenerator<F, R, S>::broadcast_shape(O& shape) const
+    {
+        return xt::broadcast_shape(m_shape, shape);
+    }
+
+    /**
+     * Compares the specified strides with those of the container to see whether
+     * the broadcasting is trivial.
+     * @return a boolean indicating whether the broadcasting is trivial
+     */
+    template <class F, class R, class S>
+    template <class O>
+    inline bool xgenerator<F, R, S>::is_trivial_broadcast(const O& /*strides*/) const noexcept
+    {
+        return false;
+    }
+    //@}
+
+    template <class F, class R, class S>
+    template <class O>
+    inline auto xgenerator<F, R, S>::stepper_begin(const O& shape) const noexcept -> const_stepper
+    {
+        size_type offset = shape.size() - dimension();
+        return const_stepper(this, offset);
+    }
+
+    template <class F, class R, class S>
+    template <class O>
+    inline auto xgenerator<F, R, S>::stepper_end(const O& shape) const noexcept -> const_stepper
+    {
+        size_type offset = shape.size() - dimension();
+        return const_stepper(this, offset, true);
+    }
+
+    namespace detail
+    {
+#ifdef X_OLD_CLANG
+        template <class Functor, class I>
+        inline auto make_xgenerator(Functor&& f, std::initializer_list<I> shape) noexcept
+        {
+            using shape_type = std::vector<std::size_t>;
+            using type = xgenerator<Functor, typename Functor::value_type, shape_type>;
+            return type(std::forward<Functor>(f), forward_sequence<shape_type>(shape));
+        }
+#else
+        template <class Functor, class I, std::size_t L>
+        inline auto make_xgenerator(Functor&& f, const I (&shape)[L]) noexcept
+        {
+            using shape_type = std::array<std::size_t, L>;
+            using type = xgenerator<Functor, typename Functor::value_type, shape_type>;
+            return type(std::forward<Functor>(f), forward_sequence<shape_type>(shape));
+        }
+#endif
+
+        template <class Functor, class S>
+        inline auto make_xgenerator(Functor&& f, S&& shape) noexcept
+        {
+            using type = xgenerator<Functor, typename Functor::value_type, std::decay_t<S>>;
+            return type(std::forward<Functor>(f), std::forward<S>(shape));
+        }
+    }
+}
+
+#endif

--- a/inst/include/xtensor/xindexview.hpp
+++ b/inst/include/xtensor/xindexview.hpp
@@ -1,0 +1,647 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XINDEXVIEW_HPP
+#define XINDEXVIEW_HPP
+
+#include <algorithm>
+#include <cstddef>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+#include "xexpression.hpp"
+#include "xiterable.hpp"
+#include "xstrides.hpp"
+#include "xutils.hpp"
+
+namespace xt
+{
+
+    template <class CT, class I>
+    class xindexview;
+
+    template <class CT, class I>
+    struct xcontainer_inner_types<xindexview<CT, I>>
+    {
+        using xexpression_type = std::decay_t<CT>;
+        using temporary_type = xarray<typename xexpression_type::value_type, xexpression_type::static_layout>;
+    };
+
+    template <class CT, class I>
+    struct xiterable_inner_types<xindexview<CT, I>>
+    {
+        using inner_shape_type = std::array<std::size_t, 1>;
+        using const_stepper = xindexed_stepper<xindexview<CT, I>>;
+        using stepper = xindexed_stepper<xindexview<CT, I>, false>;
+        using const_iterator = xiterator<const_stepper, inner_shape_type*, DEFAULT_LAYOUT>;
+        using iterator = xiterator<stepper, inner_shape_type*, DEFAULT_LAYOUT>;
+        using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+        using reverse_iterator = std::reverse_iterator<iterator>;
+    };
+
+    /**************
+     * xindexview *
+     **************/
+
+    /**
+     * @class xindexview
+     * @brief View of an xexpression from vector of indices.
+     *
+     * The xindexview class implements a flat (1D) view into a multidimensional
+     * xexpression yielding the values at the indices of the index array.
+     * xindexview is not meant to be used directly, but only with the \ref index_view
+     * and \ref filter helper functions.
+     *
+     * @tparam CT the closure type of the \ref xexpression type underlying this view
+     * @tparam I the index array type of the view
+     *
+     * @sa index_view, filter
+     */
+    template <class CT, class I>
+    class xindexview : public xview_semantic<xindexview<CT, I>>,
+                       public xexpression_iterable<xindexview<CT, I>>
+    {
+
+    public:
+
+        using self_type = xindexview<CT, I>;
+        using xexpression_type = std::decay_t<CT>;
+        using semantic_base = xview_semantic<self_type>;
+
+        using value_type = typename xexpression_type::value_type;
+        using reference = typename xexpression_type::reference;
+        using const_reference = typename xexpression_type::const_reference;
+        using pointer = typename xexpression_type::pointer;
+        using const_pointer = typename xexpression_type::const_pointer;
+        using size_type = typename xexpression_type::size_type;
+        using difference_type = typename xexpression_type::difference_type;
+
+        using iterable_base = xexpression_iterable<self_type>;
+        using inner_shape_type = typename iterable_base::inner_shape_type;
+        using shape_type = inner_shape_type;
+        using strides_type = shape_type;
+
+        using indices_type = I;
+
+        using stepper = typename iterable_base::stepper;
+        using const_stepper = typename iterable_base::const_stepper;
+
+        using temporary_type = typename xcontainer_inner_types<self_type>::temporary_type;
+        using base_index_type = xindex_type_t<shape_type>;
+
+        static constexpr layout_type static_layout = layout_type::dynamic;
+        static constexpr bool contiguous_layout = false;
+
+        template <class I2>
+        xindexview(CT e, I2&& indices) noexcept;
+
+        template <class E>
+        self_type& operator=(const xexpression<E>& e);
+
+        template <class E>
+        disable_xexpression<E, self_type>& operator=(const E& e);
+
+        size_type size() const noexcept;
+        size_type dimension() const noexcept;
+        const inner_shape_type& shape() const noexcept;
+        layout_type layout() const noexcept;
+
+        reference operator()();
+        template <class... Args>
+        reference operator()(std::size_t idx, Args... /*args*/);
+        reference operator[](const xindex& index);
+        reference operator[](size_type i);
+
+        template <class It>
+        reference element(It first, It last);
+
+        const_reference operator()() const;
+        template <class... Args>
+        const_reference operator()(std::size_t idx, Args... /*args*/) const;
+        const_reference operator[](const xindex& index) const;
+        const_reference operator[](size_type i) const;
+
+        template <class It>
+        const_reference element(It first, It last) const;
+
+        template <class O>
+        bool broadcast_shape(O& shape) const;
+
+        template <class O>
+        bool is_trivial_broadcast(const O& /*strides*/) const noexcept;
+
+        template <class ST>
+        stepper stepper_begin(const ST& shape);
+        template <class ST>
+        stepper stepper_end(const ST& shape);
+
+        template <class ST>
+        const_stepper stepper_begin(const ST& shape) const;
+        template <class ST>
+        const_stepper stepper_end(const ST& shape) const;
+
+    private:
+
+        CT m_e;
+        const indices_type m_indices;
+        const inner_shape_type m_shape;
+
+        void assign_temporary_impl(temporary_type& tmp);
+
+        friend class xview_semantic<xindexview<CT, I>>;
+    };
+
+    /***************
+     * xfiltration *
+     ***************/
+
+    /**
+     * @class xfiltration
+     * @brief Filter of a xexpression for fast scalar assign.
+     *
+     * The xfiltration class implements a lazy filtration of a multidimentional
+     * \ref xexpression, optimized for scalar and computed scalar assignments.
+     * Actually, the \ref xfiltration class IS NOT an \ref xexpression and the
+     * scalar and computed scalar assignments are the only method it provides.
+     * The filtering condition is not evaluated until the filtration is assigned.
+     *
+     * xfiltration is not meant to be used directly, but only with the \ref filtration
+     * helper function.
+     *
+     * @tparam ECT the closure type of the \ref xexpression type underlying this filtration
+     * @tparam CCR the closure type of the filtering \ref xexpression type
+     *
+     * @sa filtration
+     */
+    template <class ECT, class CCT>
+    class xfiltration
+    {
+
+    public:
+
+        using self_type = xfiltration<ECT, CCT>;
+        using xexpression_type = std::decay_t<ECT>;
+        using const_reference = typename xexpression_type::const_reference;
+
+        xfiltration(ECT e, CCT condition);
+
+        template <class E>
+        disable_xexpression<E, self_type&> operator=(const E&);
+
+        template <class E>
+        disable_xexpression<E, self_type&> operator+=(const E&);
+
+        template <class E>
+        disable_xexpression<E, self_type&> operator-=(const E&);
+
+        template <class E>
+        disable_xexpression<E, self_type&> operator*=(const E&);
+
+        template <class E>
+        disable_xexpression<E, self_type&> operator/=(const E&);
+
+    private:
+
+        template <class F>
+        self_type& apply(F&& func);
+
+        ECT m_e;
+        CCT m_condition;
+    };
+
+    /*****************************
+     * xindexview implementation *
+     *****************************/
+
+    /**
+     * @name Constructor
+     */
+    //@{
+    /**
+     * Constructs an xindexview, selecting the indices specified by \a indices.
+     * The resulting xexpression has a 1D shape with a length of n for n indices.
+     * 
+     * @param e the underlying xexpression for this view
+     * @param indices the indices to select
+     */
+    template <class CT, class I>
+    template <class I2>
+    inline xindexview<CT, I>::xindexview(CT e, I2&& indices) noexcept
+        : m_e(e), m_indices(std::forward<I2>(indices)), m_shape({m_indices.size()})
+    {
+    }
+    //@}
+
+    /**
+     * @name Extended copy semantic
+     */
+    //@{
+    /**
+     * The extended assignment operator.
+     */
+    template <class CT, class I>
+    template <class E>
+    inline auto xindexview<CT, I>::operator=(const xexpression<E>& e) -> self_type&
+    {
+        return semantic_base::operator=(e);
+    }
+    //@}
+
+    template <class CT, class I>
+    template <class E>
+    inline auto xindexview<CT, I>::operator=(const E& e) -> disable_xexpression<E, self_type>&
+    {
+        std::fill(this->begin(), this->end(), e);
+        return *this;
+    }
+
+    template <class CT, class I>
+    inline void xindexview<CT, I>::assign_temporary_impl(temporary_type& tmp)
+    {
+        std::copy(tmp.cbegin(), tmp.cend(), this->xbegin());
+    }
+
+    /**
+     * @name Size and shape
+     */
+    //@{
+    /**
+     * Returns the size of the xindexview.
+     */
+    template <class CT, class I>
+    inline auto xindexview<CT, I>::size() const noexcept -> size_type
+    {
+        return compute_size(shape());
+    }
+
+    /**
+     * Returns the number of dimensions of the xindexview.
+     */
+    template <class CT, class I>
+    inline auto xindexview<CT, I>::dimension() const noexcept -> size_type
+    {
+        return 1;
+    }
+
+    /**
+     * Returns the shape of the xindexview.
+     */
+    template <class CT, class I>
+    inline auto xindexview<CT, I>::shape() const noexcept -> const inner_shape_type&
+    {
+        return m_shape;
+    }
+
+    template <class CT, class I>
+    inline layout_type xindexview<CT, I>::layout() const noexcept
+    {
+        return static_layout;
+    }
+
+    //@}
+
+    /**
+     * @name Data
+     */
+    template <class CT, class I>
+    inline auto xindexview<CT, I>::operator()() -> reference
+    {
+        return m_e();
+    }
+
+    template <class CT, class I>
+    inline auto xindexview<CT, I>::operator()() const -> const_reference
+    {
+        return m_e();
+    }
+
+    template <class CT, class I>
+    template <class... Args>
+    inline auto xindexview<CT, I>::operator()(std::size_t idx, Args... /*args*/) -> reference
+    {
+        return m_e[m_indices[idx]];
+    }
+
+    /**
+     * Returns the element at the specified position in the xindexview. 
+     * 
+     * @param idx the position in the view
+     */
+    template <class CT, class I>
+    template <class... Args>
+    inline auto xindexview<CT, I>::operator()(std::size_t idx, Args... /*args*/) const -> const_reference
+    {
+        return m_e[m_indices[idx]];
+    }
+
+    template <class CT, class I>
+    inline auto xindexview<CT, I>::operator[](const xindex& index) -> reference
+    {
+        return m_e[m_indices[index[0]]];
+    }
+
+    template <class CT, class I>
+    inline auto xindexview<CT, I>::operator[](size_type i) -> reference
+    {
+        return operator()(i);
+    }
+
+    template <class CT, class I>
+    inline auto xindexview<CT, I>::operator[](const xindex& index) const -> const_reference
+    {
+        return m_e[m_indices[index[0]]];
+    }
+
+    template <class CT, class I>
+    inline auto xindexview<CT, I>::operator[](size_type i) const -> const_reference
+    {
+        return operator()(i);
+    }
+
+    /**
+     * Returns a reference to the element at the specified position in the xindexview.
+     * @param first iterator starting the sequence of indices
+     * The number of indices in the squence should be equal to or greater 1.
+     */
+    template <class CT, class I>
+    template <class It>
+    inline auto xindexview<CT, I>::element(It first, It /*last*/) -> reference
+    {
+        return m_e[m_indices[(*first)]];
+    }
+
+    template <class CT, class I>
+    template <class It>
+    inline auto xindexview<CT, I>::element(It first, It /*last*/) const -> const_reference
+    {
+        return m_e[m_indices[(*first)]];
+    }
+    //@}
+
+    /**
+     * @name Broadcasting
+     */
+    //@{
+    /**
+     * Broadcast the shape of the xindexview to the specified parameter.
+     * @param shape the result shape
+     * @return a boolean indicating whether the broadcasting is trivial
+     */
+    template <class CT, class I>
+    template <class O>
+    inline bool xindexview<CT, I>::broadcast_shape(O& shape) const
+    {
+        return xt::broadcast_shape(m_shape, shape);
+    }
+
+    /**
+     * Compares the specified strides with those of the container to see whether
+     * the broadcasting is trivial.
+     * @return a boolean indicating whether the broadcasting is trivial
+     */
+    template <class CT, class I>
+    template <class O>
+    inline bool xindexview<CT, I>::is_trivial_broadcast(const O& /*strides*/) const noexcept
+    {
+        return false;
+    }
+    //@}
+
+    /***************
+     * stepper api *
+     ***************/
+
+    template <class CT, class I>
+    template <class ST>
+    inline auto xindexview<CT, I>::stepper_begin(const ST& shape) -> stepper
+    {
+        size_type offset = shape.size() - dimension();
+        return stepper(this, offset);
+    }
+
+    template <class CT, class I>
+    template <class ST>
+    inline auto xindexview<CT, I>::stepper_end(const ST& shape) -> stepper
+    {
+        size_type offset = shape.size() - dimension();
+        return stepper(this, offset, true);
+    }
+
+    template <class CT, class I>
+    template <class ST>
+    inline auto xindexview<CT, I>::stepper_begin(const ST& shape) const -> const_stepper
+    {
+        size_type offset = shape.size() - dimension();
+        return const_stepper(this, offset);
+    }
+
+    template <class CT, class I>
+    template <class ST>
+    inline auto xindexview<CT, I>::stepper_end(const ST& shape) const -> const_stepper
+    {
+        size_type offset = shape.size() - dimension();
+        return const_stepper(this, offset, true);
+    }
+
+    /******************************
+     * xfiltration implementation *
+     ******************************/
+
+    /**
+     * @name Constructor
+     */
+    //@{
+    /**
+     * Constructs a xfiltration on the given expression \c e, selecting
+     * the elements matching the specified \c condition. 
+     *
+     * @param e the \ref xexpression to filter.
+     * @param condition the filtering \ref xexpression to apply.
+     */
+    template <class ECT, class CCT>
+    inline xfiltration<ECT, CCT>::xfiltration(ECT e, CCT condition)
+        : m_e(e), m_condition(condition)
+    {
+    }
+    //@}
+
+    /**
+     * @name Extended copy semantic
+     */
+    //@{
+    /**
+     * Assigns the scalar \c e to \c *this.
+     * @param e the scalar to assign.
+     * @return a reference to \ *this.
+     */
+    template <class ECT, class CCT>
+    template <class E>
+    inline auto xfiltration<ECT, CCT>::operator=(const E& e) -> disable_xexpression<E, self_type&>
+    {
+        return apply([this, &e](const_reference v, bool cond) { return cond ? e : v; });
+    }
+    //@}
+
+    /**
+     * @name Computed assignement
+     */
+    //@{
+    /**
+     * Adds the scalar \c e to \c *this.
+     * @param e the scalar to add.
+     * @return a reference to \c *this.
+     */
+    template <class ECT, class CCT>
+    template <class E>
+    inline auto xfiltration<ECT, CCT>::operator+=(const E& e) -> disable_xexpression<E, self_type&>
+    {
+        return apply([this, &e](const_reference v, bool cond) { return cond ? v + e : v; });
+    }
+
+    /**
+     * Subtracts the scalar \c e from \c *this.
+     * @param e the scalar to subtract.
+     * @return a reference to \c *this.
+     */
+    template <class ECT, class CCT>
+    template <class E>
+    inline auto xfiltration<ECT, CCT>::operator-=(const E& e) -> disable_xexpression<E, self_type&>
+    {
+        return apply([this, &e](const_reference v, bool cond) { return cond ? v - e : v; });
+    }
+
+    /**
+     * Multiplies \c *this with the scalar \c e.
+     * @param e the scalar involved in the operation.
+     * @return a reference to \c *this.
+     */
+    template <class ECT, class CCT>
+    template <class E>
+    inline auto xfiltration<ECT, CCT>::operator*=(const E& e) -> disable_xexpression<E, self_type&>
+    {
+        return apply([this, &e](const_reference v, bool cond) { return cond ? v * e : v; });
+    }
+
+    /**
+     * Divides \c *this by the scalar \c e.
+     * @param e the scalar involved in the operation.
+     * @return a reference to \c *this.
+     */
+    template <class ECT, class CCT>
+    template <class E>
+    inline auto xfiltration<ECT, CCT>::operator/=(const E& e) -> disable_xexpression<E, self_type&>
+    {
+        return apply([this, &e](const_reference v, bool cond) { return cond ? v / e : v; });
+    }
+
+    template <class ECT, class CCT>
+    template <class F>
+    inline auto xfiltration<ECT, CCT>::apply(F&& func) -> self_type&
+    {
+        std::transform(m_e.cbegin(), m_e.cend(), m_condition.cbegin(), m_e.begin(), func);
+        return *this;
+    }
+
+    /**
+     * @brief creates an indexview from a container of indices.
+     *        
+     * Returns a 1D view with the elements at \a indices selected.
+     *
+     * @param e the underlying xexpression
+     * @param indices the indices to select
+     * 
+     * \code{.cpp}
+     * xarray<double> a = {{1,5,3}, {4,5,6}};
+     * b = index_view(a, {{0, 0}, {1, 0}, {1, 1}});
+     * std::cout << b << std::endl; // {1, 4, 5}
+     * b += 100;
+     * std::cout << a << std::endl; // {{101, 5, 3}, {104, 105, 6}}
+     * \endcode
+     */
+    template <class E, class I>
+    inline auto index_view(E&& e, I&& indices) noexcept
+    {
+        using view_type = xindexview<xclosure_t<E>, std::decay_t<I>>;
+        return view_type(std::forward<E>(e), std::forward<I>(indices));
+    }
+#ifdef X_OLD_CLANG
+    template <class E, class I>
+    inline auto index_view(E&& e, std::initializer_list<std::initializer_list<I>> indices) noexcept
+    {
+        std::vector<xindex> idx;
+        for (auto it = indices.begin(); it != indices.end(); ++it)
+        {
+            idx.emplace_back(xindex(it->begin(), it->end()));
+        }
+        using view_type = xindexview<xclosure_t<E>, std::vector<xindex>>;
+        return view_type(std::forward<E>(e), std::move(idx));
+    }
+#else
+    template <class E, std::size_t L>
+    inline auto index_view(E&& e, const xindex (&indices)[L]) noexcept
+    {
+        using view_type = xindexview<xclosure_t<E>, std::array<xindex, L>>;
+        return view_type(std::forward<E>(e), to_array(indices));
+    }
+#endif
+
+    /**
+     * @brief creates a view into \a e filtered by \a condition.
+     *        
+     * Returns a 1D view with the elements selected where \a condition evaluates to \em true.
+     * This is equivalent to \verbatim{index_view(e, where(condition));}\endverbatim
+     * The returned view is not optimal if you just want to assign a scalar to the filtered
+     * elements. In that case, you should consider using the \ref filtration function
+     * instead.
+     *
+     * @param e the underlying xexpression
+     * @param condition xexpression with shape of \a e which selects indices
+     *
+     * \code{.cpp}
+     * xarray<double> a = {{1,5,3}, {4,5,6}};
+     * b = filter(a, a >= 5);
+     * std::cout << b << std::endl; // {5, 5, 6}
+     * \endcode
+     *
+     * \sa filtration
+     */
+    template <class E, class O>
+    inline auto filter(E&& e, O&& condition) noexcept
+    {
+        auto indices = where(std::forward<O>(condition));
+        using view_type = xindexview<xclosure_t<E>, decltype(indices)>;
+        return view_type(std::forward<E>(e), std::move(indices));
+    }
+
+    /**
+     * @brief creates a filtration of \c e filtered by \a condition.
+     *
+     * Returns a lazy filtration optimized for scalar assignment.
+     * Actually, scalar assignment and computed scalar assignments
+     * are the only available methods of the filtration, the filtration
+     * IS NOT an \ref xexpression.
+     *
+     * @param e the \ref xexpression to filter
+     * @param condition the filtering \ref xexpression
+     *
+     * \code{.cpp}
+     * xarray<double> a = {{1,5,3}, {4,5,6}};
+     * filtration(a, a >= 5) += 2;
+     * std::cout << a << std::endl; // {{1, 7, 3}, {4, 7, 8}}
+     * \endcode
+     */
+    template <class E, class C>
+    inline auto filtration(E&& e, C&& condition) noexcept
+    {
+        using filtration_type = xfiltration<xclosure_t<E>, xclosure_t<C>>;
+        return filtration_type(std::forward<E>(e), std::forward<C>(condition));
+    }
+}
+
+#endif

--- a/inst/include/xtensor/xinfo.hpp
+++ b/inst/include/xtensor/xinfo.hpp
@@ -1,0 +1,113 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#include <string>
+
+namespace xt
+{
+    // see http://stackoverflow.com/a/20170989
+    struct static_string
+    {
+        template <std::size_t N>
+        constexpr static_string(const char(&a)[N]) noexcept
+            : data(a), size(N - 1)
+        {
+        }
+
+        constexpr static_string(const char* a, const std::size_t sz) noexcept
+            : data(a), size(sz)
+        {
+        }
+
+        const char* const data;
+        const std::size_t size;
+    };
+
+    template <class T>
+    constexpr static_string type_name()
+    {
+#ifdef __clang__
+        static_string p = __PRETTY_FUNCTION__;
+        return static_string(p.data + 31, p.size - 31 - 1);
+#elif defined(__GNUC__)
+        static_string p = __PRETTY_FUNCTION__;
+#  if __cplusplus < 201402
+        return static_string(p.data + 36, p.size - 36 - 1);
+#  else
+        return static_string(p.data + 46, p.size - 46 - 1);
+#  endif
+#elif defined(_MSC_VER)
+        static_string p = __FUNCSIG__;
+        return static_string(p.data + 38, p.size - 38 - 7);
+#endif
+    }
+
+    template <class T>
+    constexpr std::string type_to_string()
+    {
+        static_string static_name = type_name<T>();
+        return std::string(static_name.data, static_name.size);
+    }
+
+    template <class T>
+    std::string info(const T& t)
+    {
+        std::string s;
+        using shape_type = typename T::shape_type;
+        if (detail::is_array<shape_type>::value)
+        {
+            s += "Type: xtensor, fixed dimension " + std::to_string(t.dimension());
+        }
+        else
+        {
+            s += "Type: xarray, dimension " + std::to_string(t.dimension());
+        }
+        s += "\nValue type: " + type_to_string<typename T::value_type>();
+        s += "\nLayout: ";
+        if (t.layout() == layout_type::row_major)
+        {
+            s += "row_major";
+        }
+        else if (t.layout() == layout_type::column_major)
+        {
+            s += "column_major";
+        }
+        else if (t.layout() == layout_type::dynamic)
+        {
+            s += "dynamic";
+        }
+        else
+        {
+            s += "any";
+        }
+        s += "\nShape: (";
+        bool first = true;
+        for (auto& el : t.shape())
+        {
+            if (!first)
+            {
+                s += ", ";
+            }
+            first = false;
+            s += std::to_string(el);
+        }
+        s += ")\nStrides: (";
+        first = true;
+        for (auto& el : t.strides())
+        {
+            if (!first)
+            {
+                s += ", ";
+            }
+            first = false;
+            s += std::to_string(el);
+        }
+        s += ")\nSize: " + std::to_string(t.size()) + "\n";
+        return s;
+    }
+}

--- a/inst/include/xtensor/xio.hpp
+++ b/inst/include/xtensor/xio.hpp
@@ -1,0 +1,668 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XIO_HPP
+#define XIO_HPP
+
+#include <complex>
+#include <cstddef>
+#include <iomanip>
+#include <iostream>
+#include <numeric>
+#include <sstream>
+#include <string>
+
+#include "xexpression.hpp"
+#include "xmath.hpp"
+#include "xview.hpp"
+
+#if _WIN32
+using precision_type = typename std::streamsize;
+#else
+using precision_type = int;
+#endif
+
+namespace xt
+{
+
+    template <class E>
+    inline std::ostream& operator<<(std::ostream& out, const xexpression<E>& e);
+
+    namespace print_options
+    {
+        struct print_options_impl
+        {
+            std::size_t edge_items = 3;
+            std::size_t line_width = 75;
+            std::size_t threshold = 1000;
+            precision_type precision = -1;  // default precision
+        };
+
+        inline print_options_impl& print_options()
+        {
+            static print_options_impl po;
+            return po;
+        }
+
+        /**
+         * @brief Sets the line width. After \a line_width chars,
+         *        a new line is added.
+         *
+         * @param line_width The line width
+         */
+        inline void set_line_width(std::size_t line_width)
+        {
+            print_options().line_width = line_width;
+        }
+
+        /**
+         * @brief Sets the threshold after which summarization is triggered (default: 1000).
+         *
+         * @param threshold The number of elements in the xexpression that triggers
+         *                  summarization in the output
+         */
+        inline void set_threshold(std::size_t threshold)
+        {
+            print_options().threshold = threshold;
+        }
+
+        /**
+         * @brief Sets the number of edge items. If the summarization is
+         *        triggered, this value defines how many items of each dimension
+         *        are printed.
+         *
+         * @param edge_items The number of edge items
+         */
+        inline void set_edge_items(std::size_t edge_items)
+        {
+            print_options().edge_items = edge_items;
+        }
+
+        /**
+         * @brief Sets the precision for printing floating point values.
+         *
+         * @param precision The number of digits for floating point output
+         */
+        inline void set_precision(precision_type precision)
+        {
+            print_options().precision = precision;
+        }
+    }
+
+    /**************************************
+     * xexpression ostream implementation *
+     **************************************/
+
+    namespace detail
+    {
+        template <std::size_t I>
+        struct xout
+        {
+            template <class E, class F>
+            static std::ostream& output(std::ostream& out, const E& e, F& printer, std::size_t blanks,
+                                        precision_type element_width, std::size_t edge_items, std::size_t line_width)
+            {
+                using size_type = typename E::size_type;
+
+                if (e.dimension() == 0)
+                {
+                    printer.print_next(out);
+                }
+                else
+                {
+                    std::string indents(blanks, ' ');
+
+                    size_type i = 0;
+                    size_type elems_on_line = 0;
+                    size_type line_lim = (size_type)std::floor(line_width / (element_width + 2));
+
+                    out << '{';
+                    for (; i != e.shape()[0] - 1; ++i)
+                    {
+                        if (edge_items && e.shape()[0] > (edge_items * 2) && i == edge_items)
+                        {
+                            out << "..., ";
+                            if (e.dimension() > 1)
+                            {
+                                elems_on_line = 0;
+                                out << std::endl << indents;
+                            }
+                            i = e.shape()[0] - edge_items;
+                        }
+                        if (e.dimension() == 1 && line_lim != 0 && elems_on_line >= line_lim)
+                        {
+                            out << std::endl << indents;
+                            elems_on_line = 0;
+                        }
+
+                        xout<I - 1>::output(out, view(e, i), printer, blanks + 1, element_width, edge_items, line_width) << ',';
+
+                        elems_on_line++;
+
+                        if (I == 1 || e.dimension() == 1)
+                        {
+                            out << ' ';
+                        }
+                        else
+                        {
+                            out << std::endl << indents;
+                        }
+                    }
+                    if (e.dimension() == 1 && line_lim != 0 && elems_on_line >= line_lim)
+                    {
+                        out << std::endl << indents;
+                    }
+                    xout<I - 1>::output(out, view(e, i), printer, blanks + 1, element_width, edge_items, line_width) << '}';
+                }
+                return out;
+            }
+        };
+
+        template <>
+        struct xout<0>
+        {
+            template <class E, class F>
+            static std::ostream& output(std::ostream& out, const E& e, F& printer,
+                                        std::size_t, precision_type, std::size_t, std::size_t)
+            {
+                if (e.dimension() == 0)
+                {
+                    return printer.print_next(out);
+                }
+                else
+                {
+                    return out << "{...}";
+                }
+            }
+        };
+
+        template <std::size_t I>
+        struct recurser
+        {
+            template <class F, class E>
+            static void run(F& fn, const E& e, std::size_t lim = 0)
+            {
+                using size_type = typename E::size_type;
+                if (e.dimension() == 0)
+                {
+                    fn.update(e());
+                }
+                else
+                {
+                    size_type i = 0;
+                    for (; i != e.shape()[0] - 1; ++i)
+                    {
+                        if (lim && e.shape()[0] > (lim * 2) && i == lim)
+                        {
+                            i = e.shape()[0] - lim;
+                        }
+                        recurser<I - 1>::run(fn, view(e, i), lim);
+                    }
+                    recurser<I - 1>::run(fn, view(e, i), lim);
+                }
+            }
+        };
+
+        template <>
+        struct recurser<0>
+        {
+            template <class F, class E>
+            static void run(F& fn, const E& e, std::size_t)
+            {
+                if (e.dimension() == 0)
+                {
+                    fn.update(e());
+                }
+            }
+        };
+
+        template <class T, class E = void>
+        struct printer;
+
+        template <class T>
+        struct printer<T, std::enable_if_t<std::is_floating_point<typename T::value_type>::value>>
+        {
+            using value_type = typename T::value_type;
+            using cache_type = std::vector<value_type>;
+            using cache_iterator = typename cache_type::const_iterator;
+
+            printer(precision_type precision)
+                : m_precision(precision)
+            {
+            }
+
+            void init()
+            {
+                m_precision = m_required_precision < m_precision ? m_required_precision : m_precision;
+                m_it = m_cache.cbegin();
+                if (m_scientific)
+                {
+                    // 3 = sign, number and dot and 4 = "e+00"
+                    m_width = m_precision + 7;
+                    if (m_large_exponent)
+                    {
+                        // = e+000 (additional number)
+                        m_width += 1;
+                    }
+                }
+                else
+                {
+                    precision_type decimals = 1; // print a leading 0
+                    if (std::floor(m_max) != 0)
+                    {
+                        decimals += (precision_type) std::log10(std::floor(m_max));
+                    }
+                    // 2 => sign and dot
+                    m_width = 2 + decimals + m_precision;
+                }
+                if (!m_required_precision)
+                {
+                    --m_width;
+                }
+            }
+
+            std::ostream& print_next(std::ostream& out)
+            {
+                if (!m_scientific)
+                {
+                    std::stringstream buf;
+                    buf << std::setw(m_width) << std::fixed << std::setprecision(m_precision) << (*m_it);
+                    if (!m_required_precision)
+                    {
+                        buf << '.';
+                    }
+                    std::string res = buf.str();
+                    auto sit = res.rbegin();
+                    while (*sit == '0')
+                    {
+                        *sit = ' ';
+                        ++sit;
+                    }
+                    out << res;
+                }
+                else
+                {
+                    if (!m_large_exponent)
+                    {
+                        out << std::scientific << std::setw(m_width) << (*m_it);
+                    }
+                    else
+                    {
+                        std::stringstream buf;
+                        buf << std::setw(m_width) << std::scientific << std::setprecision(m_precision) << (*m_it);
+                        std::string res = buf.str();
+
+                        if (res[res.size() - 4] == 'e')
+                        {
+                            res.erase(0, 1);
+                            res.insert(res.size() - 2, "0");
+                        }
+                        out << res;
+                    }
+                }
+                ++m_it;
+                return out;
+            }
+
+            void update(const value_type& val)
+            {
+                if (val != 0 && !std::isinf(val) && !std::isnan(val))
+                {
+                    if (!m_scientific || !m_large_exponent)
+                    {
+                        int exponent = 1 + (int)std::log10(std::abs(val));
+                        if (exponent <= -5 || exponent > 7)
+                        {
+                            m_scientific = true;
+                            m_required_precision = m_precision;
+                            if (exponent <= -100 || exponent >= 100)
+                            {
+                                m_large_exponent = true;
+                            }
+                        }
+                    }
+                    if (std::abs(val) > m_max)
+                    {
+                        m_max = std::abs(val);
+                    }
+                    if (m_required_precision < m_precision)
+                    {
+                        while (std::floor(val * std::pow(10, m_required_precision)) != val * std::pow(10, m_required_precision))
+                        {
+                            m_required_precision++;
+                        }
+                    }
+                }
+                m_cache.push_back(val);
+            }
+
+            precision_type width()
+            {
+                return m_width;
+            }
+
+        private:
+
+            bool m_large_exponent = false;
+            bool m_scientific = false;
+            precision_type m_width = 9;
+            precision_type m_precision;
+            precision_type m_required_precision = 0;
+            value_type m_max = 0;
+
+            cache_type m_cache;
+            cache_iterator m_it;
+        };
+
+        template <class T>
+        struct printer<T, std::enable_if_t<std::is_integral<typename T::value_type>::value && !std::is_same<typename T::value_type, bool>::value>>
+        {
+            using value_type = typename T::value_type;
+            using cache_type = std::vector<value_type>;
+            using cache_iterator = typename cache_type::const_iterator;
+
+            printer(precision_type)
+            {
+            }
+
+            void init()
+            {
+                m_it = m_cache.cbegin();
+                m_width = 1 + (precision_type)std::log10(m_max) + m_sign;
+            }
+
+            std::ostream& print_next(std::ostream& out)
+            {
+                // + enables printing of chars etc. as numbers
+                // TODO should chars be printed as numbers?
+                out << std::setw(m_width) << +(*m_it);
+                ++m_it;
+                return out;
+            }
+
+            void update(const value_type& val)
+            {
+                if (std::abs(val) > m_max)
+                {
+                    m_max = std::abs(val);
+                }
+                if (std::is_signed<value_type>::value && val < 0)
+                {
+                    m_sign = true;
+                }
+                m_cache.push_back(val);
+            }
+
+            precision_type width()
+            {
+                return m_width;
+            }
+
+        private:
+
+            precision_type m_width;
+            bool m_sign = false;
+            value_type m_max = 0;
+
+            cache_type m_cache;
+            cache_iterator m_it;
+        };
+
+        template <class T>
+        struct printer<T, std::enable_if_t<std::is_same<typename T::value_type, bool>::value>>
+        {
+            using value_type = bool;
+            using cache_type = std::vector<bool>;
+            using cache_iterator = typename cache_type::const_iterator;
+
+            printer(precision_type)
+            {
+            }
+
+            void init()
+            {
+                m_it = m_cache.cbegin();
+            }
+
+            std::ostream& print_next(std::ostream& out)
+            {
+                if (*m_it)
+                {
+                    out << " true";
+                }
+                else
+                {
+                    out << "false";
+                }
+                // the following std::setw(5) isn't working correctly on OSX.
+                // out << std::boolalpha << std::setw(m_width) << (*m_it);
+                ++m_it;
+                return out;
+            }
+
+            void update(const value_type& val)
+            {
+                m_cache.push_back(val);
+            }
+
+            precision_type width()
+            {
+                return m_width;
+            }
+
+        private:
+
+            precision_type m_width = 5;
+
+            cache_type m_cache;
+            cache_iterator m_it;
+        };
+
+        template <class T>
+        struct printer<T, std::enable_if_t<is_complex<typename T::value_type>::value>>
+        {
+            using value_type = typename T::value_type;
+            using cache_type = std::vector<bool>;
+            using cache_iterator = typename cache_type::const_iterator;
+
+            printer(precision_type precision)
+                : real_printer(precision), imag_printer(precision)
+            {
+            }
+
+            void init()
+            {
+                real_printer.init();
+                imag_printer.init();
+                m_it = m_signs.cbegin();
+            }
+
+            std::ostream& print_next(std::ostream& out)
+            {
+                real_printer.print_next(out);
+                if (*m_it)
+                {
+                    out << "-";
+                }
+                else
+                {
+                    out << "+";
+                }
+                std::stringstream buf;
+                imag_printer.print_next(buf);
+                std::string s = buf.str();
+                if (s[0] == ' ')
+                {
+                    s.erase(0, 1);  // erase space for +/-
+                }
+                // insert j at end of number
+                std::size_t idx = s.find_last_not_of(" ");
+                s.insert(idx + 1, "i");
+                out << s;
+                ++m_it;
+                return out;
+            }
+
+            void update(const value_type& val)
+            {
+                real_printer.update(val.real());
+                imag_printer.update(std::abs(val.imag()));
+                m_signs.push_back(std::signbit(val.imag()));
+            }
+
+            precision_type width()
+            {
+                return real_printer.width() + imag_printer.width() + 2;
+            }
+
+        private:
+
+            printer<value_type> real_printer, imag_printer;
+            cache_type m_signs;
+            cache_iterator m_it;
+        };
+
+        template <class T>
+        struct printer<T, std::enable_if_t<!std::is_fundamental<typename T::value_type>::value && !is_complex<typename T::value_type>::value>>
+        {
+            using value_type = typename T::value_type;
+            using cache_type = std::vector<std::string>;
+            using cache_iterator = typename cache_type::const_iterator;
+
+            printer(precision_type)
+            {
+            }
+
+            void init()
+            {
+                m_it = m_cache.cbegin();
+                if (m_width > 20)
+                {
+                    m_width = 0;
+                }
+            }
+
+            std::ostream& print_next(std::ostream& out)
+            {
+                out << std::setw(m_width) << *m_it;
+                ++m_it;
+                return out;
+            }
+
+            void update(const value_type& val)
+            {
+                std::stringstream buf;
+                buf << val;
+                std::string s = buf.str();
+                if (int(s.size()) > m_width)
+                {
+                    m_width = int(s.size());
+                }
+                m_cache.push_back(s);
+            }
+
+            precision_type width()
+            {
+                return m_width;
+            }
+
+        private:
+
+            precision_type m_width = 0;
+            cache_type m_cache;
+            cache_iterator m_it;
+        };
+
+        template <class E>
+        struct custom_formatter
+        {
+            using value_type = typename E::value_type;
+
+            template <class F>
+            custom_formatter(F&& func)
+                : m_func(func)
+            {
+            }
+
+            std::string operator()(const value_type& val) const
+            {
+                return m_func(val);
+            }
+
+        private:
+            std::function<std::string(const value_type&)> m_func;
+        };
+
+        template <class S>
+        struct recursion_depth
+        {
+            static constexpr std::size_t value = 5;
+        };
+
+// Note: std::min is not constexpr on old versions of gcc (4.x) and clang.
+#define XTENSOR_MIN(x, y) (x > y ? y : x)
+        template <class T, std::size_t N>
+        struct recursion_depth<std::array<T, N>>
+        {
+            static constexpr std::size_t value = XTENSOR_MIN(5, N);
+        };
+#undef XTENSOR_MIN
+    }
+
+    template <class E, class F>
+    std::ostream& pretty_print(const xexpression<E>& e, F&& func, std::ostream& out = std::cout)
+    {
+        xfunction<detail::custom_formatter<E>, std::string, const_xclosure_t<E>> print_fun(detail::custom_formatter<E>(std::forward<F>(func)), e);
+        return pretty_print(print_fun, out);
+    }
+
+    template <class E>
+    std::ostream& pretty_print(const xexpression<E>& e, std::ostream& out = std::cout)
+    {
+        const E& d = e.derived_cast();
+
+        size_t lim = 0;
+        std::size_t sz = compute_size(d.shape());
+        if (sz > print_options::print_options().threshold)
+        {
+            lim = print_options::print_options().edge_items;
+        }
+        if (sz == 0)
+        {
+            out << "{}";
+            return out;
+        }
+
+        precision_type temp_precision = (precision_type)out.precision();
+        precision_type precision = temp_precision;
+        if (print_options::print_options().precision != -1)
+        {
+            out << std::setprecision(print_options::print_options().precision);
+            precision = print_options::print_options().precision;
+        }
+
+        detail::printer<E> p(precision);
+
+        constexpr std::size_t depth = detail::recursion_depth<typename E::shape_type>::value;
+        detail::recurser<depth>::run(p, d, lim);
+        p.init();
+        detail::xout<depth>::output(out, d, p, 1, p.width(), lim, print_options::print_options().line_width);
+
+        out << std::setprecision(temp_precision);  // restore precision
+
+        return out;
+    }
+
+    template <class E>
+    inline std::ostream& operator<<(std::ostream& out, const xexpression<E>& e)
+    {
+        return pretty_print(e, out);
+    }
+}
+
+#endif

--- a/inst/include/xtensor/xiterable.hpp
+++ b/inst/include/xtensor/xiterable.hpp
@@ -1,0 +1,1035 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XITERABLE_HPP
+#define XITERABLE_HPP
+
+#include "xiterator.hpp"
+
+namespace xt
+{
+
+    /*******************
+     * xconst_iterable *
+     *******************/
+
+    template <class D>
+    struct xiterable_inner_types;
+
+#define DL DEFAULT_LAYOUT
+
+    /**
+     * @class xconst_iterable
+     * @brief Base class for multidimensional iterable constant expressions
+     *
+     * The xconst_iterable class defines the interface for multidimensional
+     * constant expressions that can be iterated.
+     *
+     * @tparam D The derived type, i.e. the inheriting class for which xconst_iterable
+     *           provides the interface.
+     */
+    template <class D>
+    class xconst_iterable
+    {
+
+    public:
+
+        using derived_type = D;
+
+        using iterable_types = xiterable_inner_types<D>;
+        using inner_shape_type = typename iterable_types::inner_shape_type;
+        
+        using stepper = typename iterable_types::stepper;
+        using const_stepper = typename iterable_types::const_stepper;
+        
+        using iterator = typename iterable_types::iterator;
+        using const_iterator = typename iterable_types::const_iterator;
+       
+        template <layout_type L>
+        using broadcast_iterator = xiterator<stepper, inner_shape_type*, L>;
+        template <layout_type L>
+        using const_broadcast_iterator = xiterator<const_stepper, inner_shape_type*, L>;
+        
+        template <class S, layout_type L>
+        using shaped_xiterator = xiterator<stepper, S, L>;
+        template <class S, layout_type L>
+        using const_shaped_xiterator = xiterator<const_stepper, S, L>;
+
+        using reverse_iterator = typename iterable_types::reverse_iterator;
+        using const_reverse_iterator = typename iterable_types::const_reverse_iterator;
+        
+        template <layout_type L>
+        using reverse_broadcast_iterator = std::reverse_iterator<broadcast_iterator<L>>;
+        template <layout_type L>
+        using const_reverse_broadcast_iterator = std::reverse_iterator<const_broadcast_iterator<L>>;
+
+        template <class S, layout_type L>
+        using reverse_shaped_xiterator = std::reverse_iterator<shaped_xiterator<S, L>>;
+        template <class S, layout_type L>
+        using const_reverse_shaped_xiterator = std::reverse_iterator<const_shaped_xiterator<S, L>>;
+
+        template <layout_type L = DL>
+        const_broadcast_iterator<L> xbegin() const noexcept;
+        template <layout_type L = DL>
+        const_broadcast_iterator<L> xend() const noexcept;
+        template <layout_type L = DL>
+        const_broadcast_iterator<L> cxbegin() const noexcept;
+        template <layout_type L = DL>
+        const_broadcast_iterator<L> cxend() const noexcept;
+
+        template <class S, layout_type L = DL>
+        const_shaped_xiterator<S, L> xbegin(const S& shape) const noexcept;
+        template <class S, layout_type L = DL>
+        const_shaped_xiterator<S, L> xend(const S& shape) const noexcept;
+        template <class S, layout_type L = DL>
+        const_shaped_xiterator<S, L> cxbegin(const S& shape) const noexcept;
+        template <class S, layout_type L = DL>
+        const_shaped_xiterator<S, L> cxend(const S& shape) const noexcept;
+
+        template <layout_type L = DL>
+        const_reverse_broadcast_iterator<L> xrbegin() const noexcept;
+        template <layout_type L = DL>
+        const_reverse_broadcast_iterator<L> xrend() const noexcept;
+        template <layout_type L = DL>
+        const_reverse_broadcast_iterator<L> cxrbegin() const noexcept;
+        template <layout_type L = DL>
+        const_reverse_broadcast_iterator<L> cxrend() const noexcept;
+
+        template <class S, layout_type L = DL>
+        const_reverse_shaped_xiterator<S, L> xrbegin(const S& shape) const noexcept;
+        template <class S, layout_type L = DL>
+        const_reverse_shaped_xiterator<S, L> xrend(const S& shape) const noexcept;
+        template <class S, layout_type L = DL>
+        const_reverse_shaped_xiterator<S, L> cxrbegin(const S& shape) const noexcept;
+        template <class S, layout_type L = DL>
+        const_reverse_shaped_xiterator<S, L> cxrend(const S& shape) const noexcept;
+
+    protected:
+
+        const inner_shape_type& get_shape() const;
+
+    private:
+
+        template <layout_type L>
+        const_broadcast_iterator<L> get_cxbegin(bool reverse) const noexcept;
+        template <layout_type L>
+        const_broadcast_iterator<L> get_cxend(bool reverse) const noexcept;
+
+        template <class S, layout_type L>
+        const_shaped_xiterator<S, L> get_cxbegin(const S& shape, bool reverse) const noexcept;
+        template <class S, layout_type L>
+        const_shaped_xiterator<S, L> get_cxend(const S& shape, bool reverse) const noexcept;
+
+        template <class S>
+        const_stepper get_stepper_begin(const S& shape) const noexcept;
+        template <class S>
+        const_stepper get_stepper_end(const S& shape) const noexcept;
+
+        const derived_type& derived_cast() const;
+    };
+
+    /*************
+     * xiterable *
+     *************/
+
+    /**
+     * @class xiterable
+     * @brief Base class for multidimensional iterable expressions
+     *
+     * The xiterable class defines the interface for multidimensional
+     * expressions that can be iterated.
+     *
+     * @tparam D The derived type, i.e. the inheriting class for which xiterable
+     *           provides the interface.
+     */
+    template <class D>
+    class xiterable : public xconst_iterable<D>
+    {
+
+    public:
+
+        using derived_type = D;
+
+        using base_type = xconst_iterable<D>;
+        using inner_shape_type = typename base_type::inner_shape_type;
+        
+        using stepper = typename base_type::stepper;
+        using const_stepper = typename base_type::const_stepper;
+        
+        using iterator = typename base_type::iterator;
+        using const_iterator = typename base_type::const_iterator;
+        
+        template <layout_type L>
+        using broadcast_iterator = typename base_type::template broadcast_iterator<L>;
+        template <layout_type L>
+        using const_broadcast_iterator = typename base_type::template const_broadcast_iterator<L>;
+
+        template <class S, layout_type L>
+        using shaped_xiterator = typename base_type::template shaped_xiterator<S, L>;
+        template <class S, layout_type L>
+        using const_shaped_xiterator = typename base_type::template const_shaped_xiterator<S, L>;
+
+        using reverse_iterator = typename base_type::reverse_iterator;
+        using const_reverse_iterator = typename base_type::const_reverse_iterator;
+
+        template <layout_type L>
+        using reverse_broadcast_iterator = typename base_type::template reverse_broadcast_iterator<L>;
+        template <layout_type L>
+        using const_reverse_broadcast_iterator = typename base_type::template const_reverse_broadcast_iterator<L>;
+
+        template <class S, layout_type L>
+        using reverse_shaped_xiterator = typename base_type::template reverse_shaped_xiterator<S, L>;
+        template <class S, layout_type L>
+        using const_reverse_shaped_xiterator = typename base_type::template const_reverse_shaped_xiterator<S, L>;
+
+        template <layout_type L = DL>
+        broadcast_iterator<L> xbegin() noexcept;
+        template <layout_type L = DL>
+        broadcast_iterator<L> xend() noexcept;
+
+        using base_type::xbegin;
+        using base_type::xend;
+
+        template <class S, layout_type L = DL>
+        shaped_xiterator<S, L> xbegin(const S& shape) noexcept;
+        template <class S, layout_type L = DL>
+        shaped_xiterator<S, L> xend(const S& shape) noexcept;
+
+        template <layout_type L = DL>
+        reverse_broadcast_iterator<L> xrbegin() noexcept;
+        template <layout_type L = DL>
+        reverse_broadcast_iterator<L> xrend() noexcept;
+
+        using base_type::xrbegin;
+        using base_type::xrend;
+
+        template <class S, layout_type L = DL>
+        reverse_shaped_xiterator<S, L> xrbegin(const S& shape) noexcept;
+        template <class S, layout_type L = DL>
+        reverse_shaped_xiterator<S, L> xrend(const S& shape) noexcept;
+
+    private:
+
+        template <layout_type L>
+        broadcast_iterator<L> get_xbegin(bool reverse) noexcept;
+        template <layout_type L>
+        broadcast_iterator<L> get_xend(bool reverse) noexcept;
+
+        template <class S, layout_type L>
+        shaped_xiterator<S, L> get_xbegin(const S& shape, bool reverse) noexcept;
+        template <class S, layout_type L>
+        shaped_xiterator<S, L> get_xend(const S& shape, bool reverse) noexcept;
+
+        template <class S>
+        stepper get_stepper_begin(const S& shape) noexcept;
+        template <class S>
+        stepper get_stepper_end(const S& shape) noexcept;
+
+        derived_type& derived_cast();
+    };
+
+#undef DL
+
+    /******************************
+     * xexpression_const_iterable *
+     ******************************/
+
+    /**
+     * @class xexpression_const_iterable
+     * @brief Base class for multidimensional iterable constant expressions
+     *        that don't store any data
+     *
+     * The xexpression_const_iterable class defines the interface for multidimensional
+     * constant expressions that don't store any data and that can be iterated.
+     *
+     * @tparam D The derived type, i.e. the inheriting class for which xexpression_const_iterable
+     *           provides the interface.
+     */
+    template <class D>
+    class xexpression_const_iterable : public xconst_iterable<D>
+    {
+
+    public:
+
+        using base_type = xconst_iterable<D>;
+        using inner_shape_type = typename base_type::inner_shape_type;
+        
+        using stepper = typename base_type::stepper;
+        using const_stepper = typename base_type::const_stepper;
+        
+        using iterator = typename base_type::iterator;
+        using const_iterator = typename base_type::const_iterator;
+        
+        template <layout_type L>
+        using broadcast_iterator = typename base_type::template broadcast_iterator<L>;
+        template <layout_type L>
+        using const_broadcast_iterator = typename base_type::template const_broadcast_iterator<L>;
+
+        template <class S, layout_type L>
+        using shaped_xiterator = typename base_type::template shaped_xiterator<S, L>;
+        template <class S, layout_type L>
+        using const_shaped_xiterator = typename base_type::template const_shaped_xiterator<S, L>;
+
+        using reverse_iterator = typename base_type::reverse_iterator;
+        using const_reverse_iterator = typename base_type::const_reverse_iterator;
+
+        template <layout_type L>
+        using reverse_broadcast_iterator = typename base_type::template reverse_broadcast_iterator<L>;
+        template <layout_type L>
+        using const_reverse_broadcast_iterator = typename base_type::template const_reverse_broadcast_iterator<L>;
+
+        template <class S, layout_type L>
+        using reverse_shaped_xiterator = typename base_type::template reverse_shaped_xiterator<S, L>;
+        template <class S, layout_type L>
+        using const_reverse_shaped_xiterator = typename base_type::template const_reverse_shaped_xiterator<S, L>;
+
+        const_iterator begin() const noexcept;
+        const_iterator end() const noexcept;
+        const_iterator cbegin() const noexcept;
+        const_iterator cend() const noexcept;
+
+        const_reverse_iterator rbegin() const noexcept;
+        const_reverse_iterator rend() const noexcept;
+        const_reverse_iterator crbegin() const noexcept;
+        const_reverse_iterator crend() const noexcept;
+    };
+
+    /************************
+     * xexpression_iterable *
+     ************************/
+
+    /**
+     * @class xexpression_iterable
+     * @brief Base class for multidimensional iterable expressions
+     *        that don't store any data
+     *
+     * The xexpression_iterable class defines the interface for multidimensional
+     * expressions that don't store any data and that can be iterated.
+     *
+     * @tparam D The derived type, i.e.the inheriting class for which xexpression_iterable
+     *           provides the interface.
+     */
+    template <class D>
+    class xexpression_iterable : public xiterable<D>
+    {
+
+    public:
+
+        using base_type = xiterable<D>;
+        using inner_shape_type = typename base_type::inner_shape_type;
+        
+        using stepper = typename base_type::stepper;
+        using const_stepper = typename base_type::const_stepper;
+        
+        using iterator = typename base_type::iterator;
+        using const_iterator = typename base_type::const_iterator;
+        
+        template <layout_type L>
+        using broadcast_iterator = typename base_type::template broadcast_iterator<L>;
+        template <layout_type L>
+        using const_broadcast_iterator = typename base_type::template const_broadcast_iterator<L>;
+
+        template <class S, layout_type L>
+        using shaped_xiterator = typename base_type::template shaped_xiterator<S, L>;
+        template <class S, layout_type L>
+        using const_shaped_xiterator = typename base_type::template const_shaped_xiterator<S, L>;
+
+        using reverse_iterator = typename base_type::reverse_iterator;
+        using const_reverse_iterator = typename base_type::const_reverse_iterator;
+
+        template <layout_type L>
+        using reverse_broadcast_iterator = typename base_type::template reverse_broadcast_iterator<L>;
+        template <layout_type L>
+        using const_reverse_broadcast_iterator = typename base_type::template const_reverse_broadcast_iterator<L>;
+
+        template <class S, layout_type L>
+        using reverse_shaped_xiterator = typename base_type::template reverse_shaped_xiterator<S, L>;
+        template <class S, layout_type L>
+        using const_reverse_shaped_xiterator = typename base_type::template const_reverse_shaped_xiterator<S, L>;
+
+        iterator begin() noexcept;
+        iterator end() noexcept;
+
+        const_iterator begin() const noexcept;
+        const_iterator end() const noexcept;
+        const_iterator cbegin() const noexcept;
+        const_iterator cend() const noexcept;
+
+        reverse_iterator rbegin() noexcept;
+        reverse_iterator rend() noexcept;
+
+        const_reverse_iterator rbegin() const noexcept;
+        const_reverse_iterator rend() const noexcept;
+        const_reverse_iterator crbegin() const noexcept;
+        const_reverse_iterator crend() const noexcept;
+    };
+
+    /**********************************
+     * xconst_iterable implementation *
+     **********************************/
+
+    /**
+     * @name Constant broadcast iterators
+     */
+    //@{
+    /**
+     * Returns a constant iterator to the first element of the expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class D>
+    template <layout_type L>
+    inline auto xconst_iterable<D>::xbegin() const noexcept -> const_broadcast_iterator<L>
+    {
+        return cxbegin<L>();
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element
+     * of the expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class D>
+    template <layout_type L>
+    inline auto xconst_iterable<D>::xend() const noexcept -> const_broadcast_iterator<L>
+    {
+        return cxend<L>();
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class D>
+    template <layout_type L>
+    inline auto xconst_iterable<D>::cxbegin() const noexcept -> const_broadcast_iterator<L>
+    {
+        return get_cxbegin<L>(false);
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element
+     * of the expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class D>
+    template <layout_type L>
+    inline auto xconst_iterable<D>::cxend() const noexcept -> const_broadcast_iterator<L>
+    {
+        return get_cxend<L>(false);
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the expression. The
+     * iteration is broadcasted to the specified shape.
+     * @param shape the shape used for broadcasting
+     * @tparam S type of the \c shape parameter.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class D>
+    template <class S, layout_type L>
+    inline auto xconst_iterable<D>::xbegin(const S& shape) const noexcept -> const_shaped_xiterator<S, L>
+    {
+        return cxbegin<S, L>(shape);
+    }
+
+    /**
+    * Returns a constant iterator to the element following the last element of the
+    * expression. The iteration is broadcasted to the specified shape.
+    * @param shape the shape used for broadcasting
+    * @tparam S type of the \c shape parameter.
+    * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+    */
+    template <class D>
+    template <class S, layout_type L>
+    inline auto xconst_iterable<D>::xend(const S& shape) const noexcept -> const_shaped_xiterator<S, L>
+    {
+        return cxend<S, L>(shape);
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the expression. The
+     * iteration is broadcasted to the specified shape.
+     * @param shape the shape used for broadcasting
+     * @tparam S type of the \c shape parameter.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class D>
+    template <class S, layout_type L>
+    inline auto xconst_iterable<D>::cxbegin(const S& shape) const noexcept -> const_shaped_xiterator<S, L>
+    {
+        return get_cxbegin<S, L>(shape, false);
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element of the
+     * expression. The iteration is broadcasted to the specified shape.
+     * @param shape the shape used for broadcasting
+     * @tparam S type of the \c shape parameter.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class D>
+    template <class S, layout_type L>
+    inline auto xconst_iterable<D>::cxend(const S& shape) const noexcept -> const_shaped_xiterator<S, L>
+    {
+        return get_cxend<S, L>(shape, false);
+    }
+    //@}
+
+    /**
+     * @name Constant reverse broadcast iterators
+     */
+    //@{
+    /**
+     * Returns a constant iterator to the first element of the reversed expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class D>
+    template <layout_type L>
+    inline auto xconst_iterable<D>::xrbegin() const noexcept -> const_reverse_broadcast_iterator<L>
+    {
+        return cxrbegin<L>();
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element
+     * of the reversed expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class D>
+    template <layout_type L>
+    inline auto xconst_iterable<D>::xrend() const noexcept -> const_reverse_broadcast_iterator<L>
+    {
+        return cxrend<L>();
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the reversed expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class D>
+    template<layout_type L>
+    inline auto xconst_iterable<D>::cxrbegin() const noexcept -> const_reverse_broadcast_iterator<L>
+    {
+        return const_reverse_broadcast_iterator<L>(get_cxend<L>(true));
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element
+     * of the reversed expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class D>
+    template <layout_type L>
+    inline auto xconst_iterable<D>::cxrend() const noexcept -> const_reverse_broadcast_iterator<L>
+    {
+        return const_reverse_broadcast_iterator<L>(get_cxbegin<L>(true));
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the reversed expression.
+     * The iteration is broadcasted to the specified shape.
+     * @param shape the shape used for broadcasting
+     * @tparam S type of the \c shape parameter.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class D>
+    template <class S, layout_type L>
+    inline auto xconst_iterable<D>::xrbegin(const S& shape) const noexcept -> const_reverse_shaped_xiterator<S, L>
+    {
+        return cxrbegin<S, L>(shape);
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element of the
+     * reversed expression. The iteration is broadcasted to the specified shape.
+     * @param shape the shape used for broadcasting
+     * @tparam S type of the \c shape parameter.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class D>
+    template <class S, layout_type L>
+    inline auto xconst_iterable<D>::xrend(const S& shape) const noexcept -> const_reverse_shaped_xiterator<S, L>
+    {
+        return cxrend<S, L>(shape);
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the reversed expression.
+     * The iteration is broadcasted to the specified shape.
+     * @param shape the shape used for broadcasting
+     * @tparam S type of the \c shape parameter.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class D>
+    template <class S, layout_type L>
+    inline auto xconst_iterable<D>::cxrbegin(const S& shape) const noexcept -> const_reverse_shaped_xiterator<S, L>
+    {
+        return const_reverse_shaped_xiterator<S, L>(get_cxend<S, L>(shape, true));
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element of the
+     * reversed expression. The iteration is broadcasted to the specified shape.
+     * @param shape the shape used for broadcasting
+     * @tparam S type of the \c shape parameter.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class D>
+    template <class S, layout_type L>
+    inline auto xconst_iterable<D>::cxrend(const S& shape) const noexcept -> const_reverse_shaped_xiterator<S, L>
+    {
+        return const_reverse_shaped_xiterator<S, L>(get_cxbegin<S, L>(shape, true));
+    }
+    //@}
+
+    template <class D>
+    template <layout_type L>
+    inline auto xconst_iterable<D>::get_cxbegin(bool reverse) const noexcept -> const_broadcast_iterator<L>
+    {
+        return const_broadcast_iterator<L>(get_stepper_begin(get_shape()), &get_shape(), reverse);
+    }
+
+    template <class D>
+    template <layout_type L>
+    inline auto xconst_iterable<D>::get_cxend(bool reverse) const noexcept -> const_broadcast_iterator<L>
+    {
+        return const_broadcast_iterator<L>(get_stepper_end(get_shape()), &get_shape(), reverse);
+    }
+
+    template <class D>
+    template <class S, layout_type L>
+    inline auto xconst_iterable<D>::get_cxbegin(const S& shape, bool reverse) const noexcept -> const_shaped_xiterator<S, L>
+    {
+        return const_shaped_xiterator<S, L>(get_stepper_begin(shape), shape, reverse);
+    }
+
+    template <class D>
+    template <class S, layout_type L>
+    inline auto xconst_iterable<D>::get_cxend(const S& shape, bool reverse) const noexcept -> const_shaped_xiterator<S, L>
+    {
+        return const_shaped_xiterator<S, L>(get_stepper_end(shape), shape, reverse);
+    }
+
+    template <class D>
+    template <class S>
+    inline auto xconst_iterable<D>::get_stepper_begin(const S& shape) const noexcept -> const_stepper
+    {
+        return derived_cast().stepper_begin(shape);
+    }
+    template <class D>
+    template <class S>
+    inline auto xconst_iterable<D>::get_stepper_end(const S& shape) const noexcept -> const_stepper
+    {
+        return derived_cast().stepper_end(shape);
+    }
+
+    template <class D>
+    inline auto xconst_iterable<D>::get_shape() const -> const inner_shape_type&
+    {
+        return derived_cast().shape();
+    }
+
+    template <class D>
+    inline auto xconst_iterable<D>::derived_cast() const -> const derived_type&
+    {
+        return *static_cast<const derived_type*>(this);
+    }
+
+    /****************************
+     * xiterable implementation *
+     ****************************/
+
+    /**
+     * @name Broadcast iterators
+     */
+    //@{
+    /**
+     * Returns an iterator to the first element of the expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class D>
+    template <layout_type L>
+    inline auto xiterable<D>::xbegin() noexcept -> broadcast_iterator<L>
+    {
+        return get_xbegin<L>(false);
+    }
+
+    /**
+     * Returns an iterator to the element following the last element
+     * of the expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class D>
+    template <layout_type L>
+    inline auto xiterable<D>::xend() noexcept -> broadcast_iterator<L>
+    {
+        return get_xend<L>(false);
+    }
+
+    /**
+     * Returns an iterator to the first element of the expression. The
+     * iteration is broadcasted to the specified shape.
+     * @param shape the shape used for broadcasting
+     * @tparam S type of the \c shape parameter.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class D>
+    template <class S, layout_type L>
+    inline auto xiterable<D>::xbegin(const S& shape) noexcept -> shaped_xiterator<S, L>
+    {
+        return get_xbegin<S, L>(shape, false);
+    }
+
+    /**
+     * Returns an iterator to the element following the last element of the
+     * expression. The iteration is broadcasted to the specified shape.
+     * @param shape the shape used for broadcasting
+     * @tparam S type of the \c shape parameter.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class D>
+    template <class S, layout_type L>
+    inline auto xiterable<D>::xend(const S& shape) noexcept -> shaped_xiterator<S, L>
+    {
+        return get_xend<S, L>(shape, false);
+    }
+    //@}
+
+    /**
+     * @name Reverse broadcast iterators
+     */
+    //@{
+    /**
+     * Returns an iterator to the first element of the reversed expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class D>
+    template <layout_type L>
+    inline auto xiterable<D>::xrbegin() noexcept -> reverse_broadcast_iterator<L>
+    {
+        return reverse_broadcast_iterator<L>(get_xend<L>(true));
+    }
+
+    /**
+     * Returns an iterator to the element following the last element
+     * of the reversed expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class D>
+    template <layout_type L>
+    inline auto xiterable<D>::xrend() noexcept -> reverse_broadcast_iterator<L>
+    {
+        return reverse_broadcast_iterator<L>(get_xbegin<L>(true));
+    }
+
+    /**
+     * Returns an iterator to the first element of the reversed expression. The
+     * iteration is broadcasted to the specified shape.
+     * @param shape the shape used for broadcasting
+     * @tparam S type of the \c shape parameter.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class D>
+    template <class S, layout_type L>
+    inline auto xiterable<D>::xrbegin(const S& shape) noexcept -> reverse_shaped_xiterator<S, L>
+    {
+        return reverse_shaped_xiterator<S, L>(get_xend<S, L>(shape, true));
+    }
+
+    /**
+     * Returns an iterator to the element following the last element of the
+     * reversed expression. The iteration is broadcasted to the specified shape.
+     * @param shape the shape used for broadcasting
+     * @tparam S type of the \c shape parameter.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class D>
+    template <class S, layout_type L>
+    inline auto xiterable<D>::xrend(const S& shape) noexcept -> reverse_shaped_xiterator<S, L>
+    {
+        return reverse_shaped_xiterator<S, L>(get_xbegin<S, L>(shape, true));
+    }
+    //@}
+
+    template <class D>
+    template <layout_type L>
+    inline auto xiterable<D>::get_xbegin(bool reverse) noexcept -> broadcast_iterator<L>
+    {
+        return broadcast_iterator<L>(get_stepper_begin(this->get_shape()), &(this->get_shape()), reverse);
+    }
+
+    template <class D>
+    template <layout_type L>
+    inline auto xiterable<D>::get_xend(bool reverse) noexcept -> broadcast_iterator<L>
+    {
+        return broadcast_iterator<L>(get_stepper_end(this->get_shape()), &(this->get_shape()), reverse);
+    }
+
+    template <class D>
+    template <class S, layout_type L>
+    inline auto xiterable<D>::get_xbegin(const S& shape, bool reverse) noexcept -> shaped_xiterator<S, L>
+    {
+        return shaped_xiterator<S, L>(get_stepper_begin(shape), shape, reverse);
+    }
+
+    template <class D>
+    template <class S, layout_type L>
+    inline auto xiterable<D>::get_xend(const S& shape, bool reverse) noexcept -> shaped_xiterator<S, L>
+    {
+        return shaped_xiterator<S, L>(get_stepper_end(shape), shape, reverse);
+    }
+
+    template <class D>
+    template <class S>
+    inline auto xiterable<D>::get_stepper_begin(const S& shape) noexcept -> stepper
+    {
+        return derived_cast().stepper_begin(shape);
+    }
+
+    template <class D>
+    template <class S>
+    inline auto xiterable<D>::get_stepper_end(const S& shape) noexcept -> stepper
+    {
+        return derived_cast().stepper_end(shape);
+    }
+
+    template <class D>
+    inline auto xiterable<D>::derived_cast() -> derived_type&
+    {
+        return *static_cast<derived_type*>(this);
+    }
+
+    /*********************************************
+     * xexpression_const_iterable implementation *
+     *********************************************/
+
+    /**
+     * @name Constant Iterators
+     */
+    //@{
+    /**
+     * Returns a constant iterator to the first element of the expression.
+     */
+    template <class D>
+    inline auto xexpression_const_iterable<D>::begin() const noexcept -> const_iterator
+    {
+        return this->cxbegin();
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element
+     * of the expression.
+     */
+    template <class D>
+    inline auto xexpression_const_iterable<D>::end() const noexcept -> const_iterator
+    {
+        return this->cxend();
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the expression.
+     */
+    template <class D>
+    inline auto xexpression_const_iterable<D>::cbegin() const noexcept -> const_iterator
+    {
+        return this->cxbegin();
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element
+     * of the expression.
+     */
+    template <class D>
+    inline auto xexpression_const_iterable<D>::cend() const noexcept -> const_iterator
+    {
+        return this->cxend();
+    }
+    //@}
+
+    /**
+     * @name Constant Reverse Iterators
+     */
+    //@{
+    /**
+     * Returns a constant iterator to the first element of the reversed expression.
+     */
+    template <class D>
+    inline auto xexpression_const_iterable<D>::rbegin() const noexcept -> const_reverse_iterator
+    {
+        return this->cxrbegin();
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element
+     * of the reversed expression.
+     */
+    template <class D>
+    inline auto xexpression_const_iterable<D>::rend() const noexcept -> const_reverse_iterator
+    {
+        return this->cxrend();
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the reversed expression.
+     */
+    template <class D>
+    inline auto xexpression_const_iterable<D>::crbegin() const noexcept -> const_reverse_iterator
+    {
+        return this->cxrbegin();
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element
+     * of the reversed expression.
+     */
+    template <class D>
+    inline auto xexpression_const_iterable<D>::crend() const noexcept -> const_reverse_iterator
+    {
+        return this->cxrend();
+    }
+    //@}
+
+    /***************************************
+     * xexpression_iterable implementation *
+     ***************************************/
+
+    /**
+     * @name Iterators
+     */
+    //@{
+    /**
+     * Returns an iterator to the first element of the expression.
+     */
+    template <class D>
+    inline auto xexpression_iterable<D>::begin() noexcept -> iterator
+    {
+        return this->xbegin();
+    }
+
+    /**
+     * Returns an iterator to the element following the last element of
+     * the expression.
+     */
+    template <class D>
+    inline auto xexpression_iterable<D>::end() noexcept -> iterator
+    {
+        return this->xend();
+    }
+    //@}
+
+    /**
+     * @name Constant Iterators
+     */
+    /**
+     * Returns a constant iterator to the first element of the expression.
+     */
+    template <class D>
+    inline auto xexpression_iterable<D>::begin() const noexcept -> const_iterator
+    {
+        return this->cxbegin();
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element
+     * of the expression.
+     */
+    template <class D>
+    inline auto xexpression_iterable<D>::end() const noexcept -> const_iterator
+    {
+        return this->cxend();
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the expression.
+     */
+    template <class D>
+    inline auto xexpression_iterable<D>::cbegin() const noexcept -> const_iterator
+    {
+        return this->cxbegin();
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element
+     * of the expression.
+     */
+    template <class D>
+    inline auto xexpression_iterable<D>::cend() const noexcept -> const_iterator
+    {
+        return this->cxend();
+    }
+    //@}
+
+    /**
+     * @name Reverse Iterators
+     */
+    //@{
+    /**
+     * Returns an iterator to the first element of the reversed expression.
+     */
+    template <class D>
+    inline auto xexpression_iterable<D>::rbegin() noexcept -> reverse_iterator
+    {
+        return this->xrbegin();
+    }
+
+    /**
+     * Returns an iterator to the element following the last element
+     * of the reversed expression.
+     */
+    template <class D>
+    inline auto xexpression_iterable<D>::rend() noexcept -> reverse_iterator
+    {
+        return this->xrend();
+    }
+    //@}
+
+    /**
+     * @name Constant Reverse Iterators
+     */
+    //@{
+    /**
+     * Returns a constant iterator to the first element of the reversed expression.
+     */
+    template <class D>
+    inline auto xexpression_iterable<D>::rbegin() const noexcept -> const_reverse_iterator
+    {
+        return this->cxrbegin();
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element
+     * of the reversed expression.
+     */
+    template <class D>
+    inline auto xexpression_iterable<D>::rend() const noexcept -> const_reverse_iterator
+    {
+        return this->cxrend();
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the reversed expression.
+     */
+    template <class D>
+    inline auto xexpression_iterable<D>::crbegin() const noexcept -> const_reverse_iterator
+    {
+        return this->cxrbegin();
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element
+     * of the reversed expression.
+     */
+    template <class D>
+    inline auto xexpression_iterable<D>::crend() const noexcept -> const_reverse_iterator
+    {
+        return this->cxrend();
+    }
+    //@}
+}
+
+#endif

--- a/inst/include/xtensor/xiterator.hpp
+++ b/inst/include/xtensor/xiterator.hpp
@@ -1,0 +1,717 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XITERATOR_HPP
+#define XITERATOR_HPP
+
+#include <iterator>
+
+#include "xexception.hpp"
+#include "xlayout.hpp"
+#include "xutils.hpp"
+
+namespace xt
+{
+
+    /***********************
+     * iterator meta utils *
+     ***********************/
+
+    template <class CT>
+    class xscalar;
+
+    namespace detail
+    {
+        template <class C>
+        struct get_stepper_iterator_impl
+        {
+            using type = typename C::container_iterator;
+        };
+
+        template <class C>
+        struct get_stepper_iterator_impl<const C>
+        {
+            using type = typename C::const_container_iterator;
+        };
+
+        template <class CT>
+        struct get_stepper_iterator_impl<xscalar<CT>>
+        {
+            using type = typename xscalar<CT>::dummy_iterator;
+        };
+
+        template <class CT>
+        struct get_stepper_iterator_impl<const xscalar<CT>>
+        {
+            using type = typename xscalar<CT>::const_dummy_iterator;
+        };
+    }
+
+    template <class C>
+    using get_stepper_iterator = typename detail::get_stepper_iterator_impl<C>::type;
+
+    namespace detail
+    {
+        template <class ST>
+        struct index_type_impl
+        {
+            using type = std::vector<typename ST::value_type>;
+        };
+
+        template <class V, std::size_t L>
+        struct index_type_impl<std::array<V, L>>
+        {
+            using type = std::array<V, L>;
+        };
+    }
+
+    template <class C>
+    using xindex_type_t = typename detail::index_type_impl<C>::type;
+
+    /************
+     * xstepper *
+     ************/
+
+    template <class C>
+    class xstepper
+    {
+
+    public:
+
+        using container_type = C;
+        using subiterator_type = get_stepper_iterator<C>;
+        using subiterator_traits = std::iterator_traits<subiterator_type>;
+        using value_type = typename subiterator_traits::value_type;
+        using reference = typename subiterator_traits::reference;
+        using pointer = typename subiterator_traits::pointer;
+        using difference_type = typename subiterator_traits::difference_type;
+        using size_type = typename container_type::size_type;
+        using shape_type = typename container_type::shape_type;
+
+        xstepper() = default;
+        xstepper(container_type* c, subiterator_type it, size_type offset) noexcept;
+
+        reference operator*() const;
+
+        void step(size_type dim, size_type n = 1);
+        void step_back(size_type dim, size_type n = 1);
+        void reset(size_type dim);
+        void reset_back(size_type dim);
+
+        void to_begin();
+        void to_end();
+
+        bool equal(const xstepper& rhs) const;
+
+    private:
+
+        container_type* p_c;
+        subiterator_type m_it;
+        size_type m_offset;
+    };
+
+    template <class C>
+    bool operator==(const xstepper<C>& lhs,
+                    const xstepper<C>& rhs);
+
+    template <class C>
+    bool operator!=(const xstepper<C>& lhs,
+                    const xstepper<C>& rhs);
+
+    template <layout_type L>
+    struct stepper_tools
+    {
+
+        template <class S, class IT, class ST>
+        static void increment_stepper(S& stepper,
+                                      IT& index,
+                                      const ST& shape);
+
+        template <class S, class IT, class ST>
+        static void decrement_stepper(S& stepper,
+                                      IT& index,
+                                      const ST& shape);
+    };
+
+    /********************
+     * xindexed_stepper *
+     ********************/
+
+    template <class E, bool is_const = true>
+    class xindexed_stepper
+    {
+
+    public:
+
+        using self_type = xindexed_stepper<E, is_const>;
+        using xexpression_type = std::conditional_t<is_const, const E, E>;
+
+        using value_type = typename xexpression_type::value_type;
+        using reference = std::conditional_t<is_const,
+                                             typename xexpression_type::const_reference,
+                                             typename xexpression_type::reference>;
+        using pointer = std::conditional_t<is_const,
+                                           typename xexpression_type::const_pointer,
+                                           typename xexpression_type::pointer>;
+        using size_type = typename xexpression_type::size_type;
+        using difference_type = typename xexpression_type::difference_type;
+
+        using shape_type = typename xexpression_type::shape_type;
+        using index_type = xindex_type_t<shape_type>;
+
+        xindexed_stepper() = default;
+        xindexed_stepper(xexpression_type* e, size_type offset, bool end = false) noexcept;
+
+        reference operator*() const;
+
+        void step(size_type dim, size_type n = 1);
+        void step_back(size_type dim, size_type n = 1);
+        void reset(size_type dim);
+        void reset_back(size_type dim);
+
+        void to_begin();
+        void to_end();
+
+        bool equal(const self_type& rhs) const;
+
+    private:
+
+        xexpression_type* p_e;
+        index_type m_index;
+        size_type m_offset;
+    };
+
+    template <class C, bool is_const>
+    bool operator==(const xindexed_stepper<C, is_const>& lhs,
+                    const xindexed_stepper<C, is_const>& rhs);
+
+    template <class C, bool is_const>
+    bool operator!=(const xindexed_stepper<C, is_const>& lhs,
+                    const xindexed_stepper<C, is_const>& rhs);
+
+    /*************
+     * xiterator *
+     *************/
+
+    namespace detail
+    {
+        template <class S>
+        class shape_storage
+        {
+
+        public:
+
+            using shape_type = S;
+            using param_type = const S&;
+
+            shape_storage() = default;
+            shape_storage(param_type shape);
+            const S& shape() const;
+
+        private:
+
+            S m_shape;
+        };
+
+        template <class S>
+        class shape_storage<S*>
+        {
+
+        public:
+
+            using shape_type = S;
+            using param_type = const S*;
+
+            shape_storage(param_type shape = 0);
+            const S& shape() const;
+
+        private:
+
+            const S* p_shape;
+        };
+
+        template <layout_type L>
+        struct LAYOUT_FORBIDEN_FOR_XITERATOR;
+    }
+
+    template <class It, class S, layout_type L>
+    class xiterator : detail::shape_storage<S>
+    {
+
+    public:
+
+        using self_type = xiterator<It, S, L>;
+
+        using subiterator_type = It;
+        using value_type = typename subiterator_type::value_type;
+        using reference = typename subiterator_type::reference;
+        using pointer = typename subiterator_type::pointer;
+        using difference_type = typename subiterator_type::difference_type;
+        using size_type = typename subiterator_type::size_type;
+        using iterator_category = std::bidirectional_iterator_tag;
+
+        using private_base = detail::shape_storage<S>;
+        using shape_type = typename private_base::shape_type;
+        using shape_param_type = typename private_base::param_type;
+        using index_type = xindex_type_t<shape_type>;
+
+        xiterator() = default;
+        xiterator(It it, shape_param_type shape, bool reverse);
+
+        self_type& operator++();
+        self_type operator++(int);
+
+        self_type& operator--();
+        self_type operator--(int);
+
+        reference operator*() const;
+        pointer operator->() const;
+
+        bool equal(const xiterator& rhs) const;
+
+    private:
+
+        subiterator_type m_it;
+        index_type m_index;
+
+        using checking_type = typename detail::LAYOUT_FORBIDEN_FOR_XITERATOR<L>::type;
+    };
+
+    template <class It, class S, layout_type L>
+    bool operator==(const xiterator<It, S, L>& lhs,
+                    const xiterator<It, S, L>& rhs);
+
+    template <class It, class S, layout_type L>
+    bool operator!=(const xiterator<It, S, L>& lhs,
+                    const xiterator<It, S, L>& rhs);
+
+    /*******************************
+    * trivial_begin / trivial_end *
+    *******************************/
+
+    namespace detail
+    {
+        template <class C>
+        constexpr auto trivial_begin(C& c) -> decltype(c.begin())
+        {
+            return c.begin();
+        }
+
+        template <class C>
+        constexpr auto trivial_end(C& c) -> decltype(c.end())
+        {
+            return c.end();
+        }
+
+        template <class C>
+        constexpr auto trivial_begin(const C& c) -> decltype(c.begin())
+        {
+            return c.begin();
+        }
+
+        template <class C>
+        constexpr auto trivial_end(const C& c) -> decltype(c.end())
+        {
+            return c.end();
+        }
+    }
+
+    /***************************
+     * xstepper implementation *
+     ***************************/
+
+    template <class C>
+    inline xstepper<C>::xstepper(container_type* c, subiterator_type it, size_type offset) noexcept
+        : p_c(c), m_it(it), m_offset(offset)
+    {
+    }
+
+    template <class C>
+    inline auto xstepper<C>::operator*() const -> reference
+    {
+        return *m_it;
+    }
+
+    template <class C>
+    inline void xstepper<C>::step(size_type dim, size_type n)
+    {
+        if (dim >= m_offset)
+            m_it += n * p_c->strides()[dim - m_offset];
+    }
+
+    template <class C>
+    inline void xstepper<C>::step_back(size_type dim, size_type n)
+    {
+        if (dim >= m_offset)
+            m_it -= n * p_c->strides()[dim - m_offset];
+    }
+
+    template <class C>
+    inline void xstepper<C>::reset(size_type dim)
+    {
+        if (dim >= m_offset)
+            m_it -= p_c->backstrides()[dim - m_offset];
+    }
+
+    template <class C>
+    inline void xstepper<C>::reset_back(size_type dim)
+    {
+        if (dim >= m_offset)
+            m_it += p_c->backstrides()[dim - m_offset];
+    }
+
+    template <class C>
+    inline void xstepper<C>::to_begin()
+    {
+        m_it = p_c->data_xbegin();
+    }
+
+    template <class C>
+    inline void xstepper<C>::to_end()
+    {
+        m_it = p_c->data_xend();
+    }
+
+    template <class C>
+    inline bool xstepper<C>::equal(const xstepper& rhs) const
+    {
+        return p_c == rhs.p_c && m_it == rhs.m_it && m_offset == rhs.m_offset;
+    }
+
+    template <class C>
+    inline bool operator==(const xstepper<C>& lhs,
+                           const xstepper<C>& rhs)
+    {
+        return lhs.equal(rhs);
+    }
+
+    template <class C>
+    inline bool operator!=(const xstepper<C>& lhs,
+                           const xstepper<C>& rhs)
+    {
+        return !(lhs.equal(rhs));
+    }
+
+    template <>
+    template <class S, class IT, class ST>
+    void stepper_tools<layout_type::row_major>::increment_stepper(S& stepper,
+                                                                  IT& index,
+                                                                  const ST& shape)
+    {
+        using size_type = typename S::size_type;
+        size_type i = index.size();
+        while (i != 0)
+        {
+            --i;
+            if (++index[i] != shape[i])
+            {
+                stepper.step(i);
+                return;
+            }
+            else if (i != 0)
+            {
+                index[i] = 0;
+                stepper.reset(i);
+            }
+        }
+        if (i == 0)
+        {
+            stepper.to_end();
+        }
+    }
+
+    template <>
+    template <class S, class IT, class ST>
+    void stepper_tools<layout_type::row_major>::decrement_stepper(S& stepper,
+                                                                  IT& index,
+                                                                  const ST& shape)
+    {
+        using size_type = typename S::size_type;
+        size_type i = index.size();
+        while (i != 0)
+        {
+            --i;
+            if (index[i] == 0)
+            {
+                if (i != 0)
+                {
+                    index[i] = shape[i] - 1;
+                    stepper.reset_back(i);
+                }
+                else
+                {
+                    std::fill(index.begin(), index.end(), size_type(0));
+                    stepper.to_begin();
+                }
+            }
+            else
+            {
+                --index[i];
+                stepper.step_back(i);
+                return;
+            }
+        }
+    }
+
+    template <>
+    template <class S, class IT, class ST>
+    void stepper_tools<layout_type::column_major>::increment_stepper(S& stepper,
+                                                                     IT& index,
+                                                                     const ST& shape)
+    {
+        using size_type = typename S::size_type;
+        size_type size = index.size();
+        for (size_type i = 0; i < size; ++i)
+        {
+            if (++index[i] != shape[i])
+            {
+                stepper.step(i);
+                return;
+            }
+            else if (i != size - 1)
+            {
+                index[i] = 0;
+                stepper.reset(i);
+            }
+            else
+            {
+                stepper.to_end();
+            }
+        }
+    }
+
+    template <>
+    template <class S, class IT, class ST>
+    void stepper_tools<layout_type::column_major>::decrement_stepper(S& stepper,
+                                                                     IT& index,
+                                                                     const ST& shape)
+    {
+        using size_type = typename S::size_type;
+        size_type size = index.size();
+        for (size_type i = 0; i < size; ++i)
+        {
+            if (index[i] == 0)
+            {
+                if (i != size - 1)
+                {
+                    index[i] = shape[i] - 1;
+                    stepper.reset_back(i);
+                }
+                else
+                {
+                    std::fill(index.begin(), index.end(), size_type(0));
+                    stepper.to_begin();
+                }
+            }
+            else
+            {
+                --index[i];
+                stepper.step_back(i);
+                return;
+            }
+        }
+    }
+
+    /***********************************
+     * xindexed_stepper implementation *
+     ***********************************/
+
+    template <class C, bool is_const>
+    inline xindexed_stepper<C, is_const>::xindexed_stepper(xexpression_type* e, size_type offset, bool end) noexcept
+        : p_e(e), m_index(make_sequence<index_type>(e->shape().size(), size_type(0))), m_offset(offset)
+    {
+        if (end)
+            to_end();
+    }
+
+    template <class C, bool is_const>
+    inline auto xindexed_stepper<C, is_const>::operator*() const -> reference
+    {
+        return p_e->element(m_index.cbegin(), m_index.cend());
+    }
+
+    template <class C, bool is_const>
+    inline void xindexed_stepper<C, is_const>::step(size_type dim, size_type n)
+    {
+        if (dim >= m_offset)
+            m_index[dim - m_offset] += n;
+    }
+
+    template <class C, bool is_const>
+    inline void xindexed_stepper<C, is_const>::step_back(size_type dim, size_type n)
+    {
+        if (dim >= m_offset)
+            m_index[dim - m_offset] -= n;
+    }
+
+    template <class C, bool is_const>
+    inline void xindexed_stepper<C, is_const>::reset(size_type dim)
+    {
+        if (dim >= m_offset)
+            m_index[dim - m_offset] = 0;
+    }
+
+    template <class C, bool is_const>
+    inline void xindexed_stepper<C, is_const>::reset_back(size_type dim)
+    {
+        if (dim >= m_offset)
+            m_index[dim - m_offset] = p_e->shape()[dim - m_offset] - 1;
+    }
+
+    template <class C, bool is_const>
+    inline void xindexed_stepper<C, is_const>::to_begin()
+    {
+        std::fill(m_index.begin(), m_index.end(), size_type(0));
+    }
+    template <class C, bool is_const>
+    inline void xindexed_stepper<C, is_const>::to_end()
+    {
+        m_index = p_e->shape();
+    }
+
+    template <class C, bool is_const>
+    inline bool xindexed_stepper<C, is_const>::equal(const self_type& rhs) const
+    {
+        return p_e == rhs.p_e && m_index == rhs.m_index && m_offset == rhs.m_offset;
+    }
+
+    template <class C, bool is_const>
+    inline bool operator==(const xindexed_stepper<C, is_const>& lhs,
+                           const xindexed_stepper<C, is_const>& rhs)
+    {
+        return lhs.equal(rhs);
+    }
+
+    template <class C, bool is_const>
+    inline bool operator!=(const xindexed_stepper<C, is_const>& lhs,
+                           const xindexed_stepper<C, is_const>& rhs)
+    {
+        return !lhs.equal(rhs);
+    }
+
+    /****************************
+     * xiterator implementation *
+     ****************************/
+
+    namespace detail
+    {
+        template <class S>
+        inline shape_storage<S>::shape_storage(param_type shape)
+            : m_shape(shape)
+        {
+        }
+
+        template <class S>
+        inline const S& shape_storage<S>::shape() const
+        {
+            return m_shape;
+        }
+
+        template <class S>
+        inline shape_storage<S*>::shape_storage(param_type shape)
+            : p_shape(shape)
+        {
+        }
+
+        template <class S>
+        inline const S& shape_storage<S*>::shape() const
+        {
+            return *p_shape;
+        }
+
+        template <>
+        struct LAYOUT_FORBIDEN_FOR_XITERATOR<layout_type::row_major>
+        {
+            using type = int;
+        };
+
+        template <>
+        struct LAYOUT_FORBIDEN_FOR_XITERATOR<layout_type::column_major>
+        {
+            using type = int;
+        };
+    }
+
+    template <class It, class S, layout_type L>
+    inline xiterator<It, S, L>::xiterator(It it, shape_param_type shape, bool reverse)
+        : private_base(shape), m_it(it),
+          m_index(reverse ? forward_sequence<index_type, const shape_type&>(this->shape())
+                          : make_sequence<index_type>(this->shape().size(), size_type(0)))
+    {
+        if (reverse)
+        {
+            auto iter_end = m_index.end() - 1;
+            std::transform(m_index.begin(), iter_end, m_index.begin(),
+                           [](const auto& v) { return v - 1; });
+        }
+    }
+
+    template <class It, class S, layout_type L>
+    inline auto xiterator<It, S, L>::operator++() -> self_type&
+    {
+        stepper_tools<L>::increment_stepper(m_it, m_index, this->shape());
+        return *this;
+    }
+
+    template <class It, class S, layout_type L>
+    inline auto xiterator<It, S, L>::operator++(int) -> self_type
+    {
+        self_type tmp(*this);
+        ++(*this);
+        return tmp;
+    }
+
+    template <class It, class S, layout_type L>
+    inline auto xiterator<It, S, L>::operator--() -> self_type&
+    {
+        stepper_tools<L>::decrement_stepper(m_it, m_index, this->shape());
+        return *this;
+    }
+
+    template <class It, class S, layout_type L>
+    inline auto xiterator<It, S, L>::operator--(int) -> self_type
+    {
+        self_type tmp(*this);
+        --(*this);
+        return tmp;
+    }
+
+    template <class It, class S, layout_type L>
+    inline auto xiterator<It, S, L>::operator*() const -> reference
+    {
+        return *m_it;
+    }
+
+    template <class It, class S, layout_type L>
+    inline auto xiterator<It, S, L>::operator->() const -> pointer
+    {
+        return &(*m_it);
+    }
+
+    template <class It, class S, layout_type L>
+    inline bool xiterator<It, S, L>::equal(const xiterator& rhs) const
+    {
+        return m_it == rhs.m_it && this->shape() == rhs.shape();
+    }
+
+    template <class It, class S, layout_type L>
+    inline bool operator==(const xiterator<It, S, L>& lhs,
+                           const xiterator<It, S, L>& rhs)
+    {
+        return lhs.equal(rhs);
+    }
+
+    template <class It, class S, layout_type L>
+    inline bool operator!=(const xiterator<It, S, L>& lhs,
+                           const xiterator<It, S, L>& rhs)
+    {
+        return !(lhs.equal(rhs));
+    }
+}
+
+#endif

--- a/inst/include/xtensor/xlayout.hpp
+++ b/inst/include/xtensor/xlayout.hpp
@@ -1,0 +1,92 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XLAYOUT_HPP
+#define XLAYOUT_HPP
+
+namespace xt
+{
+    /*! layout_type enum for xcontainer based xexpressions */
+    enum class layout_type
+    {
+        /*! dynamic layout_type: you can reshape to row major, column major, or use custom strides */
+        dynamic = 0x00,
+        /*! layout_type compatible with all others */
+        any = 0xFF,
+        /*! row major layout_type */
+        row_major = 0x01,
+        /*! column major layout_type */
+        column_major = 0x02
+    };
+
+    /**
+     * Implementation of the following logical table:
+     *
+     * @verbatim
+         | d | a | r | c |
+       --+---+---+---+---+
+       d | d | d | d | d |
+       a | d | a | r | c |
+       r | d | r | r | d |
+       c | d | c | d | c |
+       d = dynamic, a = any, r = row_major, c = column_major.
+       @endverbatim
+     * Using bitmasks to avoid nested if-else statements.
+     * 
+     * @param args the input layouts.
+     * @return the output layout, computed with the previous logical table.
+     */
+    template <class... Args>
+    constexpr layout_type compute_layout(Args... args) noexcept;
+
+    constexpr layout_type default_assignable_layout(layout_type l) noexcept;
+
+    /******************
+     * Implementation *
+     ******************/
+
+    namespace detail
+    {
+        constexpr layout_type compute_layout_impl() noexcept
+        {
+            return layout_type::any;
+        }
+
+        constexpr layout_type compute_layout_impl(layout_type l) noexcept
+        {
+            return l;
+        }
+
+        constexpr layout_type compute_layout_impl(layout_type lhs, layout_type rhs) noexcept
+        {
+            using type = std::underlying_type_t<layout_type>;
+            return layout_type(static_cast<type>(lhs) & static_cast<type>(rhs));
+        }
+
+        template <class... Args>
+        constexpr layout_type compute_layout_impl(layout_type lhs, Args... args) noexcept
+        {
+            return compute_layout_impl(lhs, compute_layout_impl(args...));
+        }
+    }
+
+    template <class... Args>
+    constexpr layout_type compute_layout(Args... args) noexcept
+    {
+        return detail::compute_layout_impl(args...);
+    }
+
+    constexpr layout_type default_assignable_layout(layout_type l) noexcept
+    {
+        return (l == layout_type::row_major || l == layout_type::column_major) ?
+            l : layout_type::row_major;
+    }
+
+}
+
+#endif

--- a/inst/include/xtensor/xmath.hpp
+++ b/inst/include/xtensor/xmath.hpp
@@ -1,0 +1,1289 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+/**
+ * @brief standard mathematical functions for xexpressions
+ */
+
+#ifndef XMATH_HPP
+#define XMATH_HPP
+
+#include <cmath>
+#include <complex>
+#include <type_traits>
+
+#include "xoperation.hpp"
+#include "xreducer.hpp"
+
+namespace xt
+{
+    template <class T>
+    struct numeric_constants
+    {
+        static constexpr T PI =         3.141592653589793238463;
+        static constexpr T PI_2 =       1.57079632679489661923;
+        static constexpr T PI_4 =       0.785398163397448309616;
+        static constexpr T D_1_PI =     0.318309886183790671538;
+        static constexpr T D_2_PI =     0.636619772367581343076;
+        static constexpr T D_2_SQRTPI = 1.12837916709551257390;
+        static constexpr T SQRT2 =      1.41421356237309504880;
+        static constexpr T SQRT1_2 =    0.707106781186547524401;
+        static constexpr T E =          2.71828182845904523536;
+        static constexpr T LOG2E =      1.44269504088896340736;
+        static constexpr T LOG10E =     0.434294481903251827651;
+        static constexpr T LN2 =        0.693147180559945309417;
+    };
+
+    /***********
+     * Helpers *
+     ***********/
+
+    namespace detail
+    {
+        template <class T>
+        struct bool_functor_return_type
+        {
+            using type = bool;
+        };
+    }
+#define UNARY_MATH_FUNCTOR(NAME)\
+    template <class T>\
+    struct NAME##_fun {\
+        using argument_type = T;\
+        using result_type = T;\
+        constexpr T operator()(const T& arg) const {\
+            using std::NAME;\
+            return NAME(arg);\
+        }\
+    }
+
+#define UNARY_MATH_FUNCTOR_COMPLEX_REDUCING(NAME)\
+    template <class T>\
+    struct NAME##_fun {\
+        using argument_type = T;\
+        using result_type = complex_value_type_t<T>;\
+        constexpr result_type operator()(const T& arg) const {\
+            using std::NAME;\
+            return NAME(arg);\
+        }\
+    }
+
+#define BINARY_MATH_FUNCTOR(NAME)\
+    template <class T>\
+    struct NAME##_fun {\
+        using first_argument_type = T;\
+        using second_argument_type = T;\
+        using result_type = T;\
+        constexpr T operator()(const T& arg1, const T& arg2) const {\
+            using std::NAME;\
+            return NAME(arg1, arg2);\
+        }\
+    }
+
+#define TERNARY_MATH_FUNCTOR(NAME)\
+    template <class T>\
+    struct NAME##_fun {\
+        using first_argument_type = T;\
+        using second_argument_type = T;\
+        using third_argument_type = T;\
+        using result_type = T;\
+        constexpr T operator()(const T& arg1, const T& arg2, const T& arg3) const {\
+            using std::NAME;\
+            return NAME(arg1, arg2, arg3);\
+        }\
+    }
+
+#define UNARY_BOOL_FUNCTOR(NAME)\
+    template <class T>\
+    struct NAME##_fun {\
+        using argument_type = T;\
+        using result_type = typename xt::detail::bool_functor_return_type<T>::type;\
+        constexpr result_type operator()(const T& arg) const {\
+            using std::NAME;\
+            return NAME(arg);\
+        }\
+    }
+
+    namespace math
+    {
+        UNARY_MATH_FUNCTOR_COMPLEX_REDUCING(abs);
+        UNARY_MATH_FUNCTOR(fabs);
+        BINARY_MATH_FUNCTOR(fmod);
+        BINARY_MATH_FUNCTOR(remainder);
+        TERNARY_MATH_FUNCTOR(fma);
+        BINARY_MATH_FUNCTOR(fmax);
+        BINARY_MATH_FUNCTOR(fmin);
+        BINARY_MATH_FUNCTOR(fdim);
+        UNARY_MATH_FUNCTOR(exp);
+        UNARY_MATH_FUNCTOR(exp2);
+        UNARY_MATH_FUNCTOR(expm1);
+        UNARY_MATH_FUNCTOR(log);
+        UNARY_MATH_FUNCTOR(log10);
+        UNARY_MATH_FUNCTOR(log2);
+        UNARY_MATH_FUNCTOR(log1p);
+        BINARY_MATH_FUNCTOR(pow);
+        UNARY_MATH_FUNCTOR(sqrt);
+        UNARY_MATH_FUNCTOR(cbrt);
+        BINARY_MATH_FUNCTOR(hypot);
+        UNARY_MATH_FUNCTOR(sin);
+        UNARY_MATH_FUNCTOR(cos);
+        UNARY_MATH_FUNCTOR(tan);
+        UNARY_MATH_FUNCTOR(asin);
+        UNARY_MATH_FUNCTOR(acos);
+        UNARY_MATH_FUNCTOR(atan);
+        BINARY_MATH_FUNCTOR(atan2);
+        UNARY_MATH_FUNCTOR(sinh);
+        UNARY_MATH_FUNCTOR(cosh);
+        UNARY_MATH_FUNCTOR(tanh);
+        UNARY_MATH_FUNCTOR(asinh);
+        UNARY_MATH_FUNCTOR(acosh);
+        UNARY_MATH_FUNCTOR(atanh);
+        UNARY_MATH_FUNCTOR(erf);
+        UNARY_MATH_FUNCTOR(erfc);
+        UNARY_MATH_FUNCTOR(tgamma);
+        UNARY_MATH_FUNCTOR(lgamma);
+        UNARY_MATH_FUNCTOR(ceil);
+        UNARY_MATH_FUNCTOR(floor);
+        UNARY_MATH_FUNCTOR(trunc);
+        UNARY_MATH_FUNCTOR(round);
+        UNARY_MATH_FUNCTOR(nearbyint);
+        UNARY_MATH_FUNCTOR(rint);
+        UNARY_BOOL_FUNCTOR(isfinite);
+        UNARY_BOOL_FUNCTOR(isinf);
+        UNARY_BOOL_FUNCTOR(isnan);
+    }
+
+#undef UNARY_BOOL_FUNCTOR
+#undef TERNARY_MATH_FUNCTOR
+#undef BINARY_MATH_FUNCTOR
+#undef UNARY_MATH_FUNCTOR
+#undef UNARY_MATH_FUNCTOR_COMPLEX_REDUCING
+
+    /*******************
+     * basic functions *
+     *******************/
+
+    /**
+     * @defgroup basic_functions Basic functions
+     */
+
+    /**
+     * @ingroup basic_functions
+     * @brief Absolute value function.
+     * 
+     * Returns an \ref xfunction for the element-wise absolute value
+     * of \em e.
+     * @param e an \ref xexpression
+     * @return an \ref xfunction
+     */
+    template <class E>
+    inline auto abs(E&& e) noexcept
+        -> detail::xfunction_type_t<math::abs_fun, E>
+    {
+        return detail::make_xfunction<math::abs_fun>(std::forward<E>(e));
+    }
+
+    /**
+     * @ingroup basic_functions
+     * @brief Absolute value function.
+     * 
+     * Returns an \ref xfunction for the element-wise absolute value
+     * of \em e.
+     * @param e an \ref xexpression
+     * @return an \ref xfunction
+     */
+    template <class E>
+    inline auto fabs(E&& e) noexcept
+        -> detail::xfunction_type_t<math::fabs_fun, E>
+    {
+        return detail::make_xfunction<math::fabs_fun>(std::forward<E>(e));
+    }
+
+    /**
+     * @ingroup basic_functions
+     * @brief Remainder of the floating point division operation.
+     * 
+     * Returns an \ref xfunction for the element-wise remainder of
+     * the floating point division operation <em>e1 / e2</em>.
+     * @param e1 an \ref xexpression or a scalar
+     * @param e2 an \ref xexpression or a scalar
+     * @return an \ref xfunction
+     * @note e1 and e2 can't be both scalars.
+     */
+    template <class E1, class E2>
+    inline auto fmod(E1&& e1, E2&& e2) noexcept
+        -> detail::xfunction_type_t<math::fmod_fun, E1, E2>
+    {
+        return detail::make_xfunction<math::fmod_fun>(std::forward<E1>(e1), std::forward<E2>(e2));
+    }
+
+    /**
+     * @ingroup basic_functions
+     * @brief Signed remainder of the division operation.
+     * 
+     * Returns an \ref xfunction for the element-wise signed remainder
+     * of the floating point division operation <em>e1 / e2</em>.
+     * @param e1 an \ref xexpression or a scalar
+     * @param e2 an \ref xexpression or a scalar
+     * @return an \ref xfunction
+     * @note e1 and e2 can't be both scalars.
+     */
+    template <class E1, class E2>
+    inline auto remainder(E1&& e1, E2&& e2) noexcept
+        -> detail::xfunction_type_t<math::remainder_fun, E1, E2>
+    {
+        return detail::make_xfunction<math::remainder_fun>(std::forward<E1>(e1), std::forward<E2>(e2));
+    }
+
+    /**
+     * @ingroup basic_functions
+     * @brief Fused multiply-add operation.
+     *
+     * Returns an \ref xfunction for <em>e1 * e2 + e3</em> as if
+     * to infinite precision and rounded only once to fit the result type.
+     * @param e1 an \ref xfunction or a scalar
+     * @param e2 an \ref xfunction or a scalar
+     * @param e3 an \ref xfunction or a scalar
+     * @return an \ref xfunction
+     * @note e1, e2 and e3 can't be scalars every three.
+     */
+    template <class E1, class E2, class E3>
+    inline auto fma(E1&& e1, E2&& e2, E3&& e3) noexcept
+        -> detail::xfunction_type_t<math::fma_fun, E1, E2, E3>
+    {
+        return detail::make_xfunction<math::fma_fun>(std::forward<E1>(e1), std::forward<E2>(e2), std::forward<E3>(e3));
+    }
+
+    /**
+     * @ingroup basic_functions
+     * @brief Maximum function.
+     *
+     * Returns an \ref xfunction for the element-wise maximum
+     * of \a e1 and \a e2.
+     * @param e1 an \ref xexpression or a scalar
+     * @param e2 an \ref xexpression or a scalar
+     * @return an \ref xfunction
+     * @note e1 and e2 can't be both scalars.
+     */
+    template <class E1, class E2>
+    inline auto fmax(E1&& e1, E2&& e2) noexcept
+        -> detail::xfunction_type_t<math::fmax_fun, E1, E2>
+    {
+        return detail::make_xfunction<math::fmax_fun>(std::forward<E1>(e1), std::forward<E2>(e2));
+    }
+
+    /**
+     * @ingroup basic_functions
+     * @brief Minimum function.
+     *
+     * Returns an \ref xfunction for the element-wise minimum
+     * of \a e1 and \a e2.
+     * @param e1 an \ref xexpression or a scalar
+     * @param e2 an \ref xexpression or a scalar
+     * @return an \ref xfunction
+     * @note e1 and e2 can't be both scalars.
+     */
+    template <class E1, class E2>
+    inline auto fmin(E1&& e1, E2&& e2) noexcept
+        -> detail::xfunction_type_t<math::fmin_fun, E1, E2>
+    {
+        return detail::make_xfunction<math::fmin_fun>(std::forward<E1>(e1), std::forward<E2>(e2));
+    }
+
+    /**
+     * @ingroup basic_functions
+     * @brief Positive difference function.
+     *
+     * Returns an \ref xfunction for the element-wise positive
+     * difference of \a e1 and \a e2.
+     * @param e1 an \ref xexpression or a scalar
+     * @param e2 an \ref xexpression or a scalar
+     * @return an \ref xfunction
+     * @note e1 and e2 can't be both scalars.
+     */
+    template <class E1, class E2>
+    inline auto fdim(E1&& e1, E2&& e2) noexcept
+        -> detail::xfunction_type_t<math::fdim_fun, E1, E2>
+    {
+        return detail::make_xfunction<math::fdim_fun>(std::forward<E1>(e1), std::forward<E2>(e2));
+    }
+
+    namespace math
+    {
+        template <class T>
+        struct clamp_fun
+        {
+            using first_argument_type = T;
+            using second_argument_type = T;
+            using third_argument_type = T;
+            using result_type = T;
+            constexpr T operator()(const T& v, const T& lo, const T& hi) const
+            {
+                return v < lo ? lo : hi < v ? hi : v;
+            }
+        };
+    }
+
+    /**
+     * @ingroup basic_functions
+     * @brief Clip values between hi and lo
+     * 
+     * Returns an \ref xfunction for the element-wise clipped 
+     * values between hi- and lo
+     * @param e1 an \ref xexpression or a scalar
+     * @param hi a scalar
+     * @param lo a scalar
+     *
+     * @return a \ref xfunction
+     */
+    template <class E1, class E2, class E3>
+    inline auto clip(E1&& e1, E2&& hi, E3&& lo) noexcept
+        -> detail::xfunction_type_t<math::clamp_fun, E1, E2, E3>
+    {
+        return detail::make_xfunction<math::clamp_fun>(std::forward<E1>(e1), std::forward<E2>(hi), std::forward<E3>(lo));
+    }
+
+    namespace math
+    {
+        namespace detail
+        {
+            template <typename T>
+            constexpr std::enable_if_t<std::is_signed<T>::value, T>
+            sign_impl(T x)
+            {
+                return std::isnan(x) ? std::numeric_limits<T>::quiet_NaN() : x == 0 ? (T)copysign(T(0), x) : (T)copysign(T(1), x);
+            }
+
+            template <typename T>
+            inline std::enable_if_t<xt::detail::is_complex<T>::value, T>
+            sign_impl(T x)
+            {
+                typename T::value_type e = x.real() ? x.real() : x.imag();
+                return T(sign_impl(e), 0);
+            }
+
+            template <typename T>
+            constexpr std::enable_if_t<std::is_unsigned<T>::value, T>
+            sign_impl(T x)
+            {
+                return T(x > T(0));
+            }
+        }
+
+        template <class T>
+        struct sign_fun
+        {
+            using argument_type = T;
+            using result_type = T;
+
+            constexpr T operator()(const T& x) const
+            {
+                return detail::sign_impl(x);
+            }
+        };
+    }
+
+    /**
+     * @ingroup basic_functions
+     * @brief Returns an element-wise indication of the sign of a number
+     *
+     * If the number is positive, returns +1. If negative, -1. If the number
+     * is zero, returns 0.
+     *
+     * @param e an \ref xexpression
+     * @return an \ref xfunction
+     */
+    template <class E>
+    inline auto sign(E&& e) noexcept
+        -> detail::xfunction_type_t<math::sign_fun, E>
+    {
+        return detail::make_xfunction<math::sign_fun>(std::forward<E>(e));
+    }
+
+    /*************************
+     * exponential functions *
+     *************************/
+
+    /**
+     * @defgroup exp_functions Exponential functions
+     */
+
+    /**
+     * @ingroup exp_functions
+     * @brief Natural exponential function.
+     *
+     * Returns an \ref xfunction for the element-wise natural
+     * exponential of \em e.
+     * @param e an \ref xexpression
+     * @return an \ref xfunction
+     */
+    template <class E>
+    inline auto exp(E&& e) noexcept
+        -> detail::xfunction_type_t<math::exp_fun, E>
+    {
+        return detail::make_xfunction<math::exp_fun>(std::forward<E>(e));
+    }
+
+    /**
+     * @ingroup exp_functions
+     * @brief Base 2 exponential function.
+     *
+     * Returns an \ref xfunction for the element-wise base 2
+     * exponential of \em e.
+     * @param e an \ref xexpression
+     * @return an \ref xfunction
+     */
+    template <class E>
+    inline auto exp2(E&& e) noexcept
+        -> detail::xfunction_type_t<math::exp2_fun, E>
+    {
+        return detail::make_xfunction<math::exp2_fun>(std::forward<E>(e));
+    }
+
+    /**
+     * @ingroup exp_functions
+     * @brief Natural exponential minus one function.
+     *
+     * Returns an \ref xfunction for the element-wise natural
+     * exponential of \em e, minus 1.
+     * @param e an \ref xexpression
+     * @return an \ref xfunction
+     */
+    template <class E>
+    inline auto expm1(E&& e) noexcept
+        -> detail::xfunction_type_t<math::expm1_fun, E>
+    {
+        return detail::make_xfunction<math::expm1_fun>(std::forward<E>(e));
+    }
+
+    /**
+     * @ingroup exp_functions
+     * @brief Natural logarithm function.
+     *
+     * Returns an \ref xfunction for the element-wise natural
+     * logarithm of \em e.
+     * @param e an \ref xexpression
+     * @return an \ref xfunction
+     */
+    template <class E>
+    inline auto log(E&& e) noexcept
+        -> detail::xfunction_type_t<math::log_fun, E>
+    {
+        return detail::make_xfunction<math::log_fun>(std::forward<E>(e));
+    }
+
+    /**
+     * @ingroup exp_functions
+     * @brief Base 10 logarithm function.
+     *
+     * Returns an \ref xfunction for the element-wise base 10
+     * logarithm of \em e.
+     * @param e an \ref xexpression
+     * @return an \ref xfunction
+     */
+    template <class E>
+    inline auto log10(E&& e) noexcept
+        -> detail::xfunction_type_t<math::log10_fun, E>
+    {
+        return detail::make_xfunction<math::log10_fun>(std::forward<E>(e));
+    }
+
+    /**
+     * @ingroup exp_functions
+     * @brief Base 2 logarithm function.
+     *
+     * Returns an \ref xfunction for the element-wise base 2
+     * logarithm of \em e.
+     * @param e an \ref xexpression
+     * @return an \ref xfunction
+     */
+    template <class E>
+    inline auto log2(E&& e) noexcept
+        -> detail::xfunction_type_t<math::log2_fun, E>
+    {
+        return detail::make_xfunction<math::log2_fun>(std::forward<E>(e));
+    }
+
+    /**
+     * @ingroup exp_functions
+     * @brief Natural logarithm of one plus function.
+     *
+     * Returns an \ref xfunction for the element-wise natural
+     * logarithm of \em e, plus 1.
+     * @param e an \ref xexpression
+     * @return an \ref xfunction
+     */
+    template <class E>
+    inline auto log1p(E&& e) noexcept
+        -> detail::xfunction_type_t<math::log1p_fun, E>
+    {
+        return detail::make_xfunction<math::log1p_fun>(std::forward<E>(e));
+    }
+
+    /*******************
+     * power functions *
+     *******************/
+
+    /**
+     * @defgroup pow_functions Power functions
+     */
+
+    /**
+     * @ingroup pow_functions
+     * @brief Power function.
+     *
+     * Returns an \ref xfunction for the element-wise value of
+     * of \em e1 raised to the power \em e2.
+     * @param e1 an \ref xexpression or a scalar
+     * @param e2 an \ref xexpression or a scalar
+     * @return an \ref xfunction
+     * @note e1 and e2 can't be both scalars.
+     */
+    template <class E1, class E2>
+    inline auto pow(E1&& e1, E2&& e2) noexcept
+        -> detail::xfunction_type_t<math::pow_fun, E1, E2>
+    {
+        return detail::make_xfunction<math::pow_fun>(std::forward<E1>(e1), std::forward<E2>(e2));
+    }
+
+    /**
+     * @ingroup pow_functions
+     * @brief Square root function.
+     *
+     * Returns an \ref xfunction for the element-wise square 
+     * root of \em e.
+     * @param e an \ref xexpression
+     * @return an \ref xfunction
+     */
+    template <class E>
+    inline auto sqrt(E&& e) noexcept
+        -> detail::xfunction_type_t<math::sqrt_fun, E>
+    {
+        return detail::make_xfunction<math::sqrt_fun>(std::forward<E>(e));
+    }
+
+    /**
+     * @ingroup pow_functions
+     * @brief Cubic root function.
+     *
+     * Returns an \ref xfunction for the element-wise cubic
+     * root of \em e.
+     * @param e an \ref xexpression
+     * @return an \ref xfunction
+     */
+    template <class E>
+    inline auto cbrt(E&& e) noexcept
+        -> detail::xfunction_type_t<math::cbrt_fun, E>
+    {
+        return detail::make_xfunction<math::cbrt_fun>(std::forward<E>(e));
+    }
+
+    /**
+     * @ingroup pow_functions
+     * @brief Hypotenuse function.
+     *
+     * Returns an \ref xfunction for the element-wise square
+     * root of the sum of the square of \em e1 and \em e2, avoiding
+     * overflow and underflow at intermediate stages of computation.
+     * @param e1 an \ref xexpression or a scalar
+     * @param e2 an \ref xexpression or a scalar
+     * @return an \ref xfunction
+     * @note e1 and e2 can't be both scalars.
+     */
+    template <class E1, class E2>
+    inline auto hypot(E1&& e1, E2&& e2) noexcept
+        -> detail::xfunction_type_t<math::hypot_fun, E1, E2>
+    {
+        return detail::make_xfunction<math::hypot_fun>(std::forward<E1>(e1), std::forward<E2>(e2));
+    }
+
+    /***************************
+     * trigonometric functions *
+     ***************************/
+
+    /**
+     * @defgroup trigo_functions Trigonometric function
+     */
+
+    /**
+     * @ingroup trigo_functions
+     * @brief Sine function.
+     *
+     * Returns an \ref xfunction for the element-wise sine
+     * of \em e (measured in radians).
+     * @param e an \ref xexpression
+     * @return an \ref xfunction
+     */
+    template <class E>
+    inline auto sin(E&& e) noexcept
+        -> detail::xfunction_type_t<math::sin_fun, E>
+    {
+        return detail::make_xfunction<math::sin_fun>(std::forward<E>(e));
+    }
+
+    /**
+     * @ingroup trigo_functions
+     * @brief Cosine function.
+     *
+     * Returns an \ref xfunction for the element-wise cosine
+     * of \em e (measured in radians).
+     * @param e an \ref xexpression
+     * @return an \ref xfunction
+     */
+    template <class E>
+    inline auto cos(E&& e) noexcept
+        -> detail::xfunction_type_t<math::cos_fun, E>
+    {
+        return detail::make_xfunction<math::cos_fun>(std::forward<E>(e));
+    }
+
+    /**
+     * @ingroup trigo_functions
+     * @brief Tangent function.
+     *
+     * Returns an \ref xfunction for the element-wise tangent
+     * of \em e (measured in radians).
+     * @param e an \ref xexpression
+     * @return an \ref xfunction
+     */
+    template <class E>
+    inline auto tan(E&& e) noexcept
+        -> detail::xfunction_type_t<math::tan_fun, E>
+    {
+        return detail::make_xfunction<math::tan_fun>(std::forward<E>(e));
+    }
+
+    /**
+     * @ingroup trigo_functions
+     * @brief Arcsine function.
+     *
+     * Returns an \ref xfunction for the element-wise arcsine
+     * of \em e.
+     * @param e an \ref xexpression
+     * @return an \ref xfunction
+     */
+    template <class E>
+    inline auto asin(E&& e) noexcept
+        -> detail::xfunction_type_t<math::asin_fun, E>
+    {
+        return detail::make_xfunction<math::asin_fun>(std::forward<E>(e));
+    }
+
+    /**
+     * @ingroup trigo_functions
+     * @brief Arccosine function.
+     *
+     * Returns an \ref xfunction for the element-wise arccosine
+     * of \em e.
+     * @param e an \ref xexpression
+     * @return an \ref xfunction
+     */
+    template <class E>
+    inline auto acos(E&& e) noexcept
+        -> detail::xfunction_type_t<math::acos_fun, E>
+    {
+        return detail::make_xfunction<math::acos_fun>(std::forward<E>(e));
+    }
+
+    /**
+     * @ingroup trigo_functions
+     * @brief Arctangent function.
+     *
+     * Returns an \ref xfunction for the element-wise arctangent
+     * of \em e.
+     * @param e an \ref xexpression
+     * @return an \ref xfunction
+     */
+    template <class E>
+    inline auto atan(E&& e) noexcept
+        -> detail::xfunction_type_t<math::atan_fun, E>
+    {
+        return detail::make_xfunction<math::atan_fun>(std::forward<E>(e));
+    }
+
+    /**
+     * @ingroup trigo_functions
+     * @brief Artangent function, using signs to determine quadrants.
+     *
+     * Returns an \ref xfunction for the element-wise arctangent
+     * of <em>e1 / e2</em>, using the signs of arguments to determine the
+     * correct quadrant.
+     * @param e1 an \ref xexpression or a scalar
+     * @param e2 an \ref xexpression or a scalar
+     * @return an \ref xfunction
+     * @note e1 and e2 can't be both scalars.
+     */
+    template <class E1, class E2>
+    inline auto atan2(E1&& e1, E2&& e2) noexcept
+        -> detail::xfunction_type_t<math::atan2_fun, E1, E2>
+    {
+        return detail::make_xfunction<math::atan2_fun>(std::forward<E1>(e1), std::forward<E2>(e2));
+    }
+
+    /************************
+     * hyperbolic functions *
+     ************************/
+
+    /**
+     * @defgroup hyper_functions Hyperbolic functions
+     */
+
+    /**
+     * @ingroup hyper_functions
+     * @brief Hyperbolic sine function.
+     *
+     * Returns an \ref xfunction for the element-wise hyperbolic
+     * sine of \em e.
+     * @param e an \ref xexpression
+     * @return an \ref xfunction
+     */
+    template <class E>
+    inline auto sinh(E&& e) noexcept
+        -> detail::xfunction_type_t<math::sinh_fun, E>
+    {
+        return detail::make_xfunction<math::sinh_fun>(std::forward<E>(e));
+    }
+
+    /**
+     * @ingroup hyper_functions
+     * @brief Hyperbolic cosine function.
+     *
+     * Returns an \ref xfunction for the element-wise hyperbolic
+     * cosine of \em e.
+     * @param e an \ref xexpression
+     * @return an \ref xfunction
+     */
+    template <class E>
+    inline auto cosh(E&& e) noexcept
+        -> detail::xfunction_type_t<math::cosh_fun, E>
+    {
+        return detail::make_xfunction<math::cosh_fun>(std::forward<E>(e));
+    }
+
+    /**
+     * @ingroup hyper_functions
+     * @brief Hyperbolic tangent function.
+     *
+     * Returns an \ref xfunction for the element-wise hyperbolic
+     * tangent of \em e.
+     * @param e an \ref xexpression
+     * @return an \ref xfunction
+     */
+    template <class E>
+    inline auto tanh(E&& e) noexcept
+        -> detail::xfunction_type_t<math::tanh_fun, E>
+    {
+        return detail::make_xfunction<math::tanh_fun>(std::forward<E>(e));
+    }
+
+    /**
+     * @ingroup hyper_functions
+     * @brief Inverse hyperbolic sine function.
+     *
+     * Returns an \ref xfunction for the element-wise inverse hyperbolic
+     * sine of \em e.
+     * @param e an \ref xexpression
+     * @return an \ref xfunction
+     */
+    template <class E>
+    inline auto asinh(E&& e) noexcept
+        -> detail::xfunction_type_t<math::asinh_fun, E>
+    {
+        return detail::make_xfunction<math::asinh_fun>(std::forward<E>(e));
+    }
+
+    /**
+     * @ingroup hyper_functions
+     * @brief Inverse hyperbolic cosine function.
+     *
+     * Returns an \ref xfunction for the element-wise inverse hyperbolic
+     * cosine of \em e.
+     * @param e an \ref xexpression
+     * @return an \ref xfunction
+     */
+    template <class E>
+    inline auto acosh(E&& e) noexcept
+        -> detail::xfunction_type_t<math::acosh_fun, E>
+    {
+        return detail::make_xfunction<math::acosh_fun>(std::forward<E>(e));
+    }
+
+    /**
+     * @ingroup hyper_functions
+     * @brief Inverse hyperbolic tangent function.
+     *
+     * Returns an \ref xfunction for the element-wise inverse hyperbolic
+     * tangent of \em e.
+     * @param e an \ref xexpression
+     * @return an \ref xfunction
+     */
+    template <class E>
+    inline auto atanh(E&& e) noexcept
+        -> detail::xfunction_type_t<math::atanh_fun, E>
+    {
+        return detail::make_xfunction<math::atanh_fun>(std::forward<E>(e));
+    }
+
+    /*****************************
+     * error and gamma functions *
+     *****************************/
+
+    /**
+     * @defgroup err_functions Error and gamma functions
+     */
+
+    /**
+     * @ingroup err_functions
+     * @brief Error function.
+     *
+     * Returns an \ref xfunction for the element-wise error function
+     * of \em e.
+     * @param e an \ref xexpression
+     * @return an \ref xfunction
+     */
+    template <class E>
+    inline auto erf(E&& e) noexcept
+        -> detail::xfunction_type_t<math::erf_fun, E>
+    {
+        return detail::make_xfunction<math::erf_fun>(std::forward<E>(e));
+    }
+
+    /**
+     * @ingroup err_functions
+     * @brief Complementary error function.
+     *
+     * Returns an \ref xfunction for the element-wise complementary
+     * error function of \em e, whithout loss of precision for large argument.
+     * @param e an \ref xexpression
+     * @return an \ref xfunction
+     */
+    template <class E>
+    inline auto erfc(E&& e) noexcept
+        -> detail::xfunction_type_t<math::erfc_fun, E>
+    {
+        return detail::make_xfunction<math::erfc_fun>(std::forward<E>(e));
+    }
+
+    /**
+     * @ingroup err_functions
+     * @brief Gamma function.
+     *
+     * Returns an \ref xfunction for the element-wise gamma function
+     * of \em e.
+     * @param e an \ref xexpression
+     * @return an \ref xfunction
+     */
+    template <class E>
+    inline auto tgamma(E&& e) noexcept
+        -> detail::xfunction_type_t<math::tgamma_fun, E>
+    {
+        return detail::make_xfunction<math::tgamma_fun>(std::forward<E>(e));
+    }
+
+    /**
+     * @ingroup err_functions
+     * @brief Natural logarithm of the gamma function.
+     *
+     * Returns an \ref xfunction for the element-wise logarithm of
+     * the asbolute value fo the gamma function of \em e.
+     * @param e an \ref xexpression
+     * @return an \ref xfunction
+     */
+    template <class E>
+    inline auto lgamma(E&& e) noexcept
+        -> detail::xfunction_type_t<math::lgamma_fun, E>
+    {
+        return detail::make_xfunction<math::lgamma_fun>(std::forward<E>(e));
+    }
+
+    /*********************************************
+     * nearest integer floating point operations *
+     *********************************************/
+
+     /**
+      * @defgroup nearint_functions Nearest integer floating point operations
+      */
+
+      /**
+       * @ingroup nearint_functions
+       * @brief ceil function.
+       *
+       * Returns an \ref xfunction for the element-wise smallest integer value
+       * not less than \em e.
+       * @param e an \ref xexpression
+       * @return an \ref xfunction
+       */
+    template <class E>
+    inline auto ceil(E&& e) noexcept
+        -> detail::xfunction_type_t<math::ceil_fun, E>
+    {
+        return detail::make_xfunction<math::ceil_fun>(std::forward<E>(e));
+    }
+
+    /**
+    * @ingroup nearint_functions
+    * @brief floor function.
+    *
+    * Returns an \ref xfunction for the element-wise smallest integer value
+    * not greater than \em e.
+    * @param e an \ref xexpression
+    * @return an \ref xfunction
+    */
+    template <class E>
+    inline auto floor(E&& e) noexcept
+        -> detail::xfunction_type_t<math::floor_fun, E>
+    {
+        return detail::make_xfunction<math::floor_fun>(std::forward<E>(e));
+    }
+
+    /**
+    * @ingroup nearint_functions
+    * @brief trunc function.
+    *
+    * Returns an \ref xfunction for the element-wise nearest integer not greater
+    * in magnitude than \em e.
+    * @param e an \ref xexpression
+    * @return an \ref xfunction
+    */
+    template <class E>
+    inline auto trunc(E&& e) noexcept
+        -> detail::xfunction_type_t<math::trunc_fun, E>
+    {
+        return detail::make_xfunction<math::trunc_fun>(std::forward<E>(e));
+    }
+
+    /**
+     * @ingroup nearint_functions
+     * @brief round function.
+     *
+     * Returns an \ref xfunction for the element-wise nearest integer value
+     * to \em e, rounding halfway cases away from zero, regardless of the
+     * current rounding mode.
+     * @param e an \ref xexpression
+     * @return an \ref xfunction
+     */
+    template <class E>
+    inline auto round(E&& e) noexcept
+        -> detail::xfunction_type_t<math::round_fun, E>
+    {
+        return detail::make_xfunction<math::round_fun>(std::forward<E>(e));
+    }
+
+    /**
+     * @ingroup nearint_functions
+     * @brief nearbyint function.
+     *
+     * Returns an \ref xfunction for the element-wise rounding of \em e to integer
+     * values in floating point format, using the current rounding mode. nearbyint
+     * never raises FE_INEXACT error.
+     * @param e an \ref xexpression
+     * @return an \ref xfunction
+     */
+    template <class E>
+    inline auto nearbyint(E&& e) noexcept
+        -> detail::xfunction_type_t<math::nearbyint_fun, E>
+    {
+        return detail::make_xfunction<math::nearbyint_fun>(std::forward<E>(e));
+    }
+
+    /**
+     * @ingroup nearint_functions
+     * @brief rint function.
+     *
+     * Returns an \ref xfunction for the element-wise rounding of \em e to integer
+     * values in floating point format, using the current rounding mode. Contrary
+     * to nearbyint, rint may raise FE_INEXACT error.
+     * @param e an \ref xexpression
+     * @return an \ref xfunction
+     */
+    template <class E>
+    inline auto rint(E&& e) noexcept
+        -> detail::xfunction_type_t<math::rint_fun, E>
+    {
+        return detail::make_xfunction<math::rint_fun>(std::forward<E>(e));
+    }
+
+    /****************************
+     * classification functions *
+     ****************************/
+
+    /**
+     * @defgroup classif_functions Classification functions
+     */
+      
+    /**
+     * @ingroup classif_functions
+     * @brief finite value check
+     *
+     * Returns an \ref xfunction for the element-wise finite value check
+     * tangent of \em e.
+     * @param e an \ref xexpression
+     * @return an \ref xfunction
+     */
+    template <class E>
+    inline auto isfinite(E&& e) noexcept
+        -> detail::xfunction_type_t<math::isfinite_fun, E>
+    {
+        return detail::make_xfunction<math::isfinite_fun>(std::forward<E>(e));
+    }
+
+    /**
+     * @ingroup classif_functions
+     * @brief infinity check
+     *
+     * Returns an \ref xfunction for the element-wise infinity check
+     * tangent of \em e.
+     * @param e an \ref xexpression
+     * @return an \ref xfunction
+     */
+    template <class E>
+    inline auto isinf(E&& e) noexcept
+        -> detail::xfunction_type_t<math::isinf_fun, E>
+    {
+        return detail::make_xfunction<math::isinf_fun>(std::forward<E>(e));
+    }
+
+    /**
+     * @ingroup classif_functions
+     * @brief NaN check
+     *
+     * Returns an \ref xfunction for the element-wise NaN check
+     * tangent of \em e.
+     * @param e an \ref xexpression
+     * @return an \ref xfunction
+     */
+    template <class E>
+    inline auto isnan(E&& e) noexcept
+        -> detail::xfunction_type_t<math::isnan_fun, E>
+    {
+        return detail::make_xfunction<math::isnan_fun>(std::forward<E>(e));
+    }
+
+    namespace detail
+    {
+        template <class FUNCTOR, class T, std::size_t... Is>
+        inline auto get_functor(T&& args, std::index_sequence<Is...>)
+        {
+            return FUNCTOR(std::get<Is>(args)...);
+        }
+
+        template <template <class...> class F, class... A, class... E>
+        inline auto make_xfunction(std::tuple<A...>&& f_args, E&&... e) noexcept
+        {
+            using functor_type = F<common_value_type_t<std::decay_t<E>...>>;
+            using result_type = typename functor_type::result_type;
+            using type = xfunction<functor_type, result_type, const_xclosure_t<E>...>;
+            auto functor = get_functor<functor_type>(
+                std::forward<std::tuple<A...>>(f_args),
+                std::make_index_sequence<sizeof...(A)>{}
+            );
+            return type(std::move(functor), std::forward<E>(e)...);
+        }
+
+        template <class T>
+        struct isclose
+        {
+            using result_type = bool;
+            isclose(double rtol, double atol, bool equal_nan)
+                : m_rtol(rtol), m_atol(atol), m_equal_nan(equal_nan)
+            {}
+
+            bool operator()(const T& a, const T& b) const
+            {
+                if (m_equal_nan && std::isnan(a) && std::isnan(b))
+                {
+                    return true;
+                }
+                return std::abs(a - b) <= (m_atol + m_rtol * std::abs(b));
+            }
+
+        private:
+            double m_rtol;
+            double m_atol;
+            bool m_equal_nan;
+        };
+    }
+
+    /**
+     * @ingroup classif_functions
+     * @brief Element-wise closeness detection
+     *
+     * Returns an \ref xfunction that evaluates to
+     * true if the elements in ``e1`` and ``e2`` are close to each other
+     * according to parameters ``atol`` and ``rtol``.
+     * The equation is: ``std::abs(a - b) <= (m_atol + m_rtol * std::abs(b))``.
+     * @param e1 input array to compare
+     * @param e2 input array to compare
+     * @param rtol the relative tolerance parameter (default 1e-05)
+     * @param atol the absolute tolerance parameter (default 1e-08)
+     * @param equal_nan if true, isclose returns true if both elements of e1 and e2 are NaN
+     * @return an \ref xfunction
+     */
+    template <class E1, class E2>
+    inline auto isclose(E1&& e1, E2&& e2, double rtol = 1e-05, double atol = 1e-08, bool equal_nan = false) noexcept
+    {
+        return detail::make_xfunction<detail::isclose>(std::make_tuple(rtol, atol, equal_nan),
+                                                       std::forward<E1>(e1), std::forward<E2>(e2));
+    }
+
+    /**
+     * @ingroup classif_functions
+     * @brief Check if all elements in \em e1 are close to the
+     * corresponding elements in \em e2.
+     *
+     * Returns true if all elements in ``e1`` and ``e2`` are close to each other
+     * according to parameters ``atol`` and ``rtol``.
+     * @param e1 input array to compare
+     * @param e2 input arrays to compare
+     * @param rtol the relative tolerance parameter (default 1e-05)
+     * @param atol the absolute tolerance parameter (default 1e-08)
+     * @return a boolean
+     */
+    template <class E1, class E2>
+    inline auto allclose(E1&& e1, E2&& e2, double rtol = 1e-05, double atol = 1e-08) noexcept
+    {
+        return xt::all(isclose(std::forward<E1>(e1), std::forward<E2>(e2), rtol, atol));
+    }
+
+    /**********************
+     * Reducing functions *
+     **********************/
+
+    /**
+     * @defgroup  red_functions reducing functions
+     */
+
+    /**
+     * @ingroup red_functions
+     * @brief Sum of elements over given axes.
+     *
+     * Returns an \ref xreducer for the sum of elements over given
+     * \em axes.
+     * @param e an \ref xexpression
+     * @param axes the axes along which the sum is performed (optional)
+     * @return an \ref xreducer
+     */
+    template <class E, class X>
+    inline auto sum(E&& e, X&& axes) noexcept
+    {
+        using functor_type = std::plus<typename std::decay_t<E>::value_type>;
+        return reduce(functor_type(), std::forward<E>(e), std::forward<X>(axes));
+    }
+
+    template <class E>
+    inline auto sum(E&& e) noexcept
+    {
+        using functor_type = std::plus<typename std::decay_t<E>::value_type>;
+        return reduce(functor_type(), std::forward<E>(e));
+    }
+
+#ifdef X_OLD_CLANG
+    template <class E, class I>
+    inline auto sum(E&& e, std::initializer_list<I> axes) noexcept
+    {
+        using functor_type = std::plus<typename std::decay_t<E>::value_type>;
+        return reduce(functor_type(), std::forward<E>(e), axes);
+    }
+#else
+    template <class E, class I, std::size_t N>
+    inline auto sum(E&& e, const I (&axes)[N]) noexcept
+    {
+        using functor_type = std::plus<typename std::decay_t<E>::value_type>;
+        return reduce(functor_type(), std::forward<E>(e), axes);
+    }
+#endif
+
+    /**
+     * @ingroup red_functions
+     * @brief Product of elements over given axes.
+     *
+     * Returns an \ref xreducer for the product of elements over given
+     * \em axes.
+     * @param e an \ref xexpression
+     * @param axes the axes along which the product is computed (optional)
+     * @return an \ref xreducer
+     */
+    template <class E, class X>
+    inline auto prod(E&& e, X&& axes) noexcept
+    {
+        using functor_type = std::multiplies<typename std::decay_t<E>::value_type>;
+        return reduce(functor_type(), std::forward<E>(e), std::forward<X>(axes));
+    }
+
+    template <class E>
+    inline auto prod(E&& e) noexcept
+    {
+        using functor_type = std::multiplies<typename std::decay_t<E>::value_type>;
+        return reduce(functor_type(), std::forward<E>(e));
+    }
+
+#ifdef X_OLD_CLANG
+    template <class E, class I>
+    inline auto prod(E&& e, std::initializer_list<I> axes) noexcept
+    {
+        using functor_type = std::multiplies<typename std::decay_t<E>::value_type>;
+        return reduce(functor_type(), std::forward<E>(e), axes);
+    }
+#else
+    template <class E, class I, std::size_t N>
+    inline auto prod(E&& e, const I (&axes)[N]) noexcept
+    {
+        using functor_type = std::multiplies<typename std::decay_t<E>::value_type>;
+        return reduce(functor_type(), std::forward<E>(e), axes);
+    }
+#endif
+
+    /**
+     * @ingroup red_functions
+     * @brief Mean of elements over given axes.
+     *
+     * Returns an \ref xreducer for the mean of elements over given
+     * \em axes.
+     * @param e an \ref xexpression
+     * @param axes the axes along which the mean is computed (optional)
+     * @return an \ref xexpression
+     */
+    template <class E, class X>
+    inline auto mean(E&& e, X&& axes) noexcept
+    {
+        using value_type = typename std::decay_t<E>::value_type;
+        auto size = e.size();
+        auto s = sum(std::forward<E>(e), std::forward<X>(axes));
+        return std::move(s) / value_type(size / s.size());
+    }
+
+    template <class E>
+    inline auto mean(E&& e) noexcept
+    {
+        using value_type = typename std::decay_t<E>::value_type;
+        auto size = e.size();
+        return sum(std::forward<E>(e)) / value_type(size);
+    }
+
+#ifdef X_OLD_CLANG
+    template <class E, class I>
+    inline auto mean(E&& e, std::initializer_list<I> axes) noexcept
+    {
+        using value_type = typename std::decay_t<E>::value_type;
+        auto size = e.size();
+        auto s = sum(std::forward<E>(e), axes);
+        return std::move(s) / value_type(size / s.size());
+    }
+#else
+    template <class E, class I, std::size_t N>
+    inline auto mean(E&& e, const I (&axes)[N]) noexcept
+    {
+        using value_type = typename std::decay_t<E>::value_type;
+        auto size = e.size();
+        auto s = sum(std::forward<E>(e), axes);
+        return std::move(s) / value_type(size / s.size());
+    }
+#endif
+}
+
+#endif

--- a/inst/include/xtensor/xmissing.hpp
+++ b/inst/include/xtensor/xmissing.hpp
@@ -1,0 +1,640 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XMISSING_HPP
+#define XMISSING_HPP
+
+#include <array>
+#include <cstddef>
+#include <iterator>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "xarray.hpp"
+#include "xfunctorview.hpp"
+#include "xoptional.hpp"
+#include "xtensor.hpp"
+#include "xtensor_forward.hpp"
+#include "xutils.hpp"
+
+namespace xt
+{
+
+    /**************************************
+     * Optimized 1-D xoptional containers *
+     **************************************/
+
+    template <class T>
+    struct xoptional_sequence_inner_types;
+
+    template <class ITV, class ITB>
+    class xoptional_iterator;
+
+    template <class D>
+    class xoptional_sequence
+    {
+    public:
+        // Internal typedefs
+        using inner_types = xoptional_sequence_inner_types<D>;
+
+        using base_container_type = typename inner_types::base_container_type;
+        using base_value_type = typename base_container_type::value_type;
+        using base_reference = typename base_container_type::reference;
+        using base_const_reference = typename base_container_type::const_reference;
+
+        using flag_container_type = typename inner_types::flag_container_type;
+        using flag_type = typename flag_container_type::value_type;
+        using flag_reference = typename flag_container_type::reference;
+        using flag_const_reference = typename flag_container_type::const_reference;
+
+        // Container typedefs
+        using value_type = xoptional<base_value_type, flag_type>;
+        using reference = xoptional<base_reference, flag_reference>;
+        using const_reference = xoptional<base_const_reference, flag_const_reference>;
+        using pointer = std::nullptr_t;
+        using const_pointer = std::nullptr_t;
+
+        // Other typedefs
+        using size_type = typename base_container_type::size_type;
+        using difference_type = typename base_container_type::difference_type;
+        using iterator = xoptional_iterator<typename base_container_type::iterator,
+                                            typename flag_container_type::iterator>;
+        using const_iterator = xoptional_iterator<typename base_container_type::const_iterator,
+                                                  typename flag_container_type::const_iterator>;
+
+        using reverse_iterator = xoptional_iterator<typename base_container_type::reverse_iterator,
+                                                    typename flag_container_type::reverse_iterator>;
+        using const_reverse_iterator = xoptional_iterator<typename base_container_type::const_reverse_iterator,
+                                                          typename flag_container_type::const_reverse_iterator>;
+
+        xoptional_sequence() = default;
+        xoptional_sequence(size_type s, const base_value_type& v);
+
+        template <class CTO, class CBO>
+        xoptional_sequence(size_type s, const xoptional<CTO, CBO>& v);
+
+        bool empty() const noexcept;
+        size_type size() const noexcept;
+
+        reference operator[](size_type i);
+        const_reference operator[](size_type i) const;
+
+        reference front();
+        const_reference front() const;
+
+        reference back();
+        const_reference back() const;
+
+        iterator begin() noexcept;
+        iterator end() noexcept;
+
+        const_iterator begin() const noexcept;
+        const_iterator end() const noexcept;
+        const_iterator cbegin() const noexcept;
+        const_iterator cend() const noexcept;
+
+        reverse_iterator rbegin() noexcept;
+        reverse_iterator rend() noexcept;
+
+        const_reverse_iterator rbegin() const noexcept;
+        const_reverse_iterator rend() const noexcept;
+        const_reverse_iterator crbegin() const noexcept;
+        const_reverse_iterator crend() const noexcept;
+
+    protected:
+
+        base_container_type m_values;
+        flag_container_type m_flags;
+    };
+
+    /****************************************************
+     * xoptional_vector and xoptional_array inner types *
+     ****************************************************/
+
+    template <class T, std::size_t I>
+    class xoptional_array;
+
+    template <class T, std::size_t I>
+    struct xoptional_sequence_inner_types<xoptional_array<T, I>>
+    {
+        using base_container_type = std::array<T, I>;
+        using flag_container_type = std::array<bool, I>;
+    };
+
+    template <class T, class A, class BA>
+    class xoptional_vector;
+
+    template <class T, class A, class BA>
+    struct xoptional_sequence_inner_types<xoptional_vector<T, A, BA>>
+    {
+        using base_container_type = std::vector<T, A>;
+        using flag_container_type = std::vector<bool, BA>;
+    };
+
+    /*****************************************************
+     * xoptional_vector and xoptional_array declarations *
+     *****************************************************/
+
+    template <class T, std::size_t I>
+    class xoptional_array : public xoptional_sequence<xoptional_array<T, I>>
+    {
+    public:
+
+        using self_type = xoptional_array;
+        using base_type = xoptional_sequence<self_type>;
+        using base_value_type = typename base_type::base_value_type;
+        using size_type = typename base_type::size_type;
+
+        xoptional_array() = default;
+        xoptional_array(size_type s, const base_value_type& v);
+
+        template <class CTO, class CBO>
+        xoptional_array(size_type s, const xoptional<CTO, CBO>& v);
+    };
+
+    template <class T, class A = std::allocator<T>, class BA = std::allocator<bool>>
+    class xoptional_vector : public xoptional_sequence<xoptional_vector<T, A, BA>>
+    {
+    public:
+
+        using self_type = xoptional_vector;
+        using base_type = xoptional_sequence<self_type>;
+        using base_value_type = typename base_type::base_value_type;
+
+        using value_type = typename base_type::value_type;
+        using size_type = typename base_type::size_type;
+        using difference_type = typename base_type::difference_type;
+        using reference = typename base_type::reference;
+        using const_reference = typename base_type::const_reference;
+        using pointer = typename base_type::pointer;
+        using const_pointer = typename base_type::const_pointer;
+
+        using iterator = typename base_type::iterator;
+        using const_iterator = typename base_type::const_iterator;
+        using reverse_iterator = typename base_type::reverse_iterator;
+        using const_reverse_iterator = typename base_type::const_reverse_iterator;
+
+        xoptional_vector() = default;
+        xoptional_vector(size_type, const base_value_type&);
+
+        template <class CTO, class CBO>
+        xoptional_vector(size_type, const xoptional<CTO, CBO>&);
+
+        void resize(size_type);
+        void resize(size_type, const base_value_type&);
+        template <class CTO, class CBO>
+        void resize(size_type, const xoptional<CTO, CBO>&);
+    };
+
+    /**********************************
+     * xoptional_iterator declaration *
+     **********************************/
+
+    template <class ITV, class ITB>
+    class xoptional_iterator
+    {
+    public:
+
+        using self_type = xoptional_iterator<ITV, ITB>;
+
+        // Internal typedefs
+        using base_value_type = typename ITV::value_type;
+        using base_reference = typename ITV::reference;
+
+        using flag_type = typename ITB::value_type;
+        using flag_reference = typename ITB::reference;
+
+        // Container typedefs
+        using value_type = xoptional<base_value_type, flag_type>;
+        using reference = xoptional<base_reference, flag_reference>;
+
+        using pointer = std::nullptr_t;
+        using difference_type = typename ITV::difference_type;
+        using iterator_category = std::random_access_iterator_tag;
+
+        xoptional_iterator() = default;
+        xoptional_iterator(ITV itv, ITB itb);
+
+        self_type& operator++();
+        self_type operator++(int);
+
+        reference operator*() const;
+        pointer operator->() const;
+
+        self_type& operator--();
+        self_type operator--(int);
+
+        self_type& operator+=(difference_type n);
+        self_type& operator-=(difference_type n);
+
+        self_type operator+(difference_type n) const;
+        self_type operator-(difference_type n) const;
+        difference_type operator-(const self_type& rhs) const;
+
+        bool equal(const xoptional_iterator& rhs) const;
+
+    private:
+
+        ITV m_itv;
+        ITB m_itb;
+    };
+
+    template <class ITV, class ITB>
+    bool operator==(const xoptional_iterator<ITV, ITB>&, const xoptional_iterator<ITV, ITB>&);
+
+    template <class ITV, class ITB>
+    bool operator!=(const xoptional_iterator<ITV, ITB>&, const xoptional_iterator<ITV, ITB>&);
+
+    /*************************************
+     * xoptional_sequence implementation *
+     *************************************/
+
+    template <class D>
+    xoptional_sequence<D>::xoptional_sequence(size_type s, const base_value_type& v)
+        : m_values(make_sequence<base_container_type>(s, v)),
+          m_flags(make_sequence<flag_container_type>(s, true))
+    {
+    }
+
+    template <class D>
+    template <class CTO, class CBO>
+    xoptional_sequence<D>::xoptional_sequence(size_type s, const xoptional<CTO, CBO>& v)
+        : m_values(make_sequence<base_container_type>(s, v.value())), m_flags(make_sequence<flag_container_type>(s, v.has_value()))
+    {
+    }
+
+    template <class D>
+    auto xoptional_sequence<D>::empty() const noexcept -> bool
+    {
+        return m_values.empty();
+    }
+
+    template <class D>
+    auto xoptional_sequence<D>::size() const noexcept -> size_type
+    {
+        return m_values.size();
+    }
+
+    template <class D>
+    auto xoptional_sequence<D>::operator[](size_type i) -> reference
+    {
+        return reference(m_values[i], m_flags[i]);
+    }
+
+    template <class D>
+    auto xoptional_sequence<D>::operator[](size_type i) const -> const_reference
+    {
+        return const_reference(m_values[i], m_flags[i]);
+    }
+
+    template <class D>
+    auto xoptional_sequence<D>::front() -> reference
+    {
+        return reference(m_values.front(), m_flags.front());
+    }
+
+    template <class D>
+    auto xoptional_sequence<D>::front() const -> const_reference
+    {
+        return const_reference(m_values.front(), m_flags.front());
+    }
+
+    template <class D>
+    auto xoptional_sequence<D>::back() -> reference
+    {
+        return reference(m_values.back(), m_flags.back());
+    }
+
+    template <class D>
+    auto xoptional_sequence<D>::back() const -> const_reference
+    {
+        return const_reference(m_values.back(), m_flags.back());
+    }
+
+    template <class D>
+    auto xoptional_sequence<D>::begin() noexcept -> iterator
+    {
+        return iterator(m_values.begin(), m_flags.begin());
+    }
+
+    template <class D>
+    auto xoptional_sequence<D>::end() noexcept -> iterator
+    {
+        return iterator(m_values.end(), m_flags.end());
+    }
+
+    template <class D>
+    auto xoptional_sequence<D>::begin() const noexcept -> const_iterator
+    {
+        return cbegin();
+    }
+
+    template <class D>
+    auto xoptional_sequence<D>::end() const noexcept -> const_iterator
+    {
+        return cend();
+    }
+
+    template <class D>
+    auto xoptional_sequence<D>::cbegin() const noexcept -> const_iterator
+    {
+        return const_iterator(m_values.cbegin(), m_flags.cbegin());
+    }
+
+    template <class D>
+    auto xoptional_sequence<D>::cend() const noexcept -> const_iterator
+    {
+        return const_iterator(m_values.cend(), m_flags.cend());
+    }
+
+    template <class D>
+    auto xoptional_sequence<D>::rbegin() noexcept -> reverse_iterator
+    {
+        return reverse_iterator(m_values.rbegin(), m_flags.rbegin());
+    }
+
+    template <class D>
+    auto xoptional_sequence<D>::rend() noexcept -> reverse_iterator
+    {
+        return reverse_iterator(m_values.rend(), m_flags.rend());
+    }
+
+    template <class D>
+    auto xoptional_sequence<D>::rbegin() const noexcept -> const_reverse_iterator
+    {
+        return crbegin();
+    }
+
+    template <class D>
+    auto xoptional_sequence<D>::rend() const noexcept -> const_reverse_iterator
+    {
+        return crend();
+    }
+
+    template <class D>
+    auto xoptional_sequence<D>::crbegin() const noexcept -> const_reverse_iterator
+    {
+        return const_reverse_iterator(m_values.crbegin(), m_flags.crbegin());
+    }
+
+    template <class D>
+    auto xoptional_sequence<D>::crend() const noexcept -> const_reverse_iterator
+    {
+        return const_reverse_iterator(m_values.crend(), m_flags.crend());
+    }
+
+    /*******************************************************
+     * xoptional_array and xoptional_vector implementation *
+     *******************************************************/
+
+    template <class T, std::size_t I>
+    xoptional_array<T, I>::xoptional_array(size_type s, const base_value_type& v)
+        : base_type(s, v)
+    {
+    }
+
+    template <class T, std::size_t I>
+    template <class CTO, class CBO>
+    xoptional_array<T, I>::xoptional_array(size_type s, const xoptional<CTO, CBO>& v)
+        : base_type(s, v)
+    {
+    }
+
+    template <class T, class A, class BA>
+    xoptional_vector<T, A, BA>::xoptional_vector(size_type s, const base_value_type& v)
+        : base_type(s, v)
+    {
+    }
+
+    template <class T, class A, class BA>
+    template <class CTO, class CBO>
+    xoptional_vector<T, A, BA>::xoptional_vector(size_type s, const xoptional<CTO, CBO>& v)
+        : base_type(s, v)
+    {
+    }
+
+    template <class T, class A, class BA>
+    void xoptional_vector<T, A, BA>::resize(size_type s)
+    {
+        // Default to missing
+        this->m_values.resize(s);
+        this->m_flags.resize(s, false);
+    }
+
+    template <class T, class A, class BA>
+    void xoptional_vector<T, A, BA>::resize(size_type s, const base_value_type& v)
+    {
+        this->m_values.resize(s, v);
+        this->m_flags.resize(s, true);
+    }
+
+    template <class T, class A, class BA>
+    template <class CTO, class CBO>
+    void xoptional_vector<T, A, BA>::resize(size_type s, const xoptional<CTO, CBO>& v)
+    {
+        this->m_values.resize(s, v.value());
+        this->m_flags.resize(s, v.has_value());
+    }
+
+    /*************************************
+     * xoptional_iterator implementation *
+     *************************************/
+
+    template <class ITV, class ITB>
+    xoptional_iterator<ITV, ITB>::xoptional_iterator(ITV itv, ITB itb)
+        : m_itv(itv), m_itb(itb)
+    {
+    }
+
+    template <class ITV, class ITB>
+    auto xoptional_iterator<ITV, ITB>::operator++() -> self_type&
+    {
+        ++m_itv;
+        ++m_itb;
+        return *this;
+    }
+
+    template <class ITV, class ITB>
+    auto xoptional_iterator<ITV, ITB>::operator++(int) -> self_type
+    {
+        self_type tmp(*this);
+        ++(*this);
+        return tmp;
+    }
+
+    template <class ITV, class ITB>
+    auto xoptional_iterator<ITV, ITB>::operator--() -> self_type&
+    {
+        --m_itv;
+        --m_itb;
+        return *this;
+    }
+
+    template <class ITV, class ITB>
+    auto xoptional_iterator<ITV, ITB>::operator--(int) -> self_type
+    {
+        self_type tmp(*this);
+        --(*this);
+        return tmp;
+    }
+
+    template <class ITV, class ITB>
+    auto xoptional_iterator<ITV, ITB>::operator+=(difference_type n) -> self_type&
+    {
+        m_itv += n;
+        m_itb += n;
+        return *this;
+    }
+
+    template <class ITV, class ITB>
+    auto xoptional_iterator<ITV, ITB>::operator-=(difference_type n) -> self_type&
+    {
+        m_itv -= n;
+        m_itb -= n;
+        return *this;
+    }
+
+    template <class ITV, class ITB>
+    auto xoptional_iterator<ITV, ITB>::operator+(difference_type n) const -> self_type
+    {
+        return self_type(m_itv + n, m_itb + n);
+    }
+
+    template <class ITV, class ITB>
+    auto xoptional_iterator<ITV, ITB>::operator-(difference_type n) const -> self_type
+    {
+        return self_type(m_itv - n, m_itb - n);
+    }
+
+    template <class ITV, class ITB>
+    auto xoptional_iterator<ITV, ITB>::operator-(const self_type& rhs) const -> difference_type
+    {
+        return m_itv - rhs.m_itv;
+    }
+
+    template <class ITV, class ITB>
+    auto xoptional_iterator<ITV, ITB>::operator*() const -> reference
+    {
+        return reference(*m_itv, *m_itb);
+    }
+
+    template <class ITV, class ITB>
+    auto xoptional_iterator<ITV, ITB>::operator-> () const -> std::nullptr_t
+    {
+        return nullptr;
+    }
+
+    template <class ITV, class ITB>
+    auto xoptional_iterator<ITV, ITB>::equal(const xoptional_iterator& rhs) const -> bool
+    {
+        return m_itv == rhs.m_itv && m_itb == rhs.m_itb;
+    }
+
+    template <class ITV, class ITB>
+    bool operator==(const xoptional_iterator<ITV, ITB>& lhs, const xoptional_iterator<ITV, ITB>& rhs)
+    {
+        return lhs.equal(rhs);
+    }
+
+    template <class ITV, class ITB>
+    bool operator!=(const xoptional_iterator<ITV, ITB>& lhs, const xoptional_iterator<ITV, ITB>& rhs)
+    {
+        return !lhs.equal(rhs);
+    }
+
+    /*******************************************************
+     * value() and has_value() xfunctorview implementation *
+     *******************************************************/
+
+    namespace detail
+    {
+        template <class E>
+        struct value_forwarder
+        {
+            // internal types
+            using xexpression_type = std::decay_t<E>;
+            using optional_type = typename xexpression_type::value_type;
+            using optional_reference = typename xexpression_type::reference;
+            using optional_const_reference = typename xexpression_type::const_reference;
+
+            // types
+            using value_type = typename optional_type::value_type;
+            using reference = typename optional_reference::value_closure;
+            using const_reference = typename optional_const_reference::value_closure;
+            using pointer = value_type*;
+            using const_pointer = const value_type*;
+ 
+            template <class T>
+            decltype(auto) operator()(T&&t) const
+            {
+                return std::forward<T>(t).value();
+            }
+        };
+
+        template <class E>
+        struct flag_forwarder
+        {
+            // internal types
+            using xexpression_type = std::decay_t<E>;
+            using optional_type = typename xexpression_type::value_type;
+            using optional_reference = typename xexpression_type::reference;
+            using optional_const_reference = typename xexpression_type::const_reference;
+
+            // types
+            using value_type = typename optional_type::flag_type;
+            using reference = typename optional_reference::flag_closure;
+            using const_reference = typename optional_const_reference::flag_closure;
+            using pointer = value_type*;
+            using const_pointer = const value_type*;
+
+            template <class T>
+            decltype(auto) operator()(T&&t) const
+            {
+                return std::forward<T>(t).has_value();
+            }
+        };
+    }
+
+    template <class E>
+    auto value(E&& e)
+        -> disable_xoptional<typename std::decay_t<E>::value_type, E>
+    {
+        return std::forward<E>(e);
+    }
+
+    template <class E>
+    auto has_value(E&& e)
+        -> disable_xoptional<typename std::decay_t<E>::value_type, decltype(ones<bool>(std::forward<E>(e).shape()))>
+    {
+        return ones<bool>(std::forward<E>(e).shape());
+    }
+
+    template <class E>
+    auto value(E&& e)
+        -> enable_xoptional<typename std::decay_t<E>::value_type, xfunctorview<detail::value_forwarder<E>, xclosure_t<E>>>
+    {
+        using type = xfunctorview<detail::value_forwarder<E>, xclosure_t<E>>;
+        return type(std::forward<E>(e));
+    }
+
+    template <class E>
+    auto has_value(E&& e)
+        -> enable_xoptional<typename std::decay_t<E>::value_type, xfunctorview<detail::flag_forwarder<E>, xclosure_t<E>>>
+    {
+        using type = xfunctorview<detail::flag_forwarder<E>, xclosure_t<E>>;
+        return type(std::forward<E>(e));
+    }
+
+    /***************************
+     * value_or implementation *
+     ***************************/
+
+}
+
+#endif

--- a/inst/include/xtensor/xnoalias.hpp
+++ b/inst/include/xtensor/xnoalias.hpp
@@ -1,0 +1,100 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XNOALIAS_HPP
+#define XNOALIAS_HPP
+
+#include "xsemantic.hpp"
+
+namespace xt
+{
+
+    template <class A>
+    class noalias_proxy
+    {
+
+    public:
+
+        noalias_proxy(A& a) noexcept;
+
+        template <class E>
+        A& operator=(const xexpression<E>& e);
+
+        template <class E>
+        A& operator+=(const xexpression<E>& e);
+
+        template <class E>
+        A& operator-=(const xexpression<E>& e);
+
+        template <class E>
+        A& operator*=(const xexpression<E>& e);
+
+        template <class E>
+        A& operator/=(const xexpression<E>& e);
+
+    private:
+
+        A& m_array;
+    };
+
+    template <class A>
+    noalias_proxy<A> noalias(A& a) noexcept;
+
+    /********************************
+     * noalias_proxy implementation *
+     ********************************/
+
+    template <class A>
+    inline noalias_proxy<A>::noalias_proxy(A& a) noexcept
+        : m_array(a)
+    {
+    }
+
+    template <class A>
+    template <class E>
+    inline A& noalias_proxy<A>::operator=(const xexpression<E>& e)
+    {
+        return m_array.assign(e);
+    }
+
+    template <class A>
+    template <class E>
+    inline A& noalias_proxy<A>::operator+=(const xexpression<E>& e)
+    {
+        return m_array.plus_assign(e);
+    }
+
+    template <class A>
+    template <class E>
+    inline A& noalias_proxy<A>::operator-=(const xexpression<E>& e)
+    {
+        return m_array.minus_assign(e);
+    }
+
+    template <class A>
+    template <class E>
+    inline A& noalias_proxy<A>::operator*=(const xexpression<E>& e)
+    {
+        return m_array.multiplies_assign(e);
+    }
+
+    template <class A>
+    template <class E>
+    inline A& noalias_proxy<A>::operator/=(const xexpression<E>& e)
+    {
+        return m_array.divides_assign(e);
+    }
+
+    template <class A>
+    inline noalias_proxy<A> noalias(A& a) noexcept
+    {
+        return noalias_proxy<A>(a);
+    }
+}
+
+#endif

--- a/inst/include/xtensor/xoffsetview.hpp
+++ b/inst/include/xtensor/xoffsetview.hpp
@@ -1,0 +1,40 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XOFFSETVIEW_HPP
+#define XOFFSETVIEW_HPP
+
+#include "xtensor/xfunctorview.hpp"
+
+namespace xt
+{
+    namespace detail
+    {
+        template <class M, std::size_t I>
+        struct offset_forwarder
+        {
+            using value_type = M;
+            using reference = M&;
+            using const_reference = const M&;
+            using pointer = M*;
+            using const_pointer = const M*;
+           
+            template <class T>
+            decltype(auto) operator()(T&&t) const
+            {
+                return forward_offset<M, I>(t);
+            }
+        };
+    }
+
+        
+    template <class CT, class M, std::size_t I>
+    using xoffsetview = xfunctorview<detail::offset_forwarder<M, I>, CT>;
+}
+
+#endif

--- a/inst/include/xtensor/xoperation.hpp
+++ b/inst/include/xtensor/xoperation.hpp
@@ -1,0 +1,658 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XOPERATION_HPP
+#define XOPERATION_HPP
+
+#include <algorithm>
+#include <functional>
+#include <type_traits>
+
+#include "xfunction.hpp"
+#include "xscalar.hpp"
+#include "xstrides.hpp"
+
+namespace xt
+{
+
+    namespace detail
+    {
+
+        /***********
+         * helpers *
+         ***********/
+
+        template <class T>
+        struct identity
+        {
+            using result_type = T;
+
+            constexpr T operator()(const T& t) const noexcept
+            {
+                return +t;
+            }
+        };
+
+        template <class T>
+        struct conditional_ternary
+        {
+            using result_type = T;
+
+            constexpr result_type operator()(const T& t1, const T& t2, const T& t3) const noexcept
+            {
+                return t1 ? t2 : t3;
+            }
+        };
+
+        template <class T>
+        struct minimum
+        {
+            using result_type = T;
+
+            constexpr result_type operator()(const T& t1, const T& t2) const noexcept
+            {
+                return (t1 < t2) ? t1 : t2;
+            }
+        };
+
+        template <class T>
+        struct maximum
+        {
+            using result_type = T;
+
+            constexpr result_type operator()(const T& t1, const T& t2) const noexcept
+            {
+                return (t1 > t2) ? t1 : t2;
+            }
+        };
+
+        template <template <class...> class F, class... E>
+        inline auto make_xfunction(E&&... e) noexcept
+        {
+            using functor_type = F<common_value_type_t<std::decay_t<E>...>>;
+            using result_type = typename functor_type::result_type;
+            using type = xfunction<functor_type, result_type, const_xclosure_t<E>...>;
+            return type(functor_type(), std::forward<E>(e)...);
+        }
+
+        template <template <class...> class F, class... E>
+        struct xfunction_type
+        {
+            using type = xfunction<F<common_value_type_t<std::decay_t<E>...>>,
+                                   typename F<common_value_type_t<std::decay_t<E>...>>::result_type,
+                                   const_xclosure_t<E>...>;
+        };
+
+        // On MSVC, the second argument of enable_if_t is always evaluated, even if the condition is false.
+        // Wrapping the xfunction type in the xfunction_type metafunction avoids this evaluation when
+        // the condition is false, since it leads to a tricky bug preventing from using operator+ and operator-
+        // on vector and arrays iterators.
+        template <template <class...> class F, class... E>
+        using xfunction_type_t = typename std::enable_if_t<has_xexpression<std::decay_t<E>...>::value,
+                                                           xfunction_type<F, E...>>::type;
+    }
+
+    /*************
+     * operators *
+     *************/
+
+    /**
+     * @defgroup arithmetic_operators Arithmetic operators
+     */
+
+    /**
+     * @ingroup arithmetic_operators
+     * @brief Identity
+     *
+     * Returns an \ref xfunction for the element-wise identity
+     * of \a e.
+     * @param e an \ref xexpression
+     * @return an \ref xfunction
+     */
+    template <class E>
+    inline auto operator+(E&& e) noexcept
+        -> detail::xfunction_type_t<detail::identity, E>
+    {
+        return detail::make_xfunction<detail::identity>(std::forward<E>(e));
+    }
+
+    /**
+    * @ingroup arithmetic_operators
+    * @brief Opposite
+    *
+    * Returns an \ref xfunction for the element-wise opposite
+    * of \a e.
+    * @param e an \ref xexpression
+    * @return an \ref xfunction
+    */
+    template <class E>
+    inline auto operator-(E&& e) noexcept
+        -> detail::xfunction_type_t<std::negate, E>
+    {
+        return detail::make_xfunction<std::negate>(std::forward<E>(e));
+    }
+
+    /**
+    * @ingroup arithmetic_operators
+    * @brief Addition
+    *
+    * Returns an \ref xfunction for the element-wise addition
+    * of \a e1 and \a e2.
+    * @param e1 an \ref xexpression or a scalar
+    * @param e2 an \ref xexpression or a scalar
+    * @return an \ref xfunction
+    */
+    template <class E1, class E2>
+    inline auto operator+(E1&& e1, E2&& e2) noexcept
+        -> detail::xfunction_type_t<std::plus, E1, E2>
+    {
+        return detail::make_xfunction<std::plus>(std::forward<E1>(e1), std::forward<E2>(e2));
+    }
+
+    /**
+    * @ingroup arithmetic_operators
+    * @brief Substraction
+    *
+    * Returns an \ref xfunction for the element-wise substraction
+    * of \a e2 to \a e1.
+    * @param e1 an \ref xexpression or a scalar
+    * @param e2 an \ref xexpression or a scalar
+    * @return an \ref xfunction
+    */
+    template <class E1, class E2>
+    inline auto operator-(E1&& e1, E2&& e2) noexcept
+        -> detail::xfunction_type_t<std::minus, E1, E2>
+    {
+        return detail::make_xfunction<std::minus>(std::forward<E1>(e1), std::forward<E2>(e2));
+    }
+
+    /**
+    * @ingroup arithmetic_operators
+    * @brief Multiplication
+    *
+    * Returns an \ref xfunction for the element-wise multiplication
+    * of \a e1 by \a e2.
+    * @param e1 an \ref xexpression or a scalar
+    * @param e2 an \ref xexpression or a scalar
+    * @return an \ref xfunction
+    */
+    template <class E1, class E2>
+    inline auto operator*(E1&& e1, E2&& e2) noexcept
+        -> detail::xfunction_type_t<std::multiplies, E1, E2>
+    {
+        return detail::make_xfunction<std::multiplies>(std::forward<E1>(e1), std::forward<E2>(e2));
+    }
+
+    /**
+    * @ingroup arithmetic_operators
+    * @brief Division
+    *
+    * Returns an \ref xfunction for the element-wise division
+    * of \a e1 by \a e2.
+    * @param e1 an \ref xexpression or a scalar
+    * @param e2 an \ref xexpression or a scalar
+    * @return an \ref xfunction
+    */
+    template <class E1, class E2>
+    inline auto operator/(E1&& e1, E2&& e2) noexcept
+        -> detail::xfunction_type_t<std::divides, E1, E2>
+    {
+        return detail::make_xfunction<std::divides>(std::forward<E1>(e1), std::forward<E2>(e2));
+    }
+
+    /**
+     * @defgroup logical_operators Logical operators
+     */
+
+    /**
+     * @ingroup logical_operators
+     * @brief Or
+     *
+     * Returns an \ref xfunction for the element-wise or
+     * of \a e1 and \a e2.
+     * @param e1 an \ref xexpression or a scalar
+     * @param e2 an \ref xexpression or a scalar
+     * @return an \ref xfunction
+     */
+    template <class E1, class E2>
+    inline auto operator||(E1&& e1, E2&& e2) noexcept
+        -> detail::xfunction_type_t<std::logical_or, E1, E2>
+    {
+        return detail::make_xfunction<std::logical_or>(std::forward<E1>(e1), std::forward<E2>(e2));
+    }
+
+    /**
+    * @ingroup logical_operators
+    * @brief And
+    *
+    * Returns an \ref xfunction for the element-wise and
+    * of \a e1 and \a e2.
+    * @param e1 an \ref xexpression or a scalar
+    * @param e2 an \ref xexpression or a scalar
+    * @return an \ref xfunction
+    */
+    template <class E1, class E2>
+    inline auto operator&&(E1&& e1, E2&& e2) noexcept
+        -> detail::xfunction_type_t<std::logical_and, E1, E2>
+    {
+        return detail::make_xfunction<std::logical_and>(std::forward<E1>(e1), std::forward<E2>(e2));
+    }
+
+    /**
+    * @ingroup logical_operators
+    * @brief Not
+    *
+    * Returns an \ref xfunction for the element-wise not
+    * of \a e.
+    * @param e an \ref xexpression
+    * @return an \ref xfunction
+    */
+    template <class E>
+    inline auto operator!(E&& e) noexcept
+        -> detail::xfunction_type_t<std::logical_not, E>
+    {
+        return detail::make_xfunction<std::logical_not>(std::forward<E>(e));
+    }
+
+    /**
+     * @defgroup comparison_operators Comparison operators
+     */
+
+    /**
+     * @ingroup comparison_operators
+     * @brief Lesser than
+     *
+     * Returns an \ref xfunction for the element-wise
+     * lesser than comparison of \a e1 and \a e2.
+     * @param e1 an \ref xexpression or a scalar
+     * @param e2 an \ref xexpression or a scalar
+     * @return an \ref xfunction
+     */
+    template <class E1, class E2>
+    inline auto operator<(E1&& e1, E2&& e2) noexcept
+        -> detail::xfunction_type_t<std::less, E1, E2>
+    {
+        return detail::make_xfunction<std::less>(std::forward<E1>(e1), std::forward<E2>(e2));
+    }
+
+    /**
+    * @ingroup comparison_operators
+    * @brief Lesser or equal
+    *
+    * Returns an \ref xfunction for the element-wise
+    * lesser or equal comparison of \a e1 and \a e2.
+    * @param e1 an \ref xexpression or a scalar
+    * @param e2 an \ref xexpression or a scalar
+    * @return an \ref xfunction
+    */
+    template <class E1, class E2>
+    inline auto operator<=(E1&& e1, E2&& e2) noexcept
+        -> detail::xfunction_type_t<std::less_equal, E1, E2>
+    {
+        return detail::make_xfunction<std::less_equal>(std::forward<E1>(e1), std::forward<E2>(e2));
+    }
+
+    /**
+    * @ingroup comparison_operators
+    * @brief Greater than
+    *
+    * Returns an \ref xfunction for the element-wise
+    * greater than comparison of \a e1 and \a e2.
+    * @param e1 an \ref xexpression or a scalar
+    * @param e2 an \ref xexpression or a scalar
+    * @return an \ref xfunction
+    */
+    template <class E1, class E2>
+    inline auto operator>(E1&& e1, E2&& e2) noexcept
+        -> detail::xfunction_type_t<std::greater, E1, E2>
+    {
+        return detail::make_xfunction<std::greater>(std::forward<E1>(e1), std::forward<E2>(e2));
+    }
+
+    /**
+    * @ingroup comparison_operators
+    * @brief Greater or equal
+    *
+    * Returns an \ref xfunction for the element-wise
+    * greater or equal comparison of \a e1 and \a e2.
+    * @param e1 an \ref xexpression or a scalar
+    * @param e2 an \ref xexpression or a scalar
+    * @return an \ref xfunction
+    */
+    template <class E1, class E2>
+    inline auto operator>=(E1&& e1, E2&& e2) noexcept
+        -> detail::xfunction_type_t<std::greater_equal, E1, E2>
+    {
+        return detail::make_xfunction<std::greater_equal>(std::forward<E1>(e1), std::forward<E2>(e2));
+    }
+
+    /**
+     * @ingroup comparison_operators
+     * @brief Equality
+     *
+     * Returns true if \a e1 and \a e2 have the same shape
+     * and hold the same values. Unlike other comparison
+     * operators, this does not return an \ref xfunction.
+     * @param e1 an \ref xexpression or a scalar
+     * @param e2 an \ref xexpression or a scalar
+     * @return a boolean
+     */
+    template <class E1, class E2>
+    inline bool operator==(const xexpression<E1>& e1, const xexpression<E2>& e2)
+    {
+        const E1& de1 = e1.derived_cast();
+        const E2& de2 = e2.derived_cast();
+        bool res = de1.dimension() == de2.dimension() && std::equal(de1.shape().begin(), de1.shape().end(), de2.shape().begin());
+        auto iter1 = de1.xbegin();
+        auto iter2 = de2.xbegin();
+        auto iter_end = de1.xend();
+        while (res && iter1 != iter_end)
+        {
+            res = (*iter1++ == *iter2++);
+        }
+        return res;
+    }
+
+    /**
+    * @ingroup comparison_operators
+    * @brief Inequality
+    *
+    * Returns true if \a e1 and \a e2 have different shapes
+    * or hold the different values. Unlike other comparison
+    * operators, this does not return an \ref xfunction.
+    * @param e1 an \ref xexpression or a scalar
+    * @param e2 an \ref xexpression or a scalar
+    * @return a boolean
+    */
+    template <class E1, class E2>
+    inline bool operator!=(const xexpression<E1>& e1, const xexpression<E2>& e2)
+    {
+        return !(e1 == e2);
+    }
+
+    /**
+    * @ingroup comparison_operators
+    * @brief Element-wise equality
+    *
+    * Returns an \ref xfunction for the element-wise
+    * equality of \a e1 and \a e2.
+    * @param e1 an \ref xexpression or a scalar
+    * @param e2 an \ref xexpression or a scalar
+    * @return an \ref xfunction
+    */
+    template <class E1, class E2>
+    inline auto equal(E1&& e1, E2&& e2) noexcept
+        -> detail::xfunction_type_t<std::equal_to, E1, E2>
+    {
+        return detail::make_xfunction<std::equal_to>(std::forward<E1>(e1), std::forward<E2>(e2));
+    }
+
+    /**
+    * @ingroup comparison_operators
+    * @brief Element-wise inequality
+    *
+    * Returns an \ref xfunction for the element-wise
+    * inequality of \a e1 and \a e2.
+    * @param e1 an \ref xexpression or a scalar
+    * @param e2 an \ref xexpression or a scalar
+    * @return an \ref xfunction
+    */
+    template <class E1, class E2>
+    inline auto not_equal(E1&& e1, E2&& e2) noexcept
+        -> detail::xfunction_type_t<std::not_equal_to, E1, E2>
+    {
+        return detail::make_xfunction<std::not_equal_to>(std::forward<E1>(e1), std::forward<E2>(e2));
+    }
+
+    /**
+    * @ingroup logical_operators
+    * @brief Ternary selection
+    *
+    * Returns an \ref xfunction for the element-wise
+    * ternary selection (i.e. operator ? :) of \a e1,
+    * \a e2 and \a e3.
+    * @param e1 a boolean \ref xexpression
+    * @param e2 an \ref xexpression or a scalar
+    * @param e3 an \ref xexpression or a scalar
+    * @return an \ref xfunction
+    */
+    template <class E1, class E2, class E3>
+    inline auto where(E1&& e1, E2&& e2, E3&& e3) noexcept
+        -> detail::xfunction_type_t<detail::conditional_ternary, E1, E2, E3>
+    {
+        return detail::make_xfunction<detail::conditional_ternary>(std::forward<E1>(e1), std::forward<E2>(e2), std::forward<E3>(e3));
+    }
+
+    /**
+    * @ingroup logical_operators
+    * @brief Elementwise maximum
+    *
+    * Returns an \ref xfunction for the element-wise
+    * maximum between e1 and e2.
+    * @param e1 an \ref xexpression
+    * @param e2 an \ref xexpression
+    * @return an \ref xfunction
+    */
+    template <class E1, class E2>
+    inline auto maximum(E1&& e1, E2&& e2) noexcept
+        -> detail::xfunction_type_t<detail::maximum, E1, E2>
+    {
+        return detail::make_xfunction<detail::maximum>(std::forward<E1>(e1), std::forward<E2>(e2));
+    }
+
+    /**
+    * @ingroup logical_operators
+    * @brief Elementwise minimum
+    *
+    * Returns an \ref xfunction for the element-wise
+    * minimum between e1 and e2.
+    * @param e1 an \ref xexpression
+    * @param e2 an \ref xexpression
+    * @return an \ref xfunction
+    */
+    template <class E1, class E2>
+    inline auto minimum(E1&& e1, E2&& e2) noexcept
+        -> detail::xfunction_type_t<detail::minimum, E1, E2>
+    {
+        return detail::make_xfunction<detail::minimum>(std::forward<E1>(e1), std::forward<E2>(e2));
+    }
+
+    /**
+     * @ingroup logical_operators
+     * @brief Maximum element along given axis.
+     *
+     * Returns an \ref xreducer for the maximum of elements over given
+     * \em axes.
+     * @param e an \ref xexpression
+     * @param axes the axes along which the maximum is found (optional)
+     * @return an \ref xreducer
+     */
+    template <class E, class X>
+    inline auto amax(E&& e, X&& axes) noexcept
+    {
+        using functor_type = detail::maximum<typename std::decay_t<E>::value_type>;
+        return reduce(functor_type(), std::forward<E>(e), std::forward<X>(axes));
+    }
+
+    template <class E>
+    inline auto amax(E&& e) noexcept
+    {
+        using functor_type = detail::maximum<typename std::decay_t<E>::value_type>;
+        return reduce(functor_type(), std::forward<E>(e));
+    }
+
+#ifdef X_OLD_CLANG
+    template <class E, class I>
+    inline auto amax(E&& e, std::initializer_list<I> axes) noexcept
+    {
+        using functor_type = detail::maximum<typename std::decay_t<E>::value_type>;
+        return reduce(functor_type(), std::forward<E>(e), axes);
+    }
+#else
+    template <class E, class I, std::size_t N>
+    inline auto amax(E&& e, const I (&axes)[N]) noexcept
+    {
+        using functor_type = detail::maximum<typename std::decay_t<E>::value_type>;
+        return reduce(functor_type(), std::forward<E>(e), axes);
+    }
+#endif
+
+    /**
+     * @ingroup logical_operators
+     * @brief Minimum element along given axis.
+     *
+     * Returns an \ref xreducer for the minimum of elements over given
+     * \em axes.
+     * @param e an \ref xexpression
+     * @param axes the axes along which the minimum is found (optional)
+     * @return an \ref xreducer
+     */
+    template <class E, class X>
+    inline auto amin(E&& e, X&& axes) noexcept
+    {
+        using functor_type = detail::minimum<typename std::decay_t<E>::value_type>;
+        return reduce(functor_type(), std::forward<E>(e), std::forward<X>(axes));
+    }
+
+    template <class E>
+    inline auto amin(E&& e) noexcept
+    {
+        using functor_type = detail::minimum<typename std::decay_t<E>::value_type>;
+        return reduce(functor_type(), std::forward<E>(e));
+    }
+
+#ifdef X_OLD_CLANG
+    template <class E, class I>
+    inline auto amin(E&& e, std::initializer_list<I> axes) noexcept
+    {
+        using functor_type = detail::minimum<typename std::decay_t<E>::value_type>;
+        return reduce(functor_type(), std::forward<E>(e), axes);
+    }
+#else
+    template <class E, class I, std::size_t N>
+    inline auto amin(E&& e, const I (&axes)[N]) noexcept
+    {
+        using functor_type = detail::minimum<typename std::decay_t<E>::value_type>;
+        return reduce(functor_type(), std::forward<E>(e), axes);
+    }
+#endif
+
+    /**
+     * @ingroup logical_operators
+     * @brief return vector of indices where T is not zero
+     * 
+     * @param arr input array
+     * @return vector of \a index_types where arr is not equal to zero
+     */
+    template <class T>
+    inline auto nonzero(const T& arr)
+        -> std::vector<xindex_type_t<typename T::shape_type>>
+    {
+        auto shape = arr.shape();
+        using index_type = xindex_type_t<typename T::shape_type>;
+        using size_type = typename T::size_type;
+
+        index_type idx(arr.dimension(), 0);
+        std::vector<index_type> indices;
+
+        auto next_idx = [&shape](index_type& idx)
+        {
+            for (int i = int(shape.size() - 1); i >= 0; --i)
+            {
+                if (idx[i] >= shape[i] - 1)
+                {
+                    idx[i] = 0;
+                }
+                else
+                {
+                    idx[i]++;
+                    return idx;
+                }
+            }
+            // return empty index, happens at last iteration step, but remains unused
+            return index_type();
+        };
+
+        size_type total_size = compute_size(shape);
+        for (size_type i = 0; i < total_size; i++, next_idx(idx))
+        {
+            if (arr[idx])
+            {
+                indices.push_back(idx);
+            }
+        }
+        return indices;
+    }
+
+    /**
+     * @ingroup logical_operators
+     * @brief return vector of indices where condition is true
+     *        (equivalent to \a nonzero(condition))
+     * 
+     * @param condition input array
+     * @return vector of \a index_types where condition is not equal to zero
+     */
+    template <class T>
+    inline auto where(const T& condition)
+        -> std::vector<xindex_type_t<typename T::shape_type>>
+    {
+        return nonzero(condition);
+    }
+
+    /**
+    * @ingroup logical_operators
+    * @brief Any
+    *
+    * Returns true if any of the values of \a e is truthy,
+    * false otherwise.
+    * @param e an \ref xexpression
+    * @return a boolean
+    */
+    template <class E>
+    inline bool any(E&& e)
+    {
+        using xtype = std::decay_t<E>;
+        if (xtype::static_layout == layout_type::row_major || xtype::static_layout == layout_type::column_major)
+        {
+            return std::any_of(e.cbegin(), e.cend(),
+                               [](const typename std::decay_t<E>::value_type& el) { return el; });
+        }
+        else
+        {
+            return std::any_of(e.xbegin(), e.xend(),
+                               [](const typename std::decay_t<E>::value_type& el) { return el; });
+        }
+    }
+
+    /**
+    * @ingroup logical_operators
+    * @brief Any
+    *
+    * Returns true if all of the values of \a e are truthy,
+    * false otherwise.
+    * @param e an \ref xexpression
+    * @return a boolean
+    */
+    template <class E>
+    inline bool all(E&& e)
+    {
+        using xtype = std::decay_t<E>;
+        if (xtype::static_layout == layout_type::row_major || xtype::static_layout == layout_type::column_major)
+        {
+            return std::all_of(e.cbegin(), e.cend(),
+                               [](const typename std::decay_t<E>::value_type& el) { return el; });
+        }
+        else
+        {
+            return std::all_of(e.xbegin(), e.xend(),
+                               [](const typename std::decay_t<E>::value_type& el) { return el; });
+        }
+    }
+}
+
+#endif

--- a/inst/include/xtensor/xoptional.hpp
+++ b/inst/include/xtensor/xoptional.hpp
@@ -1,0 +1,958 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XOPTIONAL_HPP
+#define XOPTIONAL_HPP
+
+#include <type_traits>
+#include <utility>
+
+#include "xtensor/xutils.hpp"
+
+namespace xt
+{
+    /********************
+     * optional helpers *
+     ********************/
+
+    template <class T, class B>
+    auto optional(T&& t, B&& b) noexcept;
+
+    template <class T>
+    auto missing() noexcept;
+
+    /*************************
+     * xoptional declaration *
+     *************************/
+
+    template <class CT, class CB = bool>
+    class xoptional;
+
+    namespace detail
+    {
+        template <class E>
+        struct is_xoptional_impl : std::false_type
+        {
+        };
+
+        template <class CT, class CB>
+        struct is_xoptional_impl<xoptional<CT, CB>> : std::true_type
+        {
+        };
+
+        template <class CT, class CB>
+        struct bool_functor_return_type<xoptional<CT, CB>>
+        {
+            using type = xoptional<bool>;
+        };
+    }
+
+    template <class E>
+    using is_xoptional = detail::is_xoptional_impl<E>;
+
+    template <class E, class R = void>
+    using disable_xoptional = typename std::enable_if<!is_xoptional<E>::value, R>::type;
+
+    template <class E, class R = void>
+    using enable_xoptional = typename std::enable_if<is_xoptional<E>::value, R>::type;
+
+    /**
+     * @class xoptional
+     * @brief Optional value handler.
+     *
+     * The xoptional is an optional proxy. It holds a value (or a reference on a value) and a flag (or reference on a flag)
+     * indicating whether the element should be considered missing.
+     *
+     * xoptional is different from std::optional
+     *
+     *  - no `operator->()` that returns a pointer.
+     *  - no `operator*()` that returns a value.
+     *
+     * The only way to access the underlying value and flag is with the `value` and `value_or` methods.
+     *
+     *  - no explicit convertion to bool. This may lead to confusion when the underlying value type is boolean too.
+     *
+     * @tparam CT Closure type for the value.
+     * @tparam CB Closure type for the missing flag. A falsy flag means that the value is missing.
+     *
+     * \ref xoptional is used both as a value type (with CT and CB being value types) and reference type for containers
+     * with CT and CB being reference types. In other words, it serves as a reference proxy.
+     *
+     */
+    template <class CT, class CB>
+    class xoptional
+    {
+    public:
+        using value_closure = CT;
+        using flag_closure = CB;
+
+        using value_type = std::decay_t<CT>;
+        using flag_type = std::decay_t<CB>;
+
+        // Constructors
+        xoptional();
+        xoptional(const xoptional&) = default;
+        xoptional(xoptional&&) = default;
+
+        template <class CTO, class CBO>
+        xoptional(const xoptional<CTO, CBO>&);
+
+        template <class CTO, class CBO>
+        xoptional(xoptional<CTO, CBO>&&);
+
+        xoptional(const value_type&);
+        xoptional(value_type&&);
+
+        xoptional(value_type&&, flag_type&&);
+        xoptional(std::add_lvalue_reference_t<CT>, std::add_lvalue_reference_t<CB>);
+        xoptional(value_type&&, std::add_lvalue_reference_t<CB>);
+        xoptional(std::add_lvalue_reference_t<CT>, flag_type&&);
+
+        // Assignment
+        xoptional& operator=(const xoptional&) = default;
+
+        template <class CTO, class CBO>
+        xoptional& operator=(const xoptional<CTO, CBO>&);
+
+        template <class CTO, class CBO>
+        xoptional& operator=(xoptional<CTO, CBO>&&);
+
+        xoptional& operator=(const value_type&);
+        xoptional& operator=(value_type&&);
+
+        // Operators
+        template <class CTO, class CBO>
+        xoptional& operator+=(const xoptional<CTO, CBO>&);
+        template <class CTO, class CBO>
+        xoptional& operator-=(const xoptional<CTO, CBO>&);
+        template <class CTO, class CBO>
+        xoptional& operator*=(const xoptional<CTO, CBO>&);
+        template <class CTO, class CBO>
+        xoptional& operator/=(const xoptional<CTO, CBO>&);
+
+        template <class T>
+        disable_xoptional<T, xoptional&> operator+=(const T&);
+        template <class T>
+        disable_xoptional<T, xoptional&> operator-=(const T&);
+        template <class T>
+        disable_xoptional<T, xoptional&> operator*=(const T&);
+        template <class T>
+        disable_xoptional<T, xoptional&> operator/=(const T&);
+
+        // Access
+        std::add_lvalue_reference_t<CT> value() & noexcept;
+        std::add_lvalue_reference_t<std::add_const_t<CT>> value() const & noexcept;
+        std::conditional_t<std::is_reference<CT>::value, apply_cv_t<CT, value_type>&, value_type> value() && noexcept;
+        std::conditional_t<std::is_reference<CT>::value, const value_type&, value_type> value() const && noexcept;
+
+        template <class U>
+        value_type value_or(U&&) const & noexcept;
+        template <class U>
+        value_type value_or(U&&) const && noexcept;
+
+        // Access
+        std::add_lvalue_reference_t<CB> has_value() & noexcept;
+        std::add_lvalue_reference_t<std::add_const_t<CB>> has_value() const & noexcept;
+        std::conditional_t<std::is_reference<CB>::value, apply_cv_t<CB, flag_type>&, flag_type> has_value() && noexcept;
+        std::conditional_t<std::is_reference<CB>::value, const flag_type&, flag_type> has_value() const && noexcept;
+
+        // Swap
+        void swap(xoptional& other);
+
+        // Comparison
+        template <class CTO, class CBO>
+        bool equal(const xoptional<CTO, CBO>& rhs) const noexcept;
+
+        template <class CTO>
+        disable_xoptional<CTO, bool> equal(const CTO& rhs) const noexcept;
+
+    private:
+        template <class CTO, class CBO>
+        friend class xoptional;
+
+        CT m_value;
+        CB m_flag;
+    };
+
+    /***************************************
+     * optional and missing implementation *
+     ***************************************/
+
+     /**
+      * @brief Returns an \ref xoptional holding closure types on the specified parameters
+      *
+      * @tparam t the optional value
+      * @tparam b the boolean flag
+      */
+    template <class T, class B>
+    inline auto optional(T&& t, B&& b) noexcept
+    {
+        using optional_type = xoptional<closure_t<T>, closure_t<B>>;
+        return optional_type(std::forward<T>(t), std::forward<B>(b));
+    }
+
+    /**
+     * @brief Returns an \ref xoptional for a missig value
+     */
+    template <class T>
+    auto missing() noexcept
+    {
+        return xoptional<T, bool>(T(), false);
+    }
+
+    /****************************
+     * xoptional implementation *
+     ****************************/
+
+     // Constructors
+    template <class CT, class CB>
+    xoptional<CT, CB>::xoptional()
+        : m_value(), m_flag(false)
+    {
+    }
+
+    template <class CT, class CB>
+    template <class CTO, class CBO>
+    xoptional<CT, CB>::xoptional(const xoptional<CTO, CBO>& opt)
+        : m_value(opt.m_value), m_flag(opt.m_flag)
+    {
+    }
+
+    template <class CT, class CB>
+    template <class CTO, class CBO>
+    xoptional<CT, CB>::xoptional(xoptional<CTO, CBO>&& opt)
+        : m_value(std::move(opt.m_value)), m_flag(std::move(opt.m_flag))
+    {
+    }
+
+    template <class CT, class CB>
+    xoptional<CT, CB>::xoptional(const value_type& value)
+        : m_value(value), m_flag(true)
+    {
+    }
+
+    template <class CT, class CB>
+    xoptional<CT, CB>::xoptional(value_type&& value)
+        : m_value(value), m_flag(true)
+    {
+    }
+
+    template <class CT, class CB>
+    xoptional<CT, CB>::xoptional(value_type&& value, flag_type&& flag)
+        : m_value(std::move(value)), m_flag(std::move(flag))
+    {
+    }
+
+    template <class CT, class CB>
+    xoptional<CT, CB>::xoptional(std::add_lvalue_reference_t<CT> value, std::add_lvalue_reference_t<CB> flag)
+        : m_value(value), m_flag(flag)
+    {
+    }
+
+    template <class CT, class CB>
+    xoptional<CT, CB>::xoptional(value_type&& value, std::add_lvalue_reference_t<CB> flag)
+        : m_value(std::move(value)), m_flag(flag)
+    {
+    }
+
+    template <class CT, class CB>
+    xoptional<CT, CB>::xoptional(std::add_lvalue_reference_t<CT> value, flag_type&& flag)
+        : m_value(value), m_flag(std::move(flag))
+    {
+    }
+
+    // Assignment
+    template <class CT, class CB>
+    template <class CTO, class CBO>
+    auto xoptional<CT, CB>::operator=(const xoptional<CTO, CBO>& rhs) -> xoptional&
+    {
+        m_flag = rhs.m_flag;
+        m_value = rhs.m_value;
+        return *this;
+    }
+
+    template <class CT, class CB>
+    template <class CTO, class CBO>
+    auto xoptional<CT, CB>::operator=(xoptional<CTO, CBO>&& rhs) -> xoptional&
+    {
+        m_flag = std::move(rhs.m_flag);
+        m_value = std::move(rhs.m_value);
+        return *this;
+    }
+
+    template <class CT, class CB>
+    auto xoptional<CT, CB>::operator=(const value_type& value) -> xoptional&
+    {
+        m_flag = true;
+        m_value = value;
+        return *this;
+    }
+
+    template <class CT, class CB>
+    auto xoptional<CT, CB>::operator=(value_type&& value) -> xoptional&
+    {
+        m_flag = true;
+        m_value = std::move(value);
+        return *this;
+    }
+
+    // Operators
+    template <class CT, class CB>
+    template <class CTO, class CBO>
+    auto xoptional<CT, CB>::operator+=(const xoptional<CTO, CBO>& rhs) -> xoptional&
+    {
+        m_flag = m_flag && rhs.m_flag;
+        if (m_flag)
+            m_value += rhs.m_value;
+        return *this;
+    }
+
+    template <class CT, class CB>
+    template <class CTO, class CBO>
+    auto xoptional<CT, CB>::operator-=(const xoptional<CTO, CBO>& rhs) -> xoptional&
+    {
+        m_flag = m_flag && rhs.m_flag;
+        if (m_flag)
+            m_value -= rhs.m_value;
+        return *this;
+    }
+
+    template <class CT, class CB>
+    template <class CTO, class CBO>
+    auto xoptional<CT, CB>::operator*=(const xoptional<CTO, CBO>& rhs) -> xoptional&
+    {
+        m_flag = m_flag && rhs.m_flag;
+        if (m_flag)
+            m_value *= rhs.m_value;
+        return *this;
+    }
+
+    template <class CT, class CB>
+    template <class CTO, class CBO>
+    auto xoptional<CT, CB>::operator/=(const xoptional<CTO, CBO>& rhs) -> xoptional&
+    {
+        m_flag = m_flag && rhs.m_flag;
+        if (m_flag)
+            m_value /= rhs.m_value;
+        return *this;
+    }
+
+    template <class CT, class CB>
+    template <class T>
+    auto xoptional<CT, CB>::operator+=(const T& rhs) -> disable_xoptional<T, xoptional&>
+    {
+        if (m_flag)
+            m_value += rhs;
+        return *this;
+    }
+
+    template <class CT, class CB>
+    template <class T>
+    auto xoptional<CT, CB>::operator-=(const T& rhs) -> disable_xoptional<T, xoptional&>
+    {
+        if (m_flag)
+            m_value -= rhs;
+        return *this;
+    }
+
+    template <class CT, class CB>
+    template <class T>
+    auto xoptional<CT, CB>::operator*=(const T& rhs) -> disable_xoptional<T, xoptional&>
+    {
+        if (m_flag)
+            m_value *= rhs;
+        return *this;
+    }
+
+    template <class CT, class CB>
+    template <class T>
+    auto xoptional<CT, CB>::operator/=(const T& rhs) -> disable_xoptional<T, xoptional&>
+    {
+        if (m_flag)
+            m_value /= rhs;
+        return *this;
+    }
+
+    // Access
+    template <class CT, class CB>
+    auto xoptional<CT, CB>::value() & noexcept -> std::add_lvalue_reference_t<CT>
+    {
+        return m_value;
+    }
+
+    template <class CT, class CB>
+    auto xoptional<CT, CB>::value() const & noexcept -> std::add_lvalue_reference_t<std::add_const_t<CT>>
+    {
+        return m_value;
+    }
+
+    template <class CT, class CB>
+    auto xoptional<CT, CB>::value() && noexcept->std::conditional_t<std::is_reference<CT>::value, apply_cv_t<CT, value_type>&, value_type>
+    {
+        return m_value;
+    }
+
+    template <class CT, class CB>
+    auto xoptional<CT, CB>::value() const && noexcept->std::conditional_t<std::is_reference<CT>::value, const value_type&, value_type>
+    {
+        return m_value;
+    }
+
+    template <class CT, class CB>
+    template <class U>
+    auto xoptional<CT, CB>::value_or(U&& default_value) const & noexcept -> value_type
+    {
+        return m_flag ? m_value : std::forward<U>(default_value);
+    }
+
+    template <class CT, class CB>
+    template <class U>
+    auto xoptional<CT, CB>::value_or(U&& default_value) const && noexcept->value_type
+    {
+        return m_flag ? m_value : std::forward<U>(default_value);
+    }
+
+    // Access
+    template <class CT, class CB>
+    auto xoptional<CT, CB>::has_value() & noexcept -> std::add_lvalue_reference_t<CB>
+    {
+        return m_flag;
+    }
+
+    template <class CT, class CB>
+    auto xoptional<CT, CB>::has_value() const & noexcept -> std::add_lvalue_reference_t<std::add_const_t<CB>>
+    {
+        return m_flag;
+    }
+
+    template <class CT, class CB>
+    auto xoptional<CT, CB>::has_value() && noexcept->std::conditional_t<std::is_reference<CB>::value, apply_cv_t<CB, flag_type>&, flag_type>
+    {
+        return m_flag;
+    }
+
+    template <class CT, class CB>
+    auto xoptional<CT, CB>::has_value() const && noexcept->std::conditional_t<std::is_reference<CB>::value, const flag_type&, flag_type>
+    {
+        return m_flag;
+    }
+
+    // Swap
+    template <class CT, class CB>
+    void xoptional<CT, CB>::swap(xoptional& other)
+    {
+        std::swap(m_value, other.m_flag);
+        std::swap(m_flag, other.m_flag);
+    }
+
+    // Comparison
+    template <class CT, class CB>
+    template <class CTO, class CBO>
+    auto xoptional<CT, CB>::equal(const xoptional<CTO, CBO>& rhs) const noexcept -> bool
+    {
+        return (!m_flag && !rhs.m_flag) || (m_value == rhs.m_value && (m_flag && rhs.m_flag));
+    }
+
+    template <class CT, class CB>
+    template <class CTO>
+    auto xoptional<CT, CB>::equal(const CTO& rhs) const noexcept -> disable_xoptional<CTO, bool>
+    {
+        return m_flag ? (m_value == rhs) : false;
+    }
+
+    // External operators
+    template <class T, class B, class S>
+    inline S& operator<<(S& out, const xoptional<T, B>& v)
+    {
+        if (v.has_value())
+            out << v.value();
+        else
+            out << "N/A";
+        return out;
+    }
+
+    template <class T1, class B1, class T2, class B2>
+    inline auto operator==(const xoptional<T1, B1>& e1, const xoptional<T2, B2>& e2) noexcept
+        -> bool
+    {
+        return e1.equal(e2);
+    }
+
+    template <class T1, class B1, class T2>
+    inline auto operator==(const xoptional<T1, B1>& e1, const T2& e2) noexcept
+        -> disable_xoptional<T2, bool>
+    {
+        return e1.equal(e2);
+    }
+
+    template <class T1, class T2, class B2>
+    inline auto operator==(const T1& e1, const xoptional<T2, B2>& e2) noexcept
+        -> disable_xoptional<T1, bool>
+    {
+        return e2.equal(e1);
+    }
+
+    template <class T, class B>
+    inline auto operator+(const xoptional<T, B>& e) noexcept
+        -> xoptional<std::decay_t<T>>
+    {
+        return e;
+    }
+
+    template <class T1, class B1, class T2, class B2>
+    inline auto operator!=(const xoptional<T1, B1>& e1, const xoptional<T2, B2>& e2) noexcept
+        -> bool
+    {
+        return !e1.equal(e2);
+    }
+
+    template <class T1, class B1, class T2>
+    inline auto operator!=(const xoptional<T1, B1>& e1, const T2& e2) noexcept
+        -> disable_xoptional<T2, bool>
+    {
+        return !e1.equal(e2);
+    }
+
+    template <class T1, class T2, class B2>
+    inline auto operator!=(const T1& e1, const xoptional<T2, B2>& e2) noexcept
+        -> disable_xoptional<T1, bool>
+    {
+        return !e2.equal(e1);
+    }
+
+    // Operations
+    template <class T, class B>
+    inline auto operator-(const xoptional<T, B>& e) noexcept
+        -> xoptional<std::decay_t<T>>
+    {
+        using value_type = std::decay_t<T>;
+        return e.has_value() ? -e.value() : missing<value_type>();
+    }
+
+    template <class T1, class B1, class T2, class B2>
+    inline auto operator+(const xoptional<T1, B1>& e1, const xoptional<T2, B2>& e2) noexcept
+        -> xoptional<std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>>
+    {
+        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
+        return e1.has_value() && e2.has_value() ? e1.value() + e2.value() : missing<value_type>();
+    }
+
+    template <class T1, class T2, class B2>
+    inline auto operator+(const T1& e1, const xoptional<T2, B2>& e2) noexcept
+        -> xoptional<std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>>
+    {
+        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
+        return e2.has_value() ? e1 + e2.value() : missing<value_type>();
+    }
+
+    template <class T1, class B1, class T2>
+    inline auto operator+(const xoptional<T1, B1>& e1, const T2& e2) noexcept
+        -> xoptional<std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>>
+    {
+        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
+        return e1.has_value() ? e1.value() + e2 : missing<value_type>();
+    }
+
+    template <class T1, class B1, class T2, class B2>
+    inline auto operator-(const xoptional<T1, B1>& e1, const xoptional<T2, B2>& e2) noexcept
+        -> xoptional<std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>>
+    {
+        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
+        return e1.has_value() && e2.has_value() ? e1.value() - e2.value() : missing<value_type>();
+    }
+
+    template <class T1, class T2, class B2>
+    inline auto operator-(const T1& e1, const xoptional<T2, B2>& e2) noexcept
+        -> xoptional<std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>>
+    {
+        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
+        return e2.has_value() ? e1 - e2.value() : missing<value_type>();
+    }
+
+    template <class T1, class B1, class T2>
+    inline auto operator-(const xoptional<T1, B1>& e1, const T2& e2) noexcept
+        -> xoptional<std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>>
+    {
+        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
+        return e1.has_value() ? e1.value() - e2 : missing<value_type>();
+    }
+
+    template <class T1, class B1, class T2, class B2>
+    inline auto operator*(const xoptional<T1, B1>& e1, const xoptional<T2, B2>& e2) noexcept
+        -> xoptional<std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>>
+    {
+        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
+        return e1.has_value() && e2.has_value() ? e1.value() * e2.value() : missing<value_type>();
+    }
+
+    template <class T1, class T2, class B2>
+    inline auto operator*(const T1& e1, const xoptional<T2, B2>& e2) noexcept
+        -> xoptional<std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>>
+    {
+        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
+        return e2.has_value() ? e1 * e2.value() : missing<value_type>();
+    }
+
+    template <class T1, class B1, class T2>
+    inline auto operator*(const xoptional<T1, B1>& e1, const T2& e2) noexcept
+        -> xoptional<std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>>
+    {
+        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
+        return e1.has_value() ? e1.value() * e2 : missing<value_type>();
+    }
+
+    template <class T1, class B1, class T2, class B2>
+    inline auto operator/(const xoptional<T1, B1>& e1, const xoptional<T2, B2>& e2) noexcept
+        -> xoptional<std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>>
+    {
+        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
+        return e1.has_value() && e2.has_value() ? e1.value() / e2.value() : missing<value_type>();
+    }
+
+    template <class T1, class T2, class B2>
+    inline auto operator/(const T1& e1, const xoptional<T2, B2>& e2) noexcept
+    {
+        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
+        return e2.has_value() ? e1 / e2.value() : missing<value_type>();
+    }
+
+    template <class T1, class B1, class T2>
+    inline auto operator/(const xoptional<T1, B1>& e1, const T2& e2) noexcept
+    {
+        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
+        return e1.has_value() ? e1.value() / e2 : missing<value_type>();
+    }
+
+    template <class T1, class B1, class T2, class B2>
+    inline auto operator||(const xoptional<T1, B1>& e1, const xoptional<T2, B2>& e2) noexcept
+        -> xoptional<std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>>
+    {
+        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
+        return e1.has_value() && e2.has_value() ? e1.value() || e2.value() : missing<value_type>();
+    }
+
+    template <class T1, class T2, class B2>
+    inline auto operator||(const T1& e1, const xoptional<T2, B2>& e2) noexcept
+        -> xoptional<std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>>
+    {
+        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
+        return e2.has_value() ? e1 || e2.value() : missing<value_type>();
+    }
+
+    template <class T1, class B1, class T2>
+    inline auto operator||(const xoptional<T1, B1>& e1, const T2& e2) noexcept
+        -> xoptional<std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>>
+    {
+        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
+        return e1.has_value() ? e1.value() || e2 : missing<value_type>();
+    }
+
+
+    template <class T1, class B1, class T2, class B2>
+    inline auto operator&&(const xoptional<T1, B1>& e1, const xoptional<T2, B2>& e2) noexcept
+        -> xoptional<std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>>
+    {
+        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
+        return e1.has_value() && e2.has_value() ? e1.value() && e2.value() : missing<value_type>();
+    }
+
+    template <class T1, class T2, class B2>
+    inline auto operator&&(const T1& e1, const xoptional<T2, B2>& e2) noexcept
+        -> xoptional<std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>>
+    {
+        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
+        return e2.has_value() ? e1 && e2.value() : missing<value_type>();
+    }
+
+    template <class T1, class B1, class T2>
+    inline auto operator&&(const xoptional<T1, B1>& e1, const T2& e2) noexcept
+        -> xoptional<std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>>
+    {
+        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
+        return e1.has_value() ? e1.value() && e2 : missing<value_type>();
+    }
+
+    template <class T, class B>
+    inline auto operator!(const xoptional<T, B>& e) noexcept
+        -> xoptional<bool>
+    {
+        return e.has_value() ? !e.value() : missing<bool>();
+    }
+
+    template <class T1, class B1, class T2, class B2>
+    inline auto operator<(const xoptional<T1, B1>& e1, const xoptional<T2, B2>& e2) noexcept
+        -> xoptional<bool>
+    {
+        return e1.has_value() && e2.has_value() ? e1.value() < e2.value() : missing<bool>();
+    }
+
+    template <class T1, class T2, class B2>
+    inline auto operator<(const T1& e1, const xoptional<T2, B2>& e2) noexcept
+        -> xoptional<bool>
+    {
+        return e2.has_value() ? e1 < e2.value() : missing<bool>();
+    }
+
+    template <class T1, class B1, class T2>
+    inline auto operator<(const xoptional<T1, B1>& e1, const T2& e2) noexcept
+        -> xoptional<bool>
+    {
+        return e1.has_value() ? e1.value() < e2 : missing<bool>();
+    }
+
+    template <class T1, class B1, class T2, class B2>
+    inline auto operator<=(const xoptional<T1, B1>& e1, const xoptional<T2, B2>& e2) noexcept
+        -> xoptional<bool>
+    {
+        return e1.has_value() && e2.has_value() ? e1.value() <= e2.value() : missing<bool>();
+    }
+
+    template <class T1, class T2, class B2>
+    inline auto operator<=(const T1& e1, const xoptional<T2, B2>& e2) noexcept
+        -> xoptional<bool>
+    {
+        return e2.has_value() ? e1 <= e2.value() : missing<bool>();
+    }
+
+    template <class T1, class B1, class T2>
+    inline auto operator<=(const xoptional<T1, B1>& e1, const T2& e2) noexcept
+        -> xoptional<bool>
+    {
+        return e1.has_value() ? e1.value() <= e2 : missing<bool>();
+    }
+
+    template <class T1, class B1, class T2, class B2>
+    inline auto operator>(const xoptional<T1, B1>& e1, const xoptional<T2, B2>& e2) noexcept
+        -> xoptional<bool>
+    {
+        return e1.has_value() && e2.has_value() ? e1.value() > e2.value() : missing<bool>();
+    }
+
+    template <class T1, class T2, class B2>
+    inline auto operator>(const T1& e1, const xoptional<T2, B2>& e2) noexcept
+        -> xoptional<bool>
+    {
+        return e2.has_value() ? e1 > e2.value() : missing<bool>();
+    }
+
+    template <class T1, class B1, class T2>
+    inline auto operator>(const xoptional<T1, B1>& e1, const T2& e2) noexcept
+        -> xoptional<bool>
+    {
+        return e1.has_value() ? e1.value() > e2 : missing<bool>();
+    }
+
+    template <class T1, class B1, class T2, class B2>
+    inline auto operator>=(const xoptional<T1, B1>& e1, const xoptional<T2, B2>& e2) noexcept
+        -> xoptional<bool>
+    {
+        return e1.has_value() && e2.has_value() ? e1.value() >= e2.value() : missing<bool>();
+    }
+
+    template <class T1, class T2, class B2>
+    inline auto operator>=(const T1& e1, const xoptional<T2, B2>& e2) noexcept
+        -> xoptional<bool>
+    {
+        return e2.has_value() ? e1 >= e2.value() : missing<bool>();
+    }
+
+    template <class T1, class B1, class T2>
+    inline auto operator>=(const xoptional<T1, B1>& e1, const T2& e2) noexcept
+        -> xoptional<bool>
+    {
+        return e1.has_value() ? e1.value() >= e2 : missing<bool>();
+    }
+
+#define UNARY_OPTIONAL(NAME)\
+    template <class T, class B>\
+    inline auto NAME(const xoptional<T, B>& e) {\
+        using std::NAME;\
+        return e.has_value() ? NAME(e.value()) : missing<std::decay_t<T>>();\
+    }
+
+#define UNARY_BOOL_OPTIONAL(NAME)\
+    template <class T, class B>\
+    inline xoptional<bool> NAME(const xoptional<T, B>& e) {\
+        using std::NAME;\
+        return e.has_value() ? bool(NAME(e.value())) : missing<bool>();\
+    }
+
+#define BINARY_OPTIONAL_1(NAME)\
+    template <class T1, class B1, class T2>\
+    inline auto NAME(const xoptional<T1, B1>& e1, const T2& e2) {\
+        using std::NAME;\
+        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;\
+        return e1.has_value() ? NAME(e1.value(), e2) : missing<value_type>();\
+    }
+
+
+#define BINARY_OPTIONAL_2(NAME)\
+    template <class T1, class T2, class B2>\
+    inline auto NAME(const T1& e1, const xoptional<T2, B2>& e2) {\
+        using std::NAME;\
+        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;\
+        return e2.has_value() ? NAME(e1, e2.value()) : missing<value_type>();\
+    }
+
+#define BINARY_OPTIONAL_12(NAME)\
+    template <class T1, class B1, class T2, class B2>\
+    inline auto NAME(const xoptional<T1, B1>& e1, const xoptional<T2, B2>& e2) {\
+        using std::NAME;\
+        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;\
+        return e1.has_value() && e2.has_value() ? NAME(e1.value(), e2.value()) : missing<value_type>();\
+    }
+
+#define BINARY_OPTIONAL(NAME)\
+    BINARY_OPTIONAL_1(NAME)\
+    BINARY_OPTIONAL_2(NAME)\
+    BINARY_OPTIONAL_12(NAME)
+
+#define TERNARY_OPTIONAL_1(NAME)\
+    template <class T1, class B1, class T2, class T3>\
+    inline auto NAME(const xoptional<T1, B1>& e1, const T2& e2, const T3& e3) {\
+        using std::NAME;\
+        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>, std::decay_t<T3>>;\
+        return e1.has_value() ? NAME(e1.value(), e2, e3) : missing<value_type>();\
+    }
+
+#define TERNARY_OPTIONAL_2(NAME)\
+    template <class T1, class T2, class B2, class T3>\
+    inline auto NAME(const T1& e1, const xoptional<T2, B2>& e2, const T3& e3) {\
+        using std::NAME;\
+        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>, std::decay_t<T3>>;\
+        return e2.has_value() ? NAME(e1, e2.value(), e3) : missing<value_type>();\
+    }
+
+#define TERNARY_OPTIONAL_3(NAME)\
+    template <class T1, class T2, class T3, class B3>\
+    inline auto NAME(const T1& e1, const T2& e2, const xoptional<T3, B3>& e3) {\
+        using std::NAME;\
+        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>, std::decay_t<T3>>;\
+        return e3.has_value() ? NAME(e1, e2, e3.value()) : missing<value_type>();\
+    }
+
+#define TERNARY_OPTIONAL_12(NAME)\
+    template <class T1, class B1, class T2, class B2, class T3>\
+    inline auto NAME(const xoptional<T1, B1>& e1, const xoptional<T2, B2>& e2, const T3& e3) {\
+        using std::NAME;\
+        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>, std::decay_t<T3>>;\
+        return (e1.has_value() && e2.has_value()) ? NAME(e1.value(), e2.value(), e3) : missing<value_type>();\
+    }
+
+#define TERNARY_OPTIONAL_13(NAME)\
+    template <class T1, class B1, class T2, class T3, class B3>\
+    inline auto NAME(const xoptional<T1, B1>& e1, const T2& e2, const xoptional<T3, B3>& e3) {\
+        using std::NAME;\
+        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>, std::decay_t<T3>>;\
+        return (e1.has_value() && e3.has_value()) ? NAME(e1.value(), e2, e3.value()) : missing<value_type>();\
+    }
+
+#define TERNARY_OPTIONAL_23(NAME)\
+    template <class T1, class T2, class B2, class T3, class B3>\
+    inline auto NAME(const T1& e1, const xoptional<T2, B2>& e2, const xoptional<T3, B3>& e3) {\
+        using std::NAME;\
+        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>, std::decay_t<T3>>;\
+        return (e2.has_value() && e3.has_value()) ? NAME(e1, e2.value(), e3.value()) : missing<value_type>();\
+    }
+
+#define TERNARY_OPTIONAL_123(NAME)\
+    template <class T1, class B1, class T2, class B2, class T3, class B3>\
+    inline auto NAME(const xoptional<T1, B1>& e1, const xoptional<T2, B2>& e2, const xoptional<T3, B3>& e3) {\
+        using std::NAME;\
+        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>, std::decay_t<T3>>;\
+        return (e1.has_value() && e2.has_value() && e3.has_value()) ?\
+                NAME(e1.value(), e2.value(), e3.value()) : missing<value_type>();\
+    }
+
+#define TERNARY_OPTIONAL(NAME)\
+    TERNARY_OPTIONAL_1(NAME)\
+    TERNARY_OPTIONAL_2(NAME)\
+    TERNARY_OPTIONAL_3(NAME)\
+    TERNARY_OPTIONAL_12(NAME)\
+    TERNARY_OPTIONAL_13(NAME)\
+    TERNARY_OPTIONAL_23(NAME)\
+    TERNARY_OPTIONAL_123(NAME)
+
+    namespace math
+    {
+        template <class T, class B>
+        struct sign_fun<xoptional<T, B>>
+        {
+            using argument_type = xoptional<T, B>;
+            using result_type = xoptional<std::decay_t<T>>;
+
+            constexpr result_type operator()(const xoptional<T, B>& x) const
+            {
+                return x.has_value() ? xoptional<T>(detail::sign_impl(x.value()))
+                    : missing<std::decay_t<T>>();
+            }
+        };
+    }
+
+    template <class T, class B>
+    inline auto sign(const xoptional<T, B>& e)
+    {
+            return e.has_value() ? math::detail::sign_impl(e.value()) : missing<std::decay_t<T>>();
+    }
+
+    UNARY_OPTIONAL(abs)
+    UNARY_OPTIONAL(fabs)
+    BINARY_OPTIONAL(fmod)
+    BINARY_OPTIONAL(remainder)
+    TERNARY_OPTIONAL(fma)
+    BINARY_OPTIONAL(fmax)
+    BINARY_OPTIONAL(fmin)
+    BINARY_OPTIONAL(fdim)
+    UNARY_OPTIONAL(exp)
+    UNARY_OPTIONAL(exp2)
+    UNARY_OPTIONAL(expm1)
+    UNARY_OPTIONAL(log)
+    UNARY_OPTIONAL(log10)
+    UNARY_OPTIONAL(log2)
+    UNARY_OPTIONAL(log1p)
+    BINARY_OPTIONAL(pow)
+    UNARY_OPTIONAL(sqrt)
+    UNARY_OPTIONAL(cbrt)
+    BINARY_OPTIONAL(hypot)
+    UNARY_OPTIONAL(sin)
+    UNARY_OPTIONAL(cos)
+    UNARY_OPTIONAL(tan)
+    UNARY_OPTIONAL(acos)
+    UNARY_OPTIONAL(asin)
+    UNARY_OPTIONAL(atan)
+    BINARY_OPTIONAL(atan2)
+    UNARY_OPTIONAL(sinh)
+    UNARY_OPTIONAL(cosh)
+    UNARY_OPTIONAL(tanh)
+    UNARY_OPTIONAL(acosh)
+    UNARY_OPTIONAL(asinh)
+    UNARY_OPTIONAL(atanh)
+    UNARY_OPTIONAL(erf)
+    UNARY_OPTIONAL(erfc)
+    UNARY_OPTIONAL(tgamma)
+    UNARY_OPTIONAL(lgamma)
+    UNARY_BOOL_OPTIONAL(isfinite)
+    UNARY_BOOL_OPTIONAL(isinf)
+    UNARY_BOOL_OPTIONAL(isnan)
+
+#undef TERNARY_OPTIONAL
+#undef TERNARY_OPTIONAL_123
+#undef TERNARY_OPTIONAL_23
+#undef TERNARY_OPTIONAL_13
+#undef TERNARY_OPTIONAL_12
+#undef TERNARY_OPTIONAL_3
+#undef TERNARY_OPTIONAL_2
+#undef TERNARY_OPTIONAL_1
+#undef BINARY_OPTIONAL
+#undef BINARY_OPTIONAL_12
+#undef BINARY_OPTIONAL_2
+#undef BINARY_OPTIONAL_1
+#undef UNARY_OPTIONAL
+}
+
+#endif

--- a/inst/include/xtensor/xrandom.hpp
+++ b/inst/include/xtensor/xrandom.hpp
@@ -1,0 +1,229 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+/**
+ * @brief functions to obtain xgenerators generating random numbers with given shape
+ */
+
+#ifndef XRANDOM_HPP
+#define XRANDOM_HPP
+
+#include <functional>
+#include <random>
+#include <utility>
+
+#include "xgenerator.hpp"
+
+namespace xt
+{
+    /*********************
+     * Random generators *
+     *********************/
+
+    namespace random
+    {
+        using default_engine_type = std::mt19937;
+        using seed_type = default_engine_type::result_type;
+
+        default_engine_type& get_default_random_engine();
+        void seed(seed_type seed);
+
+        template <class T, class S, class E = random::default_engine_type>
+        auto rand(const S& shape, T lower = 0, T upper = 1,
+                  E& engine = random::get_default_random_engine());
+
+        template <class T, class S, class E = random::default_engine_type>
+        auto randint(const S& shape, T lower = 0, T upper = std::numeric_limits<T>::max(),
+                     E& engine = random::get_default_random_engine());
+
+        template <class T, class S, class E = random::default_engine_type>
+        auto randn(const S& shape, T mean = 0, T std_dev = 1,
+                   E& engine = random::get_default_random_engine());
+
+#ifdef X_OLD_CLANG
+        template <class T, class I, class E = random::default_engine_type>
+        auto rand(std::initializer_list<I> shape, T lower = 0, T upper = 1,
+                  E& engine = random::get_default_random_engine());
+
+        template <class T, class I, class E = random::default_engine_type>
+        auto randint(std::initializer_list<I> shape,
+                     T lower = 0, T upper = std::numeric_limits<T>::max(),
+                     E& engine = random::get_default_random_engine());
+
+        template <class T, class I, class E = random::default_engine_type>
+        auto randn(std::initializer_list<I>, T mean = 0, T std_dev = 1,
+                   E& engine = random::get_default_random_engine());
+#else
+        template <class T, class I, std::size_t L, class E = random::default_engine_type>
+        auto rand(const I (&shape)[L], T lower = 0, T upper = 1,
+                  E& engine = random::get_default_random_engine());
+
+        template <class T, class I, std::size_t L, class E = random::default_engine_type>
+        auto randint(const I (&shape)[L], T lower = 0, T upper = std::numeric_limits<T>::max(),
+                     E& engine = random::get_default_random_engine());
+
+        template <class T, class I, std::size_t L, class E = random::default_engine_type>
+        auto randn(const I (&shape)[L], T mean = 0, T std_dev = 1,
+                   E& engine = random::get_default_random_engine());
+#endif
+    }
+
+    namespace detail
+    {
+        template <class T>
+        struct random_impl
+        {
+            using value_type = T;
+
+            random_impl(std::function<value_type()>&& generator)
+                : m_generator(std::move(generator))
+            {
+            }
+
+            template <class... Args>
+            inline value_type operator()(Args...) const
+            {
+                return m_generator();
+            }
+
+            template <class It>
+            inline value_type element(It, It) const
+            {
+                return m_generator();
+            }
+
+        private:
+            std::function<value_type()> m_generator;
+        };
+    }
+
+    namespace random
+    {
+        /**
+         * Returns a reference to the default random number engine
+         */
+        inline default_engine_type& get_default_random_engine()
+        {
+            static default_engine_type mt;
+            return mt;
+        }
+
+        /**
+         * Seeds the default random number generator with @p seed
+         * @param seed The seed
+         */
+        inline void seed(seed_type seed)
+        {
+            get_default_random_engine().seed(seed);
+        }
+
+        /**
+         * xexpression with specified @p shape containing uniformly distributed random numbers 
+         * in the interval from @p lower to @p upper, excluding upper.
+         * 
+         * Numbers are drawn from @c std::uniform_real_distribution.
+         * 
+         * @param shape shape of resulting xexpression
+         * @param lower lower bound
+         * @param upper upper bound
+         * @param engine random number engine
+         * @tparam T number type to use
+         */
+        template <class T, class S, class E>
+        inline auto rand(const S& shape, T lower, T upper, E& engine)
+        {
+            std::uniform_real_distribution<T> dist(lower, upper);
+            return detail::make_xgenerator(detail::random_impl<T>(std::bind(dist, std::ref(engine))), shape);
+        }
+
+        /**
+         * xexpression with specified @p shape containing uniformly distributed 
+         * random integers in the interval from @p lower to @p upper, excluding upper.
+         * 
+         * Numbers are drawn from @c std::uniform_int_distribution.
+         * 
+         * @param shape shape of resulting xexpression
+         * @param lower lower bound
+         * @param upper upper bound
+         * @param engine random number engine
+         * @tparam T number type to use
+         */
+        template <class T, class S, class E>
+        inline auto randint(const S& shape, T lower, T upper, E& engine)
+        {
+            std::uniform_int_distribution<T> dist(lower, upper - 1);
+            return detail::make_xgenerator(detail::random_impl<T>(std::bind(dist, std::ref(engine))), shape);
+        }
+
+        /**
+         * xexpression with specified @p shape containing numbers sampled from 
+         * the Normal (Gaussian) random number distribution with mean @p mean and 
+         * standard deviation @p std_dev.
+         * 
+         * Numbers are drawn from @c std::normal_distribution.
+         * 
+         * @param shape shape of resulting xexpression
+         * @param mean mean of normal distribution
+         * @param std_dev standard deviation of normal distribution
+         * @param engine random number engine
+         * @tparam T number type to use
+         */
+        template <class T, class S, class E>
+        inline auto randn(const S& shape, T mean, T std_dev, E& engine)
+        {
+            std::normal_distribution<T> dist(mean, std_dev);
+            return detail::make_xgenerator(detail::random_impl<T>(std::bind(dist, std::ref(engine))), shape);
+        }
+
+#ifdef X_OLD_CLANG
+        template <class T, class I, class E>
+        inline auto rand(std::initializer_list<I> shape, T lower, T upper, E& engine)
+        {
+            std::uniform_real_distribution<T> dist(lower, upper);
+            return detail::make_xgenerator(detail::random_impl<T>(std::bind(dist, std::ref(engine))), shape);
+        }
+
+        template <class T, class I, class E>
+        inline auto randint(std::initializer_list<I> shape, T lower, T upper, E& engine)
+        {
+            std::uniform_int_distribution<T> dist(lower, upper - 1);
+            return detail::make_xgenerator(detail::random_impl<T>(std::bind(dist, std::ref(engine))), shape);
+        }
+
+        template <class T, class I, class E>
+        inline auto randn(std::initializer_list<I> shape, T mean, T std_dev, E& engine)
+        {
+            std::normal_distribution<T> dist(mean, std_dev);
+            return detail::make_xgenerator(detail::random_impl<T>(std::bind(dist, std::ref(engine))), shape);
+        }
+#else
+        template <class T, class I, std::size_t L, class E>
+        inline auto rand(const I (&shape)[L], T lower, T upper, E& engine)
+        {
+            std::uniform_real_distribution<T> dist(lower, upper);
+            return detail::make_xgenerator(detail::random_impl<T>(std::bind(dist, std::ref(engine))), shape);
+        }
+
+        template <class T, class I, std::size_t L, class E>
+        inline auto randint(const I (&shape)[L], T lower, T upper, E& engine)
+        {
+            std::uniform_int_distribution<T> dist(lower, upper - 1);
+            return detail::make_xgenerator(detail::random_impl<T>(std::bind(dist, std::ref(engine))), shape);
+        }
+
+        template <class T, class I, std::size_t L, class E>
+        inline auto randn(const I (&shape)[L], T mean, T std_dev, E& engine)
+        {
+            std::normal_distribution<T> dist(mean, std_dev);
+            return detail::make_xgenerator(detail::random_impl<T>(std::bind(dist, std::ref(engine))), shape);
+        }
+#endif
+    }
+}
+
+#endif

--- a/inst/include/xtensor/xreducer.hpp
+++ b/inst/include/xtensor/xreducer.hpp
@@ -1,0 +1,625 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XREDUCER_HPP
+#define XREDUCER_HPP
+
+#include <algorithm>
+#include <cstddef>
+#include <initializer_list>
+#include <iterator>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+#ifdef X_OLD_CLANG
+#include <vector>
+#endif
+
+#include "xbuilder.hpp"
+#include "xexpression.hpp"
+#include "xgenerator.hpp"
+#include "xiterable.hpp"
+#include "xreducer.hpp"
+#include "xutils.hpp"
+
+namespace xt
+{
+
+    /**********
+     * reduce *
+     **********/
+
+    template <class F, class E, class X>
+    auto reduce(F&& f, E&& e, X&& axes) noexcept;
+
+    template <class F, class E>
+    auto reduce(F&& f, E&& e) noexcept;
+
+#ifdef X_OLD_CLANG
+    template <class F, class E, class I>
+    auto reduce(F&& f, E&& e, std::initializer_list<I> axes) noexcept;
+#else
+    template <class F, class E, class I, std::size_t N>
+    auto reduce(F&& f, E&& e, const I (&axes)[N]) noexcept;
+#endif
+
+    /*************
+     * xreducer  *
+     *************/
+
+    template <class ST, class X>
+    struct xreducer_shape_type;
+
+    template <class F, class CT, class X>
+    class xreducer;
+
+    template <class F, class CT, class X>
+    class xreducer_stepper;
+
+    template <class F, class CT, class X>
+    struct xiterable_inner_types<xreducer<F, CT, X>>
+    {
+        using xexpression_type = std::decay_t<CT>;
+        using inner_shape_type = typename xreducer_shape_type<typename xexpression_type::shape_type, X>::type;
+        using const_stepper = xreducer_stepper<F, CT, X>;
+        using stepper = const_stepper;
+        using const_iterator = xiterator<const_stepper, inner_shape_type*, DEFAULT_LAYOUT>;
+        using iterator = const_iterator;
+        using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+        using reverse_iterator = std::reverse_iterator<iterator>;
+    };
+
+    /**
+     * @class xreducer
+     * @brief Reducing function operating over specified axes.
+     *
+     * The xreducer class implements an \ref xexpression applying
+     * a reducing function to an \ref xexpression over the specified
+     * axes.
+     *
+     * @tparam F the function type
+     * @tparam CT the closure type of the \ref xexpression to reduce
+     * @tparam X the list of axes
+     *
+     * @sa reduce
+     */
+    template <class F, class CT, class X>
+    class xreducer : public xexpression<xreducer<F, CT, X>>,
+                     public xexpression_const_iterable<xreducer<F, CT, X>>
+    {
+
+    public:
+
+        using self_type = xreducer<F, CT, X>;
+        using functor_type = typename std::remove_reference<F>::type;
+        using xexpression_type = std::decay_t<CT>;
+        using axes_type = X;
+
+        using value_type = typename xexpression_type::value_type;
+        using reference = value_type;
+        using const_reference = value_type;
+        using pointer = value_type*;
+        using const_pointer = const value_type*;
+
+        using size_type = typename xexpression_type::size_type;
+        using difference_type = typename xexpression_type::difference_type;
+
+        using iterable_base = xexpression_const_iterable<self_type>;
+        using inner_shape_type = typename iterable_base::inner_shape_type;
+        using shape_type = inner_shape_type;
+
+        using stepper = typename iterable_base::stepper;
+        using const_stepper = typename iterable_base::const_stepper;
+
+        static constexpr layout_type static_layout = layout_type::dynamic;
+        static constexpr bool contiguous_layout = false;
+
+        template <class Func, class CTA, class AX>
+        xreducer(Func&& func, CTA&& e, AX&& axes);
+
+        size_type size() const noexcept;
+        size_type dimension() const noexcept;
+        const inner_shape_type& shape() const noexcept;
+        layout_type layout() const noexcept;
+
+        template <class... Args>
+        const_reference operator()(Args... args) const;
+        const_reference operator[](const xindex& index) const;
+        const_reference operator[](size_type i) const;
+
+        template <class It>
+        const_reference element(It first, It last) const;
+
+        template <class S>
+        bool broadcast_shape(S& shape) const;
+
+        template <class S>
+        bool is_trivial_broadcast(const S& strides) const noexcept;
+
+        template <class S>
+        const_stepper stepper_begin(const S& shape) const noexcept;
+        template <class S>
+        const_stepper stepper_end(const S& shape) const noexcept;
+
+    private:
+
+        CT m_e;
+        functor_type m_f;
+        axes_type m_axes;
+        inner_shape_type m_shape;
+        shape_type m_dim_mapping;
+
+        friend class xreducer_stepper<F, CT, X>;
+    };
+
+    /*************************
+     * reduce implementation *
+     *************************/
+
+    /**
+     * @brief Returns an \ref xexpression applying the speficied reducing
+     * function to an expresssion over the given axes.
+     *
+     * @param f the reducing function to apply.
+     * @param e the \ref xexpression to reduce.
+     * @param axes the list of axes.
+     *
+     * The returned expression either hold a const reference to \p e or a copy
+     * depending on whether \p e is an lvalue or an rvalue.
+     */
+
+    template <class F, class E, class X>
+    inline auto reduce(F&& f, E&& e, X&& axes) noexcept
+    {
+        using reducer_type = xreducer<F, const_xclosure_t<E>, const_closure_t<X>>;
+        return reducer_type(std::forward<F>(f), std::forward<E>(e), std::forward<X>(axes));
+    }
+
+    template <class F, class E>
+    inline auto reduce(F&& f, E&& e) noexcept
+    {
+        auto ar = arange(e.dimension());
+        using AR = decltype(ar);
+        using reducer_type = xreducer<F, const_xclosure_t<E>, AR>;
+        return reducer_type(std::forward<F>(f), std::forward<E>(e), std::move(ar));
+    }
+
+#ifdef X_OLD_CLANG
+    template <class F, class E, class I>
+    inline auto reduce(F&& f, E&& e, std::initializer_list<I> axes) noexcept
+    {
+        using axes_type = std::vector<typename std::decay_t<E>::size_type>;
+        using reducer_type = xreducer<F, const_xclosure_t<E>, axes_type>;
+        return reducer_type(std::forward<F>(f), std::forward<E>(e), forward_sequence<axes_type>(axes));
+    }
+#else
+    template <class F, class E, class I, std::size_t N>
+    inline auto reduce(F&& f, E&& e, const I (&axes)[N]) noexcept
+    {
+        using axes_type = std::array<typename std::decay_t<E>::size_type, N>;
+        using reducer_type = xreducer<F, const_xclosure_t<E>, axes_type>;
+        return reducer_type(std::forward<F>(f), std::forward<E>(e), forward_sequence<axes_type>(axes));
+    }
+#endif
+
+    /********************
+     * xreducer_stepper *
+     ********************/
+
+    template <class F, class CT, class X>
+    class xreducer_stepper
+    {
+
+    public:
+
+        using self_type = xreducer_stepper<F, CT, X>;
+        using xreducer_type = xreducer<F, CT, X>;
+
+        using value_type = typename xreducer_type::value_type;
+        using reference = typename xreducer_type::value_type;
+        using pointer = typename xreducer_type::const_pointer;
+        using size_type = typename xreducer_type::size_type;
+        using difference_type = typename xreducer_type::difference_type;
+
+        using xexpression_type = typename xreducer_type::xexpression_type;
+        using substepper_type = typename xexpression_type::const_stepper;
+        using shape_type = typename xreducer_type::shape_type;
+
+        xreducer_stepper(const xreducer_type& red, size_type offset, bool end = false);
+
+        reference operator*() const;
+
+        void step(size_type dim, size_type n = 1);
+        void step_back(size_type dim, size_type n = 1);
+        void reset(size_type dim);
+        void reset_back(size_type dim);
+
+        void to_begin();
+        void to_end();
+
+        bool equal(const self_type& rhs) const;
+
+    private:
+
+        reference aggregate(size_type dim) const;
+
+        substepper_type get_substepper_begin() const;
+        size_type get_dim(size_type dim) const noexcept;
+        size_type shape(size_type i) const noexcept;
+        size_type axis(size_type i) const noexcept;
+
+        const xreducer_type& m_reducer;
+        size_type m_offset;
+        mutable substepper_type m_stepper;
+    };
+
+    template <class F, class CT, class X>
+    bool operator==(const xreducer_stepper<F, CT, X>& lhs,
+                    const xreducer_stepper<F, CT, X>& rhs);
+
+    template <class F, class CT, class X>
+    bool operator!=(const xreducer_stepper<F, CT, X>& lhs,
+                    const xreducer_stepper<F, CT, X>& rhs);
+
+    /******************
+     * xreducer utils *
+     ******************/
+
+    // meta-function returning the shape type for an xreducer
+    template <class ST, class X>
+    struct xreducer_shape_type
+    {
+        using type = promote_shape_t<ST, std::decay_t<X>>;
+    };
+
+    template <class I1, std::size_t N1, class I2, std::size_t N2>
+    struct xreducer_shape_type<std::array<I1, N1>, std::array<I2, N2>>
+    {
+        using type = std::array<I2, N1 - N2>;
+    };
+
+    namespace detail
+    {
+        template <class InputIt, class ExcludeIt, class OutputIt>
+        inline void excluding_copy(InputIt first, InputIt last,
+            ExcludeIt e_first, ExcludeIt e_last,
+            OutputIt d_first, OutputIt map_first)
+        {
+            using difference_type = typename std::iterator_traits<InputIt>::difference_type;
+            InputIt iter = first;
+            while (iter != last && e_first != e_last)
+            {
+                auto diff = std::distance(first, iter);
+                if (diff != difference_type(*e_first))
+                {
+                    *d_first++ = *iter++;
+                    *map_first++ = diff;
+                }
+                else
+                {
+                    ++iter;
+                    ++e_first;
+                }
+            }
+            auto diff = std::distance(first, iter);
+            auto end = std::distance(iter, last);
+            std::iota(map_first, map_first + end, diff);
+            std::copy(iter, last, d_first);
+        }
+    }
+
+    /***************************
+     * xreducer implementation *
+     ***************************/
+
+    /**
+     * @name Constructor
+     */
+    //@{
+    /**
+     * Constructs an xreducer expression applying the specified
+     * function to the given expression over the given axes.
+     *
+     * @param func the function to apply
+     * @param e the expression to reduce
+     * @param axes the axes along which the reduction is performed
+     */
+    template <class F, class CT, class X>
+    template <class Func, class CTA, class AX>
+    inline xreducer<F, CT, X>::xreducer(Func&& func, CTA&& e, AX&& axes)
+        : m_e(std::forward<CTA>(e)), m_f(std::forward<Func>(func)), m_axes(std::forward<AX>(axes)),
+          m_shape(make_sequence<shape_type>(m_e.dimension() - m_axes.size(), 0)),
+          m_dim_mapping(make_sequence<shape_type>(m_e.dimension() - m_axes.size(), 0))
+    {
+        if (!std::is_sorted(m_axes.cbegin(), m_axes.cend()))
+        {
+            throw std::runtime_error("Reducing axes should be sorted");
+        }
+        detail::excluding_copy(m_e.shape().begin(), m_e.shape().end(),
+                               m_axes.begin(), m_axes.end(),
+                               m_shape.begin(), m_dim_mapping.begin());
+    }
+    //@}
+
+    /**
+     * @name Size and shape
+     */
+    /**
+     * Returns the size of the expression.
+     */
+    template <class F, class CT, class X>
+    inline auto xreducer<F, CT, X>::size() const noexcept -> size_type
+    {
+        return compute_size(shape());
+    }
+
+    /**
+     * Returns the number of dimensions of the expression.
+     */
+    template <class F, class CT, class X>
+    inline auto xreducer<F, CT, X>::dimension() const noexcept -> size_type
+    {
+        return m_shape.size();
+    }
+
+    /**
+     * Returns the shape of the expression.
+     */
+    template <class F, class CT, class X>
+    inline auto xreducer<F, CT, X>::shape() const noexcept -> const inner_shape_type&
+    {
+        return m_shape;
+    }
+
+    /**
+     * Returns the shape of the expression.
+     */
+    template <class F, class CT, class X>
+    inline layout_type xreducer<F, CT, X>::layout() const noexcept
+    {
+        return static_layout;
+    }
+    //@}
+
+    /**
+     * @name Data
+     */
+    /**
+     * Returns a constant reference to the element at the specified position in the reducer.
+     * @param args a list of indices specifying the position in the reducer. Indices
+     * must be unsigned integers, the number of indices should be equal or greater than
+     * the number of dimensions of the reducer.
+     */
+    template <class F, class CT, class X>
+    template <class... Args>
+    inline auto xreducer<F, CT, X>::operator()(Args... args) const -> const_reference
+    {
+        std::array<std::size_t, sizeof...(Args)> arg_array = {static_cast<std::size_t>(args)...};
+        return element(arg_array.cbegin(), arg_array.cend());
+    }
+
+    /**
+     * Returns a constant reference to the element at the specified position in the reducer.
+     * @param index a sequence of indices specifying the position in the reducer. Indices
+     * must be unsigned integers, the number of indices in the sequence should be equal or greater
+     * than the number of dimensions of the reducer.
+     */
+    template <class F, class CT, class X>
+    inline auto xreducer<F, CT, X>::operator[](const xindex& index) const -> const_reference
+    {
+        return element(index.cbegin(), index.cend());
+    }
+
+    template <class F, class CT, class X>
+    inline auto xreducer<F, CT, X>::operator[](size_type i) const -> const_reference
+    {
+        return operator()(i);
+    }
+
+    /**
+     * Returns a constant reference to the element at the specified position in the reducer.
+     * @param first iterator starting the sequence of indices
+     * @param last iterator ending the sequence of indices
+     * The number of indices in the squence should be equal to or greater
+     * than the number of dimensions of the reducer.
+     */
+    template <class F, class CT, class X>
+    template <class It>
+    inline auto xreducer<F, CT, X>::element(It first, It last) const -> const_reference
+    {
+        auto stepper = const_stepper(*this, 0);
+        size_type dim = 0;
+        while (first != last)
+        {
+            stepper.step(dim++, *first++);
+        }
+        return *stepper;
+    }
+    //@}
+
+    /**
+     * @name Broadcasting
+     */
+    //@{
+    /**
+     * Broadcast the shape of the reducer to the specified parameter.
+     * @param shape the result shape
+     * @return a boolean indicating whether the broadcasting is trivial
+     */
+    template <class F, class CT, class X>
+    template <class S>
+    inline bool xreducer<F, CT, X>::broadcast_shape(S& shape) const
+    {
+        return xt::broadcast_shape(m_shape, shape);
+    }
+
+    /**
+     * Compares the specified strides with those of the container to see whether
+     * the broadcasting is trivial.
+     * @return a boolean indicating whether the broadcasting is trivial
+     */
+    template <class F, class CT, class X>
+    template <class S>
+    inline bool xreducer<F, CT, X>::is_trivial_broadcast(const S& /*strides*/) const noexcept
+    {
+        return false;
+    }
+    //@}
+
+    template <class F, class CT, class X>
+    template <class S>
+    inline auto xreducer<F, CT, X>::stepper_begin(const S& shape) const noexcept -> const_stepper
+    {
+        size_type offset = shape.size() - dimension();
+        return const_stepper(*this, offset);
+    }
+
+    template <class F, class CT, class X>
+    template <class S>
+    inline auto xreducer<F, CT, X>::stepper_end(const S& shape) const noexcept -> const_stepper
+    {
+        size_type offset = shape.size() - dimension();
+        return const_stepper(*this, offset, true);
+    }
+
+    /***********************************
+     * xreducer_stepper implementation *
+     ***********************************/
+
+    template <class F, class CT, class X>
+    inline xreducer_stepper<F, CT, X>::xreducer_stepper(const xreducer_type& red, size_type offset, bool end)
+        : m_reducer(red), m_offset(offset),
+          m_stepper(get_substepper_begin())
+    {
+        if (end)
+        {
+            to_end();
+        }
+    }
+
+    template <class F, class CT, class X>
+    inline auto xreducer_stepper<F, CT, X>::operator*() const -> reference
+    {
+        reference r = aggregate(0);
+        return r;
+    }
+
+    template <class F, class CT, class X>
+    inline void xreducer_stepper<F, CT, X>::step(size_type dim, size_type n)
+    {
+        if (dim >= m_offset)
+            m_stepper.step(get_dim(dim), n);
+    }
+
+    template <class F, class CT, class X>
+    inline void xreducer_stepper<F, CT, X>::step_back(size_type dim, size_type n)
+    {
+        if (dim >= m_offset)
+            m_stepper.step_back(get_dim(dim), n);
+    }
+
+    template <class F, class CT, class X>
+    inline void xreducer_stepper<F, CT, X>::reset(size_type dim)
+    {
+        if (dim >= m_offset)
+            m_stepper.reset(get_dim(dim));
+    }
+
+    template <class F, class CT, class X>
+    inline void xreducer_stepper<F, CT, X>::reset_back(size_type dim)
+    {
+        if (dim >= m_offset)
+            m_stepper.reset_back(get_dim(dim));
+    }
+
+    template <class F, class CT, class X>
+    inline void xreducer_stepper<F, CT, X>::to_begin()
+    {
+        m_stepper.to_begin();
+    }
+
+    template <class F, class CT, class X>
+    inline void xreducer_stepper<F, CT, X>::to_end()
+    {
+        m_stepper.to_end();
+    }
+
+    template <class F, class CT, class X>
+    inline bool xreducer_stepper<F, CT, X>::equal(const self_type& rhs) const
+    {
+        return &m_reducer == &(rhs.m_reducer) && m_stepper.equal(rhs.m_stepper);
+    }
+
+    template <class F, class CT, class X>
+    inline auto xreducer_stepper<F, CT, X>::aggregate(size_type dim) const -> reference
+    {
+        size_type index = axis(dim);
+        size_type size = shape(index);
+        reference res;
+        if (dim != m_reducer.m_axes.size() - 1)
+        {
+            res = aggregate(dim + 1);
+            for (size_type i = 1; i != size; ++i)
+            {
+                m_stepper.step(index);
+                res = m_reducer.m_f(res, aggregate(dim + 1));
+            }
+        }
+        else
+        {
+            res = *m_stepper;
+            for (size_type i = 1; i != size; ++i)
+            {
+                m_stepper.step(index);
+                res = m_reducer.m_f(res, *m_stepper);
+            }
+        }
+        m_stepper.reset(index);
+        return res;
+    }
+
+    template <class F, class CT, class X>
+    inline auto xreducer_stepper<F, CT, X>::get_substepper_begin() const -> substepper_type
+    {
+        return m_reducer.m_e.stepper_begin(m_reducer.m_e.shape());
+    }
+
+    template <class F, class CT, class X>
+    inline auto xreducer_stepper<F, CT, X>::get_dim(size_type dim) const noexcept -> size_type
+    {
+        return m_reducer.m_dim_mapping[dim];
+    }
+
+    template <class F, class CT, class X>
+    inline auto xreducer_stepper<F, CT, X>::shape(size_type i) const noexcept -> size_type
+    {
+        return m_reducer.m_e.shape()[i];
+    }
+
+    template <class F, class CT, class X>
+    inline auto xreducer_stepper<F, CT, X>::axis(size_type i) const noexcept -> size_type
+    {
+        return m_reducer.m_axes[i];
+    }
+
+    template <class F, class CT, class X>
+    inline bool operator==(const xreducer_stepper<F, CT, X>& lhs,
+                           const xreducer_stepper<F, CT, X>& rhs)
+    {
+        return lhs.equal(rhs);
+    }
+
+    template <class F, class CT, class X>
+    inline bool operator!=(const xreducer_stepper<F, CT, X>& lhs,
+                           const xreducer_stepper<F, CT, X>& rhs)
+    {
+        return !lhs.equal(rhs);
+    }
+}
+
+#endif

--- a/inst/include/xtensor/xscalar.hpp
+++ b/inst/include/xtensor/xscalar.hpp
@@ -1,0 +1,599 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XSCALAR_HPP
+#define XSCALAR_HPP
+
+#include <array>
+#include <cstddef>
+#include <utility>
+
+#include "xexpression.hpp"
+#include "xiterable.hpp"
+#include "xlayout.hpp"
+
+namespace xt
+{
+
+    /***********
+     * xscalar *
+     ***********/
+
+    // xscalar is a cheap wrapper for a scalar value as an xexpression.
+
+    template <bool is_const, class CT>
+    class xscalar_stepper;
+
+    template <bool is_const, class CT>
+    class xdummy_iterator;
+
+    template <class CT>
+    class xscalar;
+
+    template <class CT>
+    struct xiterable_inner_types<xscalar<CT>>
+    {
+        using value_type = std::decay_t<CT>;
+        using inner_shape_type = std::array<std::size_t, 0>;
+        using iterator = value_type*;
+        using const_iterator = const value_type*;
+        using const_stepper = xscalar_stepper<true, CT>;
+        using stepper = xscalar_stepper<false, CT>;
+        using reverse_iterator = std::reverse_iterator<iterator>;
+        using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+    };
+
+    template <class CT>
+    class xscalar : public xexpression<xscalar<CT>>,
+                    public xiterable<xscalar<CT>>
+    {
+
+    public:
+
+        using self_type = xscalar<CT>;
+
+        using value_type = std::decay_t<CT>;
+        using reference = value_type&;
+        using const_reference = const value_type&;
+        using pointer = value_type*;
+        using const_pointer = const value_type*;
+        using size_type = std::size_t;
+        using difference_type = std::ptrdiff_t;
+
+        using iterable_base = xiterable<self_type>;
+        using inner_shape_type = typename iterable_base::inner_shape_type;
+        using shape_type = inner_shape_type;
+
+        using stepper = typename iterable_base::stepper;
+        using const_stepper = typename iterable_base::const_stepper;
+
+        using iterator = typename iterable_base::iterator;
+        using const_iterator = typename iterable_base::const_iterator;
+
+        using dummy_iterator = xdummy_iterator<false, CT>;
+        using const_dummy_iterator = xdummy_iterator<true, CT>;
+
+        static constexpr layout_type static_layout = layout_type::any;
+        static constexpr bool contiguous_layout = true;
+
+        xscalar(CT value) noexcept;
+
+        size_type size() const noexcept;
+        size_type dimension() const noexcept;
+        const shape_type& shape() const noexcept;
+        layout_type layout() const noexcept;
+
+        template <class... Args>
+        reference operator()(Args...) noexcept;
+        reference operator[](const xindex&) noexcept;
+        reference operator[](size_type) noexcept;
+
+        template <class... Args>
+        const_reference operator()(Args...) const noexcept;
+        const_reference operator[](const xindex&) const noexcept;
+        const_reference operator[](size_type) const noexcept;
+
+        template <class It>
+        reference element(It, It) noexcept;
+
+        template <class It>
+        const_reference element(It, It) const noexcept;
+
+        template <class S>
+        bool broadcast_shape(S& shape) const noexcept;
+
+        template <class S>
+        bool is_trivial_broadcast(const S& strides) const noexcept;
+
+        iterator begin() noexcept;
+        iterator end() noexcept;
+
+        const_iterator begin() const noexcept;
+        const_iterator end() const noexcept;
+        const_iterator cbegin() const noexcept;
+        const_iterator cend() const noexcept;
+
+        template <class S>
+        stepper stepper_begin(const S& shape) noexcept;
+        template <class S>
+        stepper stepper_end(const S& shape) noexcept;
+
+        template <class S>
+        const_stepper stepper_begin(const S& shape) const noexcept;
+        template <class S>
+        const_stepper stepper_end(const S& shape) const noexcept;
+
+        dummy_iterator dummy_begin() noexcept;
+        dummy_iterator dummy_end() noexcept;
+
+        const_dummy_iterator dummy_begin() const noexcept;
+        const_dummy_iterator dummy_end() const noexcept;
+
+    private:
+
+        CT m_value;
+    };
+
+    template <class T>
+    xscalar<T&> xref(T& t);
+
+    template <class T>
+    xscalar<const T&> xcref(T& t);
+
+    /*******************
+     * xscalar_stepper *
+     *******************/
+
+    template <bool is_const, class CT>
+    class xscalar_stepper
+    {
+
+    public:
+
+        using self_type = xscalar_stepper<is_const, CT>;
+        using container_type = std::conditional_t<is_const,
+                                                  const xscalar<CT>,
+                                                  xscalar<CT>>;
+
+        using value_type = typename container_type::value_type;
+        using reference = std::conditional_t<is_const,
+                                             typename container_type::const_reference,
+                                             typename container_type::reference>;
+        using pointer = std::conditional_t<is_const,
+                                           typename container_type::const_pointer,
+                                           typename container_type::pointer>;
+        using size_type = typename container_type::size_type;
+        using difference_type = typename container_type::difference_type;
+
+        xscalar_stepper(container_type* c) noexcept;
+
+        reference operator*() const noexcept;
+
+        void step(size_type dim, size_type n = 1) noexcept;
+        void step_back(size_type dim, size_type n = 1) noexcept;
+        void reset(size_type dim) noexcept;
+        void reset_back(size_type dim) noexcept;
+
+        void to_begin() noexcept;
+        void to_end() noexcept;
+
+        bool equal(const self_type& rhs) const noexcept;
+
+    private:
+
+        container_type* p_c;
+    };
+
+    template <bool is_const, class CT>
+    bool operator==(const xscalar_stepper<is_const, CT>& lhs,
+                    const xscalar_stepper<is_const, CT>& rhs) noexcept;
+
+    template <bool is_const, class CT>
+    bool operator!=(const xscalar_stepper<is_const, CT>& lhs,
+                    const xscalar_stepper<is_const, CT>& rhs) noexcept;
+
+    /********************
+     * xdummy_iterator *
+     ********************/
+
+    template <bool is_const, class CT>
+    class xdummy_iterator
+    {
+
+    public:
+
+        using self_type = xdummy_iterator<is_const, CT>;
+        using container_type = std::conditional_t<is_const,
+                                                  const xscalar<CT>,
+                                                  xscalar<CT>>;
+
+        using value_type = typename container_type::value_type;
+        using reference = std::conditional_t<is_const,
+                                             typename container_type::const_reference,
+                                             typename container_type::reference>;
+        using pointer = std::conditional_t<is_const,
+                                           typename container_type::const_pointer,
+                                           typename container_type::pointer>;
+        using difference_type = typename container_type::difference_type;
+        using iterator_category = std::forward_iterator_tag;
+
+        explicit xdummy_iterator(container_type* c) noexcept;
+
+        self_type& operator++() noexcept;
+        self_type operator++(int) noexcept;
+
+        reference operator*() const noexcept;
+
+        bool equal(const self_type& rhs) const noexcept;
+
+    private:
+
+        container_type* p_c;
+    };
+
+    template <bool is_const, class CT>
+    bool operator==(const xdummy_iterator<is_const, CT>& lhs,
+                    const xdummy_iterator<is_const, CT>& rhs) noexcept;
+
+    template <bool is_const, class CT>
+    bool operator!=(const xdummy_iterator<is_const, CT>& lhs,
+                    const xdummy_iterator<is_const, CT>& rhs) noexcept;
+
+    /*******************************
+     * trivial_begin / trivial_end *
+     *******************************/
+
+    namespace detail
+    {
+        template <class CT>
+        constexpr auto trivial_begin(xscalar<CT>& c) -> decltype(c.dummy_begin())
+        {
+            return c.dummy_begin();
+        }
+
+        template <class CT>
+        constexpr auto trivial_end(xscalar<CT>& c) -> decltype(c.dummy_end())
+        {
+            return c.dummy_end();
+        }
+
+        template <class CT>
+        constexpr auto trivial_begin(const xscalar<CT>& c) -> decltype(c.dummy_begin())
+        {
+            return c.dummy_begin();
+        }
+
+        template <class CT>
+        constexpr auto trivial_end(const xscalar<CT>& c) -> decltype(c.dummy_end())
+        {
+            return c.dummy_end();
+        }
+    }
+
+    /**************************
+     * xscalar implementation *
+     **************************/
+
+    template <class CT>
+    inline xscalar<CT>::xscalar(CT value) noexcept
+        : m_value(value)
+    {
+    }
+
+    template <class CT>
+    inline auto xscalar<CT>::size() const noexcept -> size_type
+    {
+        return 1;
+    }
+
+    template <class CT>
+    inline auto xscalar<CT>::dimension() const noexcept -> size_type
+    {
+        return 0;
+    }
+
+    template <class CT>
+    inline auto xscalar<CT>::shape() const noexcept -> const shape_type&
+    {
+        static std::array<size_type, 0> zero_shape;
+        return zero_shape;
+    }
+
+    template <class CT>
+    inline layout_type xscalar<CT>::layout() const noexcept
+    {
+        return static_layout;
+    }
+
+    template <class CT>
+    template <class... Args>
+    inline auto xscalar<CT>::operator()(Args...) noexcept -> reference
+    {
+        return m_value;
+    }
+
+    template <class CT>
+    inline auto xscalar<CT>::operator[](const xindex&) noexcept -> reference
+    {
+        return m_value;
+    }
+
+    template <class CT>
+    inline auto xscalar<CT>::operator[](size_type) noexcept -> reference
+    {
+        return m_value;
+    }
+
+    template <class CT>
+    template <class... Args>
+    inline auto xscalar<CT>::operator()(Args...) const noexcept -> const_reference
+    {
+        return m_value;
+    }
+
+    template <class CT>
+    inline auto xscalar<CT>::operator[](const xindex&) const noexcept -> const_reference
+    {
+        return m_value;
+    }
+
+    template <class CT>
+    inline auto xscalar<CT>::operator[](size_type) const noexcept -> const_reference
+    {
+        return m_value;
+    }
+
+    template <class CT>
+    template <class It>
+    inline auto xscalar<CT>::element(It, It) noexcept -> reference
+    {
+        return m_value;
+    }
+
+    template <class CT>
+    template <class It>
+    inline auto xscalar<CT>::element(It, It) const noexcept -> const_reference
+    {
+        return m_value;
+    }
+
+    template <class CT>
+    template <class S>
+    inline bool xscalar<CT>::broadcast_shape(S&) const noexcept
+    {
+        return true;
+    }
+
+    template <class CT>
+    template <class S>
+    inline bool xscalar<CT>::is_trivial_broadcast(const S&) const noexcept
+    {
+        return true;
+    }
+
+    template <class CT>
+    inline auto xscalar<CT>::begin() noexcept -> iterator
+    {
+        return &m_value;
+    }
+
+    template <class CT>
+    inline auto xscalar<CT>::end() noexcept -> iterator
+    {
+        return &m_value + 1;
+    }
+
+    template <class CT>
+    inline auto xscalar<CT>::begin() const noexcept -> const_iterator
+    {
+        return &m_value;
+    }
+
+    template <class CT>
+    inline auto xscalar<CT>::end() const noexcept -> const_iterator
+    {
+        return &m_value + 1;
+    }
+
+    template <class CT>
+    inline auto xscalar<CT>::cbegin() const noexcept -> const_iterator
+    {
+        return &m_value;
+    }
+
+    template <class CT>
+    inline auto xscalar<CT>::cend() const noexcept -> const_iterator
+    {
+        return &m_value + 1;
+    }
+
+    template <class CT>
+    template <class S>
+    inline auto xscalar<CT>::stepper_begin(const S&) noexcept -> stepper
+    {
+        return stepper(this);
+    }
+
+    template <class CT>
+    template <class S>
+    inline auto xscalar<CT>::stepper_end(const S&) noexcept -> stepper
+    {
+        return stepper(this + 1);
+    }
+
+    template <class CT>
+    template <class S>
+    inline auto xscalar<CT>::stepper_begin(const S&) const noexcept -> const_stepper
+    {
+        return const_stepper(this);
+    }
+
+    template <class CT>
+    template <class S>
+    inline auto xscalar<CT>::stepper_end(const S&) const noexcept -> const_stepper
+    {
+        return const_stepper(this + 1);
+    }
+
+    template <class CT>
+    inline auto xscalar<CT>::dummy_begin() noexcept -> dummy_iterator
+    {
+        return dummy_iterator(this);
+    }
+
+    template <class CT>
+    inline auto xscalar<CT>::dummy_end() noexcept -> dummy_iterator
+    {
+        return dummy_iterator(this);
+    }
+
+    template <class CT>
+    inline auto xscalar<CT>::dummy_begin() const noexcept -> const_dummy_iterator
+    {
+        return const_dummy_iterator(this);
+    }
+
+    template <class CT>
+    inline auto xscalar<CT>::dummy_end() const noexcept -> const_dummy_iterator
+    {
+        return const_dummy_iterator(this);
+    }
+
+    template <class T>
+    inline xscalar<T&> xref(T& t)
+    {
+        return xscalar<T&>(t);
+    }
+
+    template <class T>
+    inline xscalar<const T&> xcref(T& t)
+    {
+        return xscalar<const T&>(t);
+    }
+
+    /**********************************
+     * xscalar_stepper implementation *
+     **********************************/
+
+    template <bool is_const, class CT>
+    inline xscalar_stepper<is_const, CT>::xscalar_stepper(container_type* c) noexcept
+        : p_c(c)
+    {
+    }
+
+    template <bool is_const, class CT>
+    inline auto xscalar_stepper<is_const, CT>::operator*() const noexcept -> reference
+    {
+        return p_c->operator()();
+    }
+
+    template <bool is_const, class CT>
+    inline void xscalar_stepper<is_const, CT>::step(size_type /*dim*/, size_type /*n*/) noexcept
+    {
+    }
+
+    template <bool is_const, class CT>
+    inline void xscalar_stepper<is_const, CT>::step_back(size_type /*dim*/, size_type /*n*/) noexcept
+    {
+    }
+
+    template <bool is_const, class CT>
+    inline void xscalar_stepper<is_const, CT>::reset(size_type /*dim*/) noexcept
+    {
+    }
+
+    template <bool is_const, class CT>
+    inline void xscalar_stepper<is_const, CT>::reset_back(size_type /*dim*/) noexcept
+    {
+    }
+
+    template <bool is_const, class CT>
+    inline void xscalar_stepper<is_const, CT>::to_begin() noexcept
+    {
+        p_c = p_c->stepper_begin(p_c->shap()).pc;
+    }
+
+    template <bool is_const, class CT>
+    inline void xscalar_stepper<is_const, CT>::to_end() noexcept
+    {
+        p_c = p_c->stepper_end(p_c->shape()).p_c;
+    }
+
+    template <bool is_const, class CT>
+    inline bool xscalar_stepper<is_const, CT>::equal(const self_type& rhs) const noexcept
+    {
+        return (p_c == rhs.p_c);
+    }
+
+    template <bool is_const, class CT>
+    inline bool operator==(const xscalar_stepper<is_const, CT>& lhs,
+                           const xscalar_stepper<is_const, CT>& rhs) noexcept
+    {
+        return lhs.equal(rhs);
+    }
+
+    template <bool is_const, class CT>
+    inline bool operator!=(const xscalar_stepper<is_const, CT>& lhs,
+                           const xscalar_stepper<is_const, CT>& rhs) noexcept
+    {
+        return !(lhs.equal(rhs));
+    }
+
+    /***********************************
+     * xdummy_iterator implementation *
+     ***********************************/
+
+    template <bool is_const, class CT>
+    inline xdummy_iterator<is_const, CT>::xdummy_iterator(container_type* c) noexcept
+        : p_c(c)
+    {
+    }
+
+    template <bool is_const, class CT>
+    inline auto xdummy_iterator<is_const, CT>::operator++() noexcept -> self_type&
+    {
+        return *this;
+    }
+
+    template <bool is_const, class CT>
+    inline auto xdummy_iterator<is_const, CT>::operator++(int) noexcept -> self_type
+    {
+        self_type tmp(*this);
+        ++(*this);
+        return tmp;
+    }
+
+    template <bool is_const, class CT>
+    inline auto xdummy_iterator<is_const, CT>::operator*() const noexcept -> reference
+    {
+        return p_c->operator()();
+    }
+
+    template <bool is_const, class CT>
+    inline bool xdummy_iterator<is_const, CT>::equal(const self_type& rhs) const noexcept
+    {
+        return p_c == rhs.p_c;
+    }
+
+    template <bool is_const, class CT>
+    inline bool operator==(const xdummy_iterator<is_const, CT>& lhs,
+                           const xdummy_iterator<is_const, CT>& rhs) noexcept
+    {
+        return lhs.equal(rhs);
+    }
+
+    template <bool is_const, class CT>
+    inline bool operator!=(const xdummy_iterator<is_const, CT>& lhs,
+                           const xdummy_iterator<is_const, CT>& rhs) noexcept
+    {
+        return !(lhs.equal(rhs));
+    }
+}
+
+#endif

--- a/inst/include/xtensor/xsemantic.hpp
+++ b/inst/include/xtensor/xsemantic.hpp
@@ -1,0 +1,567 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XSEMANTIC_HPP
+#define XSEMANTIC_HPP
+
+#include <functional>
+#include <utility>
+
+#include "xassign.hpp"
+#include "xexpression.hpp"
+
+namespace xt
+{
+
+    /**
+     * @class xsemantic_base
+     * @brief Base interface for assignable xexpressions.
+     *
+     * The xsemantic_base class defines the interface for assignable
+     * xexpressions.
+     *
+     * @tparam D The derived type, i.e. the inheriting class for which xsemantic_base
+     *           provides the interface.
+     */
+    template <class D>
+    class xsemantic_base : public xexpression<D>
+    {
+
+    public:
+
+        using base_type = xexpression<D>;
+        using derived_type = typename base_type::derived_type;
+
+        using temporary_type = typename xcontainer_inner_types<D>::temporary_type;
+
+        template <class E>
+        disable_xexpression<E, derived_type&> operator+=(const E&);
+
+        template <class E>
+        disable_xexpression<E, derived_type&> operator-=(const E&);
+
+        template <class E>
+        disable_xexpression<E, derived_type&> operator*=(const E&);
+
+        template <class E>
+        disable_xexpression<E, derived_type&> operator/=(const E&);
+
+        template <class E>
+        derived_type& operator+=(const xexpression<E>&);
+
+        template <class E>
+        derived_type& operator-=(const xexpression<E>&);
+
+        template <class E>
+        derived_type& operator*=(const xexpression<E>&);
+
+        template <class E>
+        derived_type& operator/=(const xexpression<E>&);
+
+        template <class E>
+        derived_type& assign(const xexpression<E>&);
+
+        template <class E>
+        derived_type& plus_assign(const xexpression<E>&);
+
+        template <class E>
+        derived_type& minus_assign(const xexpression<E>&);
+
+        template <class E>
+        derived_type& multiplies_assign(const xexpression<E>&);
+
+        template <class E>
+        derived_type& divides_assign(const xexpression<E>&);
+
+    protected:
+
+        xsemantic_base() = default;
+        ~xsemantic_base() = default;
+
+        xsemantic_base(const xsemantic_base&) = default;
+        xsemantic_base& operator=(const xsemantic_base&) = default;
+
+        xsemantic_base(xsemantic_base&&) = default;
+        xsemantic_base& operator=(xsemantic_base&&) = default;
+
+        template <class E>
+        derived_type& operator=(const xexpression<E>&);
+    };
+
+
+    /**
+     * @class xcontainer_semantic
+     * @brief Implementation of the xsemantic_base interface
+     * for dense multidimensional containers.
+     *
+     * The xcontainer_semantic class is an implementation of the
+     * xsemantic_base interface for dense multidimensional
+     * containers.
+     *
+     * @tparam D the derived type
+     */
+    template <class D>
+    class xcontainer_semantic : public xsemantic_base<D>
+    {
+
+    public:
+
+        using base_type = xsemantic_base<D>;
+        using derived_type = D;
+        using temporary_type = typename base_type::temporary_type;
+
+        derived_type& assign_temporary(temporary_type&);
+
+        template <class E>
+        derived_type& assign_xexpression(const xexpression<E>& e);
+
+        template <class E>
+        derived_type& computed_assign(const xexpression<E>& e);
+
+        template <class E, class F>
+        derived_type& scalar_computed_assign(const E& e, F&& f);
+
+    protected:
+
+        xcontainer_semantic() = default;
+        ~xcontainer_semantic() = default;
+
+        xcontainer_semantic(const xcontainer_semantic&) = default;
+        xcontainer_semantic& operator=(const xcontainer_semantic&) = default;
+
+        xcontainer_semantic(xcontainer_semantic&&) = default;
+        xcontainer_semantic& operator=(xcontainer_semantic&&) = default;
+
+        template <class E>
+        derived_type& operator=(const xexpression<E>&);
+    };
+
+
+    /**
+     * @class xadaptor_semantic
+     * @brief Implementation of the xsemantic_base interface
+     * for dense multidimensional container adaptors.
+     *
+     * The xadaptor_semantic class is an implementation of the
+     * xsemantic_base interface for dense multidimensional
+     * container adaptors.
+     *
+     * @tparam D the derived type
+     */
+    template <class D>
+    class xadaptor_semantic : public xsemantic_base<D>
+    {
+
+    public:
+
+        using base_type = xsemantic_base<D>;
+        using derived_type = D;
+        using temporary_type = typename base_type::temporary_type;
+
+        derived_type& assign_temporary(temporary_type&);
+
+        template <class E>
+        derived_type& assign_xexpression(const xexpression<E>& e);
+
+        template <class E>
+        derived_type& computed_assign(const xexpression<E>& e);
+
+        template <class E, class F>
+        derived_type& scalar_computed_assign(const E& e, F&& f);
+
+    protected:
+
+        xadaptor_semantic() = default;
+        ~xadaptor_semantic() = default;
+
+        xadaptor_semantic(const xadaptor_semantic&) = default;
+        xadaptor_semantic& operator=(const xadaptor_semantic&) = default;
+
+        xadaptor_semantic(xadaptor_semantic&&) = default;
+        xadaptor_semantic& operator=(xadaptor_semantic&&) = default;
+
+        template <class E>
+        derived_type& operator=(const xexpression<E>&);
+    };
+
+
+    /**
+     * @class xview_semantic
+     * @brief Implementation of the xsemantic_base interface for
+     * multidimensional views
+     *
+     * The xview_semantic is an implementation of the xsemantic_base
+     * interface for multidimensional views.
+     *
+     * @tparam D the derived type
+     */
+    template <class D>
+    class xview_semantic : public xsemantic_base<D>
+    {
+
+    public:
+
+        using base_type = xsemantic_base<D>;
+        using derived_type = D;
+        using temporary_type = typename base_type::temporary_type;
+
+        derived_type& assign_temporary(temporary_type&);
+
+        template <class E>
+        derived_type& assign_xexpression(const xexpression<E>& e);
+
+        template <class E>
+        derived_type& computed_assign(const xexpression<E>& e);
+
+        template <class E, class F>
+        derived_type& scalar_computed_assign(const E& e, F&& f);
+
+    protected:
+
+        xview_semantic() = default;
+        ~xview_semantic() = default;
+
+        xview_semantic(const xview_semantic&) = default;
+        xview_semantic& operator=(const xview_semantic&) = default;
+
+        xview_semantic(xview_semantic&&) = default;
+        xview_semantic& operator=(xview_semantic&&) = default;
+
+        template <class E>
+        derived_type& operator=(const xexpression<E>&);
+    };
+
+    /*********************************
+     * xsemantic_base implementation *
+     *********************************/
+
+    /**
+     * @name Computed assignement
+     */
+    //@{
+    /**
+     * Adds the scalar \c e to \c *this.
+     * @param e the scalar to add.
+     * @return a reference to \c *this.
+     */
+    template <class D>
+    template <class E>
+    inline auto xsemantic_base<D>::operator+=(const E& e) -> disable_xexpression<E, derived_type&>
+    {
+        return this->derived_cast().scalar_computed_assign(e, std::plus<>());
+    }
+
+    /**
+     * Subtracts the scalar \c e from \c *this.
+     * @param e the scalar to subtract.
+     * @return a reference to \c *this.
+     */
+    template <class D>
+    template <class E>
+    inline auto xsemantic_base<D>::operator-=(const E& e) -> disable_xexpression<E, derived_type&>
+    {
+        return this->derived_cast().scalar_computed_assign(e, std::minus<>());
+    }
+
+    /**
+     * Multiplies \c *this with the scalar \c e.
+     * @param e the scalar involved in the operation.
+     * @return a reference to \c *this.
+     */
+    template <class D>
+    template <class E>
+    inline auto xsemantic_base<D>::operator*=(const E& e) -> disable_xexpression<E, derived_type&>
+    {
+        return this->derived_cast().scalar_computed_assign(e, std::multiplies<>());
+    }
+
+    /**
+     * Divides \c *this by the scalar \c e.
+     * @param e the scalar involved in the operation.
+     * @return a reference to \c *this.
+     */
+    template <class D>
+    template <class E>
+    inline auto xsemantic_base<D>::operator/=(const E& e) -> disable_xexpression<E, derived_type&>
+    {
+        return this->derived_cast().scalar_computed_assign(e, std::divides<>());
+    }
+
+    /**
+     * Adds the xexpression \c e to \c *this.
+     * @param e the xexpression to add.
+     * @return a reference to \c *this.
+     */
+    template <class D>
+    template <class E>
+    inline auto xsemantic_base<D>::operator+=(const xexpression<E>& e) -> derived_type&
+    {
+        return operator=(this->derived_cast() + e.derived_cast());
+    }
+
+    /**
+     * Subtracts the xexpression \c e from \c *this.
+     * @param e the xexpression to subtract.
+     * @return a reference to \c *this.
+     */
+    template <class D>
+    template <class E>
+    inline auto xsemantic_base<D>::operator-=(const xexpression<E>& e) -> derived_type&
+    {
+        return operator=(this->derived_cast() - e.derived_cast());
+    }
+
+    /**
+     * Multiplies \c *this with the xexpression \c e.
+     * @param e the xexpression involved in the operation.
+     * @return a reference to \c *this.
+     */
+    template <class D>
+    template <class E>
+    inline auto xsemantic_base<D>::operator*=(const xexpression<E>& e) -> derived_type&
+    {
+        return operator=(this->derived_cast() * e.derived_cast());
+    }
+
+    /**
+     * Divides \c *this by the xexpression \c e.
+     * @param e the xexpression involved in the operation.
+     * @return a reference to \c *this.
+     */
+    template <class D>
+    template <class E>
+    inline auto xsemantic_base<D>::operator/=(const xexpression<E>& e) -> derived_type&
+    {
+        return operator=(this->derived_cast() / e.derived_cast());
+    }
+    //@}
+
+    /**
+     * @name Assign functions
+     */
+    /**
+     * Assigns the xexpression \c e to \c *this. Ensures no temporary
+     * will be used to perform the assignment.
+     * @param e the xexpression to assign.
+     * @return a reference to \c *this.
+     */
+    template <class D>
+    template <class E>
+    inline auto xsemantic_base<D>::assign(const xexpression<E>& e) -> derived_type&
+    {
+        return this->derived_cast().assign_xexpression(e);
+    }
+
+    /**
+     * Adds the xexpression \c e to \c *this. Ensures no temporary
+     * will be used to perform the assignment.
+     * @param e the xexpression to add.
+     * @return a reference to \c *this.
+     */
+    template <class D>
+    template <class E>
+    inline auto xsemantic_base<D>::plus_assign(const xexpression<E>& e) -> derived_type&
+    {
+        return this->derived_cast().computed_assign(this->derived_cast() + e.derived_cast());
+    }
+
+    /**
+     * Subtracts the xexpression \c e to \c *this. Ensures no temporary
+     * will be used to perform the assignment.
+     * @param e the xexpression to subtract.
+     * @return a reference to \c *this.
+     */
+    template <class D>
+    template <class E>
+    inline auto xsemantic_base<D>::minus_assign(const xexpression<E>& e) -> derived_type&
+    {
+        return this->derived_cast().computed_assign(this->derived_cast() - e.derived_cast());
+    }
+
+    /**
+     * Multiplies \c *this with the xexpression \c e. Ensures no temporary
+     * will be used to perform the assignment.
+     * @param e the xexpression involved in the operation.
+     * @return a reference to \c *this.
+     */
+    template <class D>
+    template <class E>
+    inline auto xsemantic_base<D>::multiplies_assign(const xexpression<E>& e) -> derived_type&
+    {
+        return this->derived_cast().computed_assign(this->derived_cast() * e.derived_cast());
+    }
+
+    /**
+     * Divides \c *this by the xexpression \c e. Ensures no temporary
+     * will be used to perform the assignment.
+     * @param e the xexpression involved in the operation.
+     * @return a reference to \c *this.
+     */
+    template <class D>
+    template <class E>
+    inline auto xsemantic_base<D>::divides_assign(const xexpression<E>& e) -> derived_type&
+    {
+        return this->derived_cast().computed_assign(this->derived_cast() / e.derived_cast());
+    }
+
+    template <class D>
+    template <class E>
+    inline auto xsemantic_base<D>::operator=(const xexpression<E>& e) -> derived_type&
+    {
+        temporary_type tmp(e);
+        return this->derived_cast().assign_temporary(tmp);
+    }
+
+    /**************************************
+     * xcontainer_semantic implementation *
+     **************************************/
+
+    /**
+     * Assigns the temporary \c tmp to \c *this.
+     * @param tmp the temporary to assign.
+     * @return a reference to \c *this.
+     */
+    template <class D>
+    inline auto xcontainer_semantic<D>::assign_temporary(temporary_type& tmp) -> derived_type&
+    {
+        using std::swap;
+        swap(this->derived_cast(), tmp);
+        return this->derived_cast();
+    }
+
+    template <class D>
+    template <class E>
+    inline auto xcontainer_semantic<D>::assign_xexpression(const xexpression<E>& e) -> derived_type&
+    {
+        xt::assign_xexpression(*this, e);
+        return this->derived_cast();
+    }
+
+    template <class D>
+    template <class E>
+    inline auto xcontainer_semantic<D>::computed_assign(const xexpression<E>& e) -> derived_type&
+    {
+        xt::computed_assign(*this, e);
+        return this->derived_cast();
+    }
+
+    template <class D>
+    template <class E, class F>
+    inline auto xcontainer_semantic<D>::scalar_computed_assign(const E& e, F&& f) -> derived_type&
+    {
+        xt::scalar_computed_assign(*this, e, std::forward<F>(f));
+        return this->derived_cast();
+    }
+
+    template <class D>
+    template <class E>
+    inline auto xcontainer_semantic<D>::operator=(const xexpression<E>& e) -> derived_type&
+    {
+        return base_type::operator=(e);
+    }
+
+    /************************************
+     * xadaptor_semantic implementation *
+     ************************************/
+
+    /**
+     * Assigns the temporary \c tmp to \c *this.
+     * @param tmp the temporary to assign.
+     * @return a reference to \c *this.
+     */
+    template <class D>
+    inline auto xadaptor_semantic<D>::assign_temporary(temporary_type& tmp) -> derived_type&
+    {
+        this->derived_cast().assign_temporary_impl(tmp);
+        return this->derived_cast();
+    }
+
+    template <class D>
+    template <class E>
+    inline auto xadaptor_semantic<D>::assign_xexpression(const xexpression<E>& e) -> derived_type&
+    {
+        xt::assign_xexpression(*this, e);
+        return this->derived_cast();
+    }
+
+    template <class D>
+    template <class E>
+    inline auto xadaptor_semantic<D>::computed_assign(const xexpression<E>& e) -> derived_type&
+    {
+        xt::computed_assign(*this, e);
+        return this->derived_cast();
+    }
+
+    template <class D>
+    template <class E, class F>
+    inline auto xadaptor_semantic<D>::scalar_computed_assign(const E& e, F&& f) -> derived_type&
+    {
+        xt::scalar_computed_assign(this, e, std::forward<F>(f));
+        return this->derived_cast();
+    }
+
+    template <class D>
+    template <class E>
+    inline auto xadaptor_semantic<D>::operator=(const xexpression<E>& e) -> derived_type&
+    {
+        return base_type::operator=(e);
+    }
+
+    /*********************************
+     * xview_semantic implementation *
+     *********************************/
+
+    /**
+     * Assigns the temporary \c tmp to \c *this.
+     * @param tmp the temporary to assign.
+     * @return a reference to \c *this.
+     */
+    template <class D>
+    inline auto xview_semantic<D>::assign_temporary(temporary_type& tmp) -> derived_type&
+    {
+        this->derived_cast().assign_temporary_impl(tmp);
+        return this->derived_cast();
+    }
+
+    template <class D>
+    template <class E>
+    inline auto xview_semantic<D>::assign_xexpression(const xexpression<E>& e) -> derived_type&
+    {
+        xt::assert_compatible_shape(*this, e);
+        xt::assign_data(*this, e, false);
+        return this->derived_cast();
+    }
+
+    template <class D>
+    template <class E>
+    inline auto xview_semantic<D>::computed_assign(const xexpression<E>& e) -> derived_type&
+    {
+        xt::assert_compatible_shape(*this, e);
+        xt::assign_data(*this, e, false);
+        return this->derived_cast();
+    }
+
+    template <class D>
+    template <class E, class F>
+    inline auto xview_semantic<D>::scalar_computed_assign(const E& e, F&& f) -> derived_type&
+    {
+        D& d = this->derived_cast();
+        std::transform(d.xbegin(), d.xend(), d.xbegin(),
+                       [e, &f](const auto& v) { return f(v, e); });
+        return this->derived_cast();
+    }
+
+    template <class D>
+    template <class E>
+    inline auto xview_semantic<D>::operator=(const xexpression<E>& e) -> derived_type&
+    {
+        return base_type::operator=(e);
+    }
+}
+
+#endif

--- a/inst/include/xtensor/xslice.hpp
+++ b/inst/include/xtensor/xslice.hpp
@@ -1,0 +1,529 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XSLICE_HPP
+#define XSLICE_HPP
+
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+
+#include "xutils.hpp"
+
+namespace xt
+{
+
+    namespace placeholders
+    {
+        // xtensor universal placeholder
+        struct xtuph
+        {
+        };
+
+        constexpr xtuph _{};
+    }
+
+    inline auto xnone()
+    {
+        return placeholders::xtuph();
+    }
+
+    /**********************
+     * xslice declaration *
+     **********************/
+
+    template <class D>
+    class xslice
+    {
+
+    public:
+
+        using derived_type = D;
+
+        derived_type& derived_cast() noexcept;
+        const derived_type& derived_cast() const noexcept;
+
+    protected:
+
+        xslice() = default;
+        ~xslice() = default;
+
+        xslice(const xslice&) = default;
+        xslice& operator=(const xslice&) = default;
+
+        xslice(xslice&&) = default;
+        xslice& operator=(xslice&&) = default;
+    };
+
+    template <class S>
+    using is_xslice = std::is_base_of<xslice<S>, S>;
+
+    template <class E, class R = void>
+    using disable_xslice = typename std::enable_if<!is_xslice<E>::value, R>::type;
+
+    template <class... E>
+    using has_xslice = or_<is_xslice<E>...>;
+
+    /**********************
+     * xrange declaration *
+     **********************/
+
+    template <class T>
+    class xrange : public xslice<xrange<T>>
+    {
+
+    public:
+
+        using size_type = T;
+
+        xrange() = default;
+        xrange(size_type min_val, size_type max_val) noexcept;
+
+        size_type operator()(size_type i) const noexcept;
+
+        size_type size() const noexcept;
+        size_type step_size() const noexcept;
+
+    private:
+
+        size_type m_min;
+        size_type m_size;
+    };
+
+    /**
+     * Returns a slice representing an interval, to
+     * be used as an argument of view function.
+     * @param min_val the first index of the interval
+     * @param max_val the last index of the interval
+     * @sa view
+     */
+    template <class T, class E = std::enable_if_t<!std::is_same<T, placeholders::xtuph>::value>>
+    inline auto range(T min_val, T max_val) noexcept
+    {
+        return xrange<T>(min_val, max_val);
+    }
+
+    /******************************
+     * xstepped_range declaration *
+     ******************************/
+
+    template <class T>
+    class xstepped_range : public xslice<xstepped_range<T>>
+    {
+
+    public:
+
+        using size_type = T;
+
+        xstepped_range() = default;
+        xstepped_range(size_type min_val, size_type max_val, size_type step) noexcept;
+
+        size_type operator()(size_type i) const noexcept;
+
+        size_type size() const noexcept;
+        size_type step_size() const noexcept;
+
+    private:
+
+        size_type m_min;
+        size_type m_size;
+        size_type m_step;
+    };
+
+    /**
+     * Returns a slice representing an interval, to
+     * be used as an argument of view function.
+     * @param min_val the first index of the interval
+     * @param max_val the last index of the interval
+     * @param step the space between two indices
+     * @sa view
+     */
+    template <class T, class E = std::enable_if_t<!std::is_same<T, placeholders::xtuph>::value>>
+    inline auto range(T min_val, T max_val, T step) noexcept
+    {
+        return xstepped_range<T>(min_val, max_val, step);
+    }
+
+    /********************
+     * xall declaration *
+     ********************/
+
+    template <class T>
+    class xall : public xslice<xall<T>>
+    {
+
+    public:
+
+        using size_type = T;
+
+        xall() = default;
+        explicit xall(size_type size) noexcept;
+
+        size_type operator()(size_type i) const noexcept;
+
+        size_type size() const noexcept;
+        size_type step_size() const noexcept;
+
+    private:
+
+        size_type m_size;
+    };
+
+    struct xall_tag
+    {
+    };
+
+    /**
+     * Returns a slice representing a full dimension,
+     * to be used as an argument of view function.
+     * @sa view
+     */
+    inline auto all() noexcept
+    {
+        return xall_tag();
+    }
+
+    /************************
+    * xnewaxis declaration *
+    ************************/
+
+    template <class T>
+    class xnewaxis : public xslice<xnewaxis<T>>
+    {
+
+    public:
+
+        using size_type = T;
+
+        xnewaxis() = default;
+
+        size_type operator()(size_type i) const noexcept;
+
+        size_type size() const noexcept;
+        size_type step_size() const noexcept;
+    };
+
+    struct xnewaxis_tag
+    {
+    };
+
+    /**
+    * Returns a slice representing a new axis of length one,
+    * to be used as an argument of view function.
+    * @sa view
+    */
+    inline auto newaxis() noexcept
+    {
+        return xnewaxis_tag();
+    }
+
+    template <class A, class B, class C>
+    struct xrange_adaptor
+    {
+        xrange_adaptor(A min_val, B max_val, C step)
+            : m_min(min_val), m_max(max_val), m_step(step)
+        {
+        }
+
+        template <class MI = A, class MA = B, class STEP = C>
+        inline std::enable_if_t<!std::is_integral<MI>::value && std::is_integral<MA>::value && std::is_integral<STEP>::value, xstepped_range<int>>
+        get(std::size_t size) const
+        {
+            return xstepped_range<int>(m_step > 0 ? 0 : int(size) - 1, m_max, m_step);
+        }
+
+        template <class MI = A, class MA = B, class STEP = C>
+        inline std::enable_if_t<std::is_integral<MI>::value && !std::is_integral<MA>::value && std::is_integral<STEP>::value, xstepped_range<int>>
+        get(std::size_t size) const
+        {
+            return xstepped_range<int>(m_min, m_step > 0 ? int(size) : -1, m_step);
+        }
+
+        template <class MI = A, class MA = B, class STEP = C>
+        inline std::enable_if_t<!std::is_integral<MI>::value && !std::is_integral<MA>::value && std::is_integral<STEP>::value, xstepped_range<int>>
+        get(std::size_t size) const
+        {
+            int min_val_arg = m_step > 0 ? 0 : int(size) - 1;
+            int max_val_arg = m_step > 0 ? int(size) : -1;
+            return xstepped_range<int>(min_val_arg, max_val_arg, m_step);
+        }
+
+        template <class MI = A, class MA = B, class STEP = C>
+        inline std::enable_if_t<std::is_integral<MI>::value && !std::is_integral<MA>::value && !std::is_integral<STEP>::value, xrange<std::size_t>>
+        get(std::size_t size) const
+        {
+            return xrange<std::size_t>((std::size_t)m_min, size);
+        }
+
+        template <class MI = A, class MA = B, class STEP = C>
+        inline std::enable_if_t<!std::is_integral<MI>::value && std::is_integral<MA>::value && !std::is_integral<STEP>::value, xrange<std::size_t>>
+        get(std::size_t /*size*/) const
+        {
+            return xrange<std::size_t>(0, (std::size_t)m_max);
+        }
+
+        template <class MI = A, class MA = B, class STEP = C>
+        inline std::enable_if_t<!std::is_integral<MI>::value && !std::is_integral<MA>::value && !std::is_integral<STEP>::value, xall<std::size_t>>
+        get(std::size_t size) const
+        {
+            return xall<std::size_t>(size);
+        }
+    private:
+        A m_min;
+        B m_max;
+        C m_step;
+    };
+
+    template <class A, class B>
+    inline auto range(A min_val, B max_val)
+    {
+        return xrange_adaptor<A, B, placeholders::xtuph>(min_val, max_val, placeholders::xtuph());
+    }
+
+    template <class A, class B, class C>
+    inline auto range(A min_val, B max_val, C step)
+    {
+        return xrange_adaptor<A, B, C>(min_val, max_val, step);
+    }
+
+
+    /******************************************************
+     * homogeneous get_size for integral types and slices *
+     ******************************************************/
+
+    template <class S>
+    inline disable_xslice<S, std::size_t> get_size(const S&) noexcept
+    {
+        return 1;
+    };
+
+    template <class S>
+    inline auto get_size(const xslice<S>& slice) noexcept
+    {
+        return slice.derived_cast().size();
+    };
+
+    /*******************************************************
+     * homogeneous step_size for integral types and slices *
+     *******************************************************/
+
+    template <class S>
+    inline disable_xslice<S, std::size_t> step_size(const S&) noexcept
+    {
+        return 0;
+    }
+
+    template <class S>
+    inline auto step_size(const xslice<S>& slice) noexcept
+    {
+        return slice.derived_cast().step_size();
+    }
+
+    /*********************************************
+     * homogeneous value for integral and slices *
+     *********************************************/
+
+    template <class S, class I>
+    inline disable_xslice<S, std::size_t> value(const S& s, I) noexcept
+    {
+        return s;
+    }
+
+    template <class S, class I>
+    inline auto value(const xslice<S>& slice, I i) noexcept
+    {
+        return slice.derived_cast()(i);
+    }
+
+    /****************************************
+     * homogeneous get_slice_implementation *
+     ****************************************/
+
+    template <class E, class SL>
+    inline auto get_slice_implementation(E& /*e*/, SL&& slice, std::size_t /*index*/)
+    {
+        return std::forward<SL>(slice);
+    }
+
+    template <class E>
+    inline auto get_slice_implementation(E& e, xall_tag, std::size_t index)
+    {
+        return xall<typename E::size_type>(e.shape()[index]);
+    }
+
+    template <class E>
+    inline auto get_slice_implementation(E& /*e*/, xnewaxis_tag, std::size_t /*index*/)
+    {
+        return xnewaxis<typename E::size_type>();
+    }
+
+    template <class E, class A, class B, class C>
+    inline auto get_slice_implementation(E& e, xrange_adaptor<A, B, C> adaptor, std::size_t index)
+    {
+        return adaptor.get(e.shape()[index]);
+    }
+
+
+    /******************************
+     * homogeneous get_slice_type *
+     ******************************/
+
+    namespace detail
+    {
+        template <class E, class SL>
+        struct get_slice_type_impl
+        {
+            using type = SL;
+        };
+
+        template <class E>
+        struct get_slice_type_impl<E, xall_tag>
+        {
+            using type = xall<typename E::size_type>;
+        };
+
+        template <class E>
+        struct get_slice_type_impl<E, xnewaxis_tag>
+        {
+            using type = xnewaxis<typename E::size_type>;
+        };
+
+        template <class E, class A, class B, class C>
+        struct get_slice_type_impl<E, xrange_adaptor<A, B, C>>
+        {
+            using type = decltype(xrange_adaptor<A, B, C>(A(), B(), C()).get(0));
+        };
+    }
+
+    template <class E, class SL>
+    using get_slice_type = typename detail::get_slice_type_impl<E, std::remove_reference_t<SL>>::type;
+
+    /*************************
+     * xslice implementation *
+     *************************/
+
+    template <class D>
+    inline auto xslice<D>::derived_cast() noexcept -> derived_type&
+    {
+        return *static_cast<derived_type*>(this);
+    }
+
+    template <class D>
+    inline auto xslice<D>::derived_cast() const noexcept -> const derived_type&
+    {
+        return *static_cast<const derived_type*>(this);
+    }
+
+    /*************************
+     * xrange implementation *
+     *************************/
+
+    template <class T>
+    inline xrange<T>::xrange(size_type min_val, size_type max_val) noexcept
+        : m_min(min_val), m_size(max_val - min_val)
+    {
+    }
+
+    template <class T>
+    inline auto xrange<T>::operator()(size_type i) const noexcept -> size_type
+    {
+        return m_min + i;
+    }
+
+    template <class T>
+    inline auto xrange<T>::size() const noexcept -> size_type
+    {
+        return m_size;
+    }
+
+    template <class T>
+    inline auto xrange<T>::step_size() const noexcept -> size_type
+    {
+        return 1;
+    }
+
+    /********************************
+     * xtepped_range implementation *
+     ********************************/
+
+    template <class T>
+    inline xstepped_range<T>::xstepped_range(size_type min_val, size_type max_val, size_type step) noexcept
+        : m_min(min_val), m_size((size_type)std::ceil(double(max_val - min_val) / double(step))), m_step(step)
+    {
+    }
+
+    template <class T>
+    inline auto xstepped_range<T>::operator()(size_type i) const noexcept -> size_type
+    {
+        return m_min + i * m_step;
+    }
+
+    template <class T>
+    inline auto xstepped_range<T>::size() const noexcept -> size_type
+    {
+        return m_size;
+    }
+
+    template <class T>
+    inline auto xstepped_range<T>::step_size() const noexcept -> size_type
+    {
+        return m_step;
+    }
+
+    /***********************
+     * xall implementation *
+     ***********************/
+
+    template <class T>
+    inline xall<T>::xall(size_type size) noexcept
+        : m_size(size)
+    {
+    }
+
+    template <class T>
+    inline auto xall<T>::operator()(size_type i) const noexcept -> size_type
+    {
+        return i;
+    }
+
+    template <class T>
+    inline auto xall<T>::size() const noexcept -> size_type
+    {
+        return m_size;
+    }
+
+    template <class T>
+    inline auto xall<T>::step_size() const noexcept -> size_type
+    {
+        return 1;
+    }
+
+    /***************************
+    * xnewaxis implementation *
+    ***************************/
+
+    template <class T>
+    inline auto xnewaxis<T>::operator()(size_type) const noexcept -> size_type
+    {
+        return 0;
+    }
+
+    template <class T>
+    inline auto xnewaxis<T>::size() const noexcept -> size_type
+    {
+        return 1;
+    }
+
+    template <class T>
+    inline auto xnewaxis<T>::step_size() const noexcept -> size_type
+    {
+        return 0;
+    }
+}
+
+#endif

--- a/inst/include/xtensor/xstorage.hpp
+++ b/inst/include/xtensor/xstorage.hpp
@@ -1,0 +1,540 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XSTORAGE_HPP
+#define XSTORAGE_HPP
+
+#include <algorithm>
+#include <functional>
+#include <initializer_list>
+#include <iterator>
+#include <memory>
+#include <type_traits>
+
+// Compiler bug workaround
+#if (__GNUC__ && (__GNUC__ < 5 || (__GNUC__ == 5 && __GNUC_MINOR__ < 1)) ) && !(defined(__APPLE__)) || defined(X_OLD_CLANG)
+#define is_trivially_default_constructible has_trivial_default_constructor
+#endif
+
+namespace xt
+{
+
+    namespace detail
+    {
+        template <class It>
+        using require_input_iter = typename std::enable_if<std::is_convertible<typename std::iterator_traits<It>::iterator_category,
+                                                                               std::input_iterator_tag>::value>::type;
+    }
+
+    template <class T, class Allocator = std::allocator<T>>
+    class uvector
+    {
+
+    public:
+
+        using allocator_type = Allocator;
+
+        using value_type = typename allocator_type::value_type;
+        using reference = typename allocator_type::reference;
+        using const_reference = typename allocator_type::const_reference;
+        using pointer = typename allocator_type::pointer;
+        using const_pointer = typename allocator_type::const_pointer;
+
+        using size_type = typename allocator_type::size_type;
+        using difference_type = typename allocator_type::difference_type;
+
+        using iterator = pointer;
+        using const_iterator = const_pointer;
+        using reverse_iterator = std::reverse_iterator<iterator>;
+        using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+        uvector() noexcept;
+        explicit uvector(const allocator_type& alloc) noexcept;
+        explicit uvector(size_type count, const allocator_type& alloc = allocator_type());
+        uvector(size_type count, const_reference value, const allocator_type& alloc = allocator_type());
+
+        template <class InputIt, class = detail::require_input_iter<InputIt>>
+        uvector(InputIt first, InputIt last, const allocator_type& alloc = allocator_type());
+
+        uvector(std::initializer_list<T> init, const allocator_type& alloc = allocator_type());
+
+        ~uvector();
+
+        uvector(const uvector& rhs);
+        uvector(const uvector& rhs, const allocator_type& alloc);
+        uvector& operator=(const uvector&);
+
+        uvector(uvector&& rhs) noexcept;
+        uvector(uvector&& rhs, const allocator_type& alloc) noexcept;
+        uvector& operator=(uvector&& rhs) noexcept;
+
+        allocator_type get_allocator() const noexcept;
+
+        bool empty() const noexcept;
+        size_type size() const noexcept;
+        void resize(size_type size);
+
+        reference operator[](size_type i);
+        const_reference operator[](size_type i) const;
+
+        reference front();
+        const_reference front() const;
+
+        reference back();
+        const_reference back() const;
+
+        pointer data() noexcept;
+        const_pointer data() const noexcept;
+
+        iterator begin() noexcept;
+        iterator end() noexcept;
+
+        const_iterator begin() const noexcept;
+        const_iterator end() const noexcept;
+
+        const_iterator cbegin() const noexcept;
+        const_iterator cend() const noexcept;
+
+        reverse_iterator rbegin() noexcept;
+        reverse_iterator rend() noexcept;
+
+        const_reverse_iterator rbegin() const noexcept;
+        const_reverse_iterator rend() const noexcept;
+
+        const_reverse_iterator crbegin() const noexcept;
+        const_reverse_iterator crend() const noexcept;
+
+        void swap(uvector& rhs) noexcept;
+
+    private:
+
+        template <class I>
+        void init_data(I first, I last);
+
+        void resize_impl(size_type new_size);
+
+        allocator_type m_allocator;
+
+        // Storing a pair of pointers is more efficient for iterating than
+        // storing a pointer to the beginning and the size of the container
+        pointer p_begin;
+        pointer p_end;
+    };
+
+    template <class T, class A>
+    bool operator==(const uvector<T, A>& lhs, const uvector<T, A>& rhs);
+
+    template <class T, class A>
+    bool operator!=(const uvector<T, A>& lhs, const uvector<T, A>& rhs);
+
+    template <class T, class A>
+    bool operator<(const uvector<T, A>& lhs, const uvector<T, A>& rhs);
+
+    template <class T, class A>
+    bool operator<=(const uvector<T, A>& lhs, const uvector<T, A>& rhs);
+
+    template <class T, class A>
+    bool operator>(const uvector<T, A>& lhs, const uvector<T, A>& rhs);
+
+    template <class T, class A>
+    bool operator>=(const uvector<T, A>& lhs, const uvector<T, A>& rhs);
+
+    template <class T, class A>
+    void swap(uvector<T, A>& lhs, uvector<T, A>& rhs) noexcept;
+
+    /**************************
+     * uvector implementation *
+     **************************/
+
+    namespace detail
+    {
+        template <class A>
+        inline typename A::pointer safe_init_allocate(A& alloc, typename A::size_type size)
+        {
+            using pointer = typename A::pointer;
+            using value_type = typename A::value_type;
+            pointer res = alloc.allocate(size);
+            if (!std::is_trivially_default_constructible<value_type>::value)
+            {
+                for (pointer p = res; p != res + size; ++p)
+                {
+                    alloc.construct(p, value_type());
+                }
+            }
+            return res;
+        }
+
+        template <class A>
+        inline void safe_destroy_deallocate(A& alloc, typename A::pointer ptr, typename A::size_type size)
+        {
+            using pointer = typename A::pointer;
+            using value_type = typename A::value_type;
+            if (ptr != nullptr)
+            {
+                if (!std::is_trivially_default_constructible<value_type>::value)
+                {
+                    for (pointer p = ptr; p != ptr + size; ++p)
+                    {
+                        alloc.destroy(p);
+                    }
+                }
+                alloc.deallocate(ptr, size);
+            }
+        }
+    }
+
+    template <class T, class A>
+    template <class I>
+    inline void uvector<T, A>::init_data(I first, I last)
+    {
+        size_type size = static_cast<size_type>(std::distance(first, last));
+        if (size != size_type(0))
+        {
+            p_begin = m_allocator.allocate(size);
+            std::uninitialized_copy(first, last, p_begin);
+            p_end = p_begin + size;
+        }
+    }
+
+    template <class T, class A>
+    inline void uvector<T, A>::resize_impl(size_type new_size)
+    {
+        size_type old_size = size();
+        pointer old_begin = p_begin;
+        if (new_size != old_size)
+        {
+            p_begin = detail::safe_init_allocate(m_allocator, new_size);
+            p_end = p_begin + new_size;
+            detail::safe_destroy_deallocate(m_allocator, old_begin, old_size);
+        }
+    }
+
+    template <class T, class A>
+    inline uvector<T, A>::uvector() noexcept
+        : uvector(allocator_type())
+    {
+    }
+
+    template <class T, class A>
+    inline uvector< T, A>::uvector(const allocator_type& alloc) noexcept
+        : m_allocator(alloc), p_begin(nullptr), p_end(nullptr)
+    {
+    }
+
+    template <class T, class A>
+    inline uvector<T, A>::uvector(size_type count, const allocator_type& alloc)
+        : m_allocator(alloc), p_begin(nullptr), p_end(nullptr)
+    {
+        if (count != 0)
+        {
+            p_begin = detail::safe_init_allocate(m_allocator, count);
+            p_end = p_begin + count;
+        }
+    }
+
+    template <class T, class A>
+    inline uvector<T, A>::uvector(size_type count, const_reference value, const allocator_type& alloc)
+        : m_allocator(alloc), p_begin(nullptr), p_end(nullptr)
+    {
+        if (count != 0)
+        {
+            p_begin = m_allocator.allocate(count);
+            p_end = p_begin + count;
+            std::uninitialized_fill(p_begin, p_end, value);
+        }
+    }
+
+    template <class T, class A>
+    template <class InputIt, class>
+    inline uvector<T, A>::uvector(InputIt first, InputIt last, const allocator_type& alloc)
+        : m_allocator(alloc), p_begin(nullptr), p_end(nullptr)
+    {
+        init_data(first, last);
+    }
+
+    template <class T, class A>
+    inline uvector<T, A>::uvector(std::initializer_list<T> init, const allocator_type& alloc)
+        : m_allocator(alloc), p_begin(nullptr), p_end(nullptr)
+    {
+        init_data(init.begin(), init.end());
+    }
+
+    template <class T, class A>
+    inline uvector<T, A>::~uvector()
+    {
+        detail::safe_destroy_deallocate(m_allocator, p_begin, size());
+        p_begin = nullptr;
+        p_end = nullptr;
+    }
+
+    template <class T, class A>
+    inline uvector<T, A>::uvector(const uvector& rhs)
+        : m_allocator(std::allocator_traits<allocator_type>::select_on_container_copy_construction(rhs.get_allocator())),
+          p_begin(nullptr), p_end(nullptr)
+    {
+        init_data(rhs.p_begin, rhs.p_end);
+    }
+
+    template <class T, class A>
+    inline uvector<T, A>::uvector(const uvector& rhs, const allocator_type& alloc)
+        : m_allocator(alloc), p_begin(nullptr), p_end(nullptr)
+    {
+        init_data(rhs.p_begin, rhs.p_end);
+    }
+
+    template <class T, class A>
+    inline uvector<T, A>& uvector<T, A>::operator=(const uvector& rhs)
+    {
+        // No copy and swap idiom here due to performance issues
+        if (this != &rhs)
+        {
+            m_allocator = std::allocator_traits<allocator_type>::select_on_container_copy_construction(rhs.get_allocator());
+            resize_impl(rhs.size());
+            if (std::is_trivially_default_constructible<value_type>::value)
+            {
+                std::uninitialized_copy(rhs.p_begin, rhs.p_end, p_begin);
+            }
+            else
+            {
+                std::copy(rhs.p_begin, rhs.p_end, p_begin);
+            }
+        }
+        return *this;
+    }
+
+    template <class T, class A>
+    inline uvector<T, A>::uvector(uvector&& rhs) noexcept
+        : m_allocator(std::move(rhs.m_allocator)), p_begin(rhs.p_begin), p_end(rhs.p_end)
+    {
+        rhs.p_begin = nullptr;
+        rhs.p_end = nullptr;
+    }
+
+    template <class T, class A>
+    inline uvector<T, A>::uvector(uvector&& rhs, const allocator_type& alloc) noexcept
+        : m_allocator(alloc), p_begin(rhs.p_begin), p_end(rhs.p_end)
+    {
+        rhs.p_begin = nullptr;
+        rhs.p_end = nullptr;
+    }
+
+    template <class T, class A>
+    inline uvector<T, A>& uvector<T, A>::operator=(uvector&& rhs) noexcept
+    {
+        using std::swap;
+        uvector tmp(std::move(rhs));
+        swap(p_begin, tmp.p_begin);
+        swap(p_end, tmp.p_end);
+        return *this;
+    }
+
+    template <class T, class A>
+    inline auto uvector<T, A>::get_allocator() const noexcept -> allocator_type
+    {
+        return allocator_type(m_allocator);
+    }
+
+    template <class T, class A>
+    inline bool uvector<T, A>::empty() const noexcept
+    {
+        return size() == size_type(0);
+    }
+
+    template <class T, class A>
+    inline auto uvector<T, A>::size() const noexcept -> size_type
+    {
+        return p_end - p_begin;
+    }
+
+    template <class T, class A>
+    inline void uvector<T, A>::resize(size_type size)
+    {
+        resize_impl(size);
+    }
+
+    template <class T, class A>
+    inline auto uvector<T, A>::operator[](size_type i) -> reference
+    {
+        return p_begin[i];
+    }
+
+    template <class T, class A>
+    inline auto uvector<T, A>::operator[](size_type i) const -> const_reference
+    {
+        return p_begin[i];
+    }
+
+    template <class T, class A>
+    inline auto uvector<T, A>::front() -> reference
+    {
+        return p_begin[0];
+    }
+
+    template <class T, class A>
+    inline auto uvector<T, A>::front() const -> const_reference
+    {
+        return p_begin[0];
+    }
+
+    template <class T, class A>
+    inline auto uvector<T, A>::back() -> reference
+    {
+        return *(p_end - 1);
+    }
+
+    template <class T, class A>
+    inline auto uvector<T, A>::back() const -> const_reference
+    {
+        return *(p_end - 1);
+    }
+
+    template <class T, class A>
+    inline auto uvector<T, A>::data() noexcept -> pointer
+    {
+        return p_begin;
+    }
+
+    template <class T, class A>
+    inline auto uvector<T, A>::data() const noexcept -> const_pointer
+    {
+        return p_begin;
+    }
+
+    template <class T, class A>
+    inline auto uvector<T, A>::begin() noexcept -> iterator
+    {
+        return p_begin;
+    }
+
+    template <class T, class A>
+    inline auto uvector<T, A>::end() noexcept -> iterator
+    {
+        return p_end;
+    }
+
+    template <class T, class A>
+    inline auto uvector<T, A>::begin() const noexcept -> const_iterator
+    {
+        return p_begin;
+    }
+
+    template <class T, class A>
+    inline auto uvector<T, A>::end() const noexcept -> const_iterator
+    {
+        return p_end;
+    }
+
+    template <class T, class A>
+    inline auto uvector<T, A>::cbegin() const noexcept -> const_iterator
+    {
+        return begin();
+    }
+
+    template <class T, class A>
+    inline auto uvector<T, A>::cend() const noexcept -> const_iterator
+    {
+        return end();
+    }
+
+    template <class T, class A>
+    inline auto uvector<T, A>::rbegin() noexcept -> reverse_iterator
+    {
+        return reverse_iterator(end());
+    }
+
+    template <class T, class A>
+    inline auto uvector<T, A>::rend() noexcept -> reverse_iterator
+    {
+        return reverse_iterator(begin());
+    }
+
+    template <class T, class A>
+    inline auto uvector<T, A>::rbegin() const noexcept -> const_reverse_iterator
+    {
+        return const_reverse_iterator(end());
+    }
+
+    template <class T, class A>
+    inline auto uvector<T, A>::rend() const noexcept -> const_reverse_iterator
+    {
+        return const_reverse_iterator(begin());
+    }
+
+    template <class T, class A>
+    inline auto uvector<T, A>::crbegin() const noexcept -> const_reverse_iterator
+    {
+        return rbegin();
+    }
+
+    template <class T, class A>
+    inline auto uvector<T, A>::crend() const noexcept -> const_reverse_iterator
+    {
+        return rend();
+    }
+
+    template <class T, class A>
+    inline void uvector<T, A>::swap(uvector<T, A>& rhs) noexcept
+    {
+        using std::swap;
+        swap(m_allocator, rhs.m_allocator);
+        swap(p_begin, rhs.p_begin);
+        swap(p_end, rhs.p_end);
+    }
+
+    template <class T, class A>
+    inline bool operator==(const uvector<T, A>& lhs, const uvector<T, A>& rhs)
+    {
+        return lhs.size() == rhs.size() && std::equal(lhs.begin(), lhs.end(), rhs.begin());
+    }
+
+    template <class T, class A>
+    inline bool operator!=(const uvector<T, A>& lhs, const uvector<T, A>& rhs)
+    {
+        return !(lhs == rhs);
+    }
+
+    template <class T, class A>
+    inline bool operator<(const uvector<T, A>& lhs, const uvector<T, A>& rhs)
+    {
+        return std::lexicographical_compare(lhs.begin(), lhs.end(),
+                                            rhs.begin(), rhs.end(),
+                                            std::less<T>());
+    }
+
+    template <class T, class A>
+    inline bool operator<=(const uvector<T, A>& lhs, const uvector<T, A>& rhs)
+    {
+        return std::lexicographical_compare(lhs.begin(), lhs.end(),
+                                            rhs.begin(), rhs.end(),
+                                            std::less_equal<T>());
+    }
+
+    template <class T, class A>
+    inline bool operator>(const uvector<T, A>& lhs, const uvector<T, A>& rhs)
+    {
+        return std::lexicographical_compare(lhs.begin(), lhs.end(),
+                                            rhs.begin(), rhs.end(),
+                                            std::greater<T>());
+    }
+
+    template <class T, class A>
+    inline bool operator>=(const uvector<T, A>& lhs, const uvector<T, A>& rhs)
+    {
+        return std::lexicographical_compare(lhs.begin(), lhs.end(),
+                                            rhs.begin(), rhs.end(),
+                                            std::greater_equal<T>());
+    }
+
+    template <class T, class A>
+    inline void swap(uvector<T, A>& lhs, uvector<T, A>& rhs) noexcept
+    {
+        lhs.swap(rhs);
+    }
+}
+
+#endif

--- a/inst/include/xtensor/xstridedview.hpp
+++ b/inst/include/xtensor/xstridedview.hpp
@@ -1,0 +1,888 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XSTRIDEDVIEW_HPP
+#define XSTRIDEDVIEW_HPP
+
+#include <algorithm>
+#include <cstddef>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+#include "xexpression.hpp"
+#include "xiterable.hpp"
+#include "xstrides.hpp"
+#include "xutils.hpp"
+#include "xview.hpp"
+
+namespace xt
+{
+    template <class CT, class S, class CD>
+    class xstrided_view;
+
+    template <class CT, class S, class CD>
+    struct xcontainer_inner_types<xstrided_view<CT, S, CD>>
+    {
+        using xexpression_type = std::decay_t<CT>;
+        using temporary_type = xarray<typename xexpression_type::value_type>;
+    };
+
+    template <class CT, class S, class CD>
+    struct xiterable_inner_types<xstrided_view<CT, S, CD>>
+    {
+        using inner_shape_type = S;
+        using inner_strides_type = inner_shape_type;
+        using inner_backstrides_type_type = inner_shape_type;
+        using const_stepper = xstepper<const xstrided_view<CT, S, CD>>;
+        using stepper = xstepper<xstrided_view<CT, S, CD>>;
+        using const_iterator = xiterator<const_stepper, inner_shape_type*, DEFAULT_LAYOUT>;
+        using iterator = xiterator<stepper, inner_shape_type*, DEFAULT_LAYOUT>;
+        using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+        using reverse_iterator = std::reverse_iterator<iterator>;
+    };
+
+    /*****************
+     * xstrided_view *
+     *****************/
+
+    /**
+     * @class xstrided_view
+     * @brief View of an xexpression using strides
+     *
+     * The xstrided_view class implements a view utilizing an offset and strides 
+     * into a multidimensional xcontainer. The xstridedview is currently used 
+     * to implement `transpose`.
+     * @tparam CT the closure type of the \ref xexpression type underlying this view
+     * @tparam CD the closure type of the underlying data container
+     * 
+     * @sa stridedview, transpose
+     */
+    template <class CT, class S, class CD>
+    class xstrided_view : public xview_semantic<xstrided_view<CT, S, CD>>,
+                          public xexpression_iterable<xstrided_view<CT, S, CD>>
+    {
+
+    public:
+
+        using self_type = xstrided_view<CT, S, CD>;
+        using xexpression_type = std::decay_t<CT>;
+        using semantic_base = xview_semantic<self_type>;
+
+        using value_type = typename xexpression_type::value_type;
+        using reference = typename xexpression_type::reference;
+        using const_reference = typename xexpression_type::const_reference;
+        using pointer = typename xexpression_type::pointer;
+        using const_pointer = typename xexpression_type::const_pointer;
+        using size_type = typename xexpression_type::size_type;
+        using difference_type = typename xexpression_type::difference_type;
+
+        using underlying_container_type = CD;
+
+        using iterable_base = xexpression_iterable<self_type>;
+        using inner_shape_type = typename iterable_base::inner_shape_type;
+        using shape_type = inner_shape_type;
+        using strides_type = shape_type;
+        using backstrides_type = shape_type;
+        using closure_type = const self_type;
+
+        using stepper = typename iterable_base::stepper;
+        using const_stepper = typename iterable_base::const_stepper;
+
+        static constexpr layout_type static_layout = layout_type::dynamic;
+        static constexpr bool contiguous_layout = false;
+
+        using temporary_type = typename xcontainer_inner_types<self_type>::temporary_type;
+        using base_index_type = xindex_type_t<shape_type>;
+
+        xstrided_view(CT e, S&& shape, S&& strides, std::size_t offset) noexcept;
+        xstrided_view(CT e, CD data, S&& shape, S&& strides, std::size_t offset) noexcept;
+
+        template <class E>
+        self_type& operator=(const xexpression<E>& e);
+
+        template <class E>
+        disable_xexpression<E, self_type>& operator=(const E& e);
+
+        size_type size() const noexcept;
+        size_type dimension() const noexcept;
+        const shape_type& shape() const noexcept;
+        const strides_type& strides() const noexcept;
+        const backstrides_type& backstrides() const noexcept;
+        layout_type layout() const noexcept;
+
+        reference operator()();
+        template <class... Args>
+        reference operator()(Args... args);
+        reference operator[](const xindex& index);
+        reference operator[](size_type i);
+
+        template <class It>
+        reference element(It first, It last);
+
+        const_reference operator()() const;
+        template <class... Args>
+        const_reference operator()(Args... args) const;
+        const_reference operator[](const xindex& index) const;
+        const_reference operator[](size_type i) const;
+
+        template <class It>
+        const_reference element(It first, It last) const;
+
+        template <class O>
+        bool broadcast_shape(O& shape) const;
+
+        template <class O>
+        bool is_trivial_broadcast(const O& strides) const noexcept;
+
+        template <class ST>
+        stepper stepper_begin(const ST& shape);
+        template <class ST>
+        stepper stepper_end(const ST& shape);
+
+        template <class ST>
+        const_stepper stepper_begin(const ST& shape) const;
+        template <class ST>
+        const_stepper stepper_end(const ST& shape) const;
+
+        using container_iterator = typename std::decay_t<CD>::iterator;
+        using const_container_iterator = typename std::decay_t<CD>::const_iterator;
+
+        container_iterator data_xbegin() noexcept;
+        const_container_iterator data_xbegin() const noexcept;
+
+        container_iterator data_xend() noexcept;
+        const_container_iterator data_xend() const noexcept;
+
+        underlying_container_type& data() noexcept;
+        const underlying_container_type& data() const noexcept;
+
+        value_type* raw_data() noexcept;
+        const value_type* raw_data() const noexcept;
+
+        size_type raw_data_offset() const noexcept;
+
+    private:
+
+        template <class It>
+        It data_xbegin_impl(It begin) const noexcept;
+
+        template <class It>
+        It data_xend_impl(It end) const noexcept;
+
+        void assign_temporary_impl(temporary_type& tmp);
+
+        CT m_e;
+        CD m_data;
+        shape_type m_shape;
+        strides_type m_strides;
+        backstrides_type m_backstrides;
+        std::size_t m_offset;
+
+        friend class xview_semantic<xstrided_view<CT, S, CD>>;
+    };
+
+    /********************************
+     * xstrided_view implementation *
+     ********************************/
+
+    /**
+     * @name Constructor
+     */
+    //@{
+    /**
+     * Constructs an xstrided_view 
+     * 
+     * @param e the underlying xexpression for this view
+     * @param shape the shape of the view
+     * @param strides the strides of the view
+     * @param offset the offset of the first element in the underlying container
+     */
+    template <class CT, class S, class CD>
+    inline xstrided_view<CT, S, CD>::xstrided_view(CT e, S&& shape, S&& strides, std::size_t offset) noexcept
+        : m_e(e), m_data(m_e.data()), m_shape(std::forward<S>(shape)), m_strides(std::forward<S>(strides)), m_offset(offset)
+    {
+        m_backstrides = make_sequence<backstrides_type>(m_shape.size(), 0);
+        adapt_strides(m_shape, m_strides, m_backstrides);
+    }
+
+    template <class CT, class S, class CD>
+    inline xstrided_view<CT, S, CD>::xstrided_view(CT e, CD data, S&& shape, S&& strides, std::size_t offset) noexcept
+        : m_e(e), m_data(data), m_shape(std::forward<S>(shape)), m_strides(std::forward<S>(strides)), m_offset(offset)
+    {
+        m_backstrides = make_sequence<backstrides_type>(m_shape.size(), 0);
+        adapt_strides(m_shape, m_strides, m_backstrides);
+    }
+    //@}
+
+    /**
+     * @name Extended copy semantic
+     */
+    //@{
+    /**
+     * The extended assignment operator.
+     */
+    template <class CT, class S, class CD>
+    template <class E>
+    inline auto xstrided_view<CT, S, CD>::operator=(const xexpression<E>& e) -> self_type&
+    {
+        return semantic_base::operator=(e);
+    }
+    //@}
+
+    template <class CT, class S, class CD>
+    template <class E>
+    inline auto xstrided_view<CT, S, CD>::operator=(const E& e) -> disable_xexpression<E, self_type>&
+    {
+        std::fill(this->begin(), this->end(), e);
+        return *this;
+    }
+
+    template <class CT, class S, class CD>
+    inline void xstrided_view<CT, S, CD>::assign_temporary_impl(temporary_type& tmp)
+    {
+        std::copy(tmp.cbegin(), tmp.cend(), this->xbegin());
+    }
+
+    /**
+     * @name Size and shape
+     */
+    //@{
+    /**
+     * Returns the size of the xstrided_view.
+     */
+    template <class CT, class S, class CD>
+    inline auto xstrided_view<CT, S, CD>::size() const noexcept -> size_type
+    {
+        return compute_size(shape());
+    }
+
+    /**
+     * Returns the number of dimensions of the xstrided_view.
+     */
+    template <class CT, class S, class CD>
+    inline auto xstrided_view<CT, S, CD>::dimension() const noexcept -> size_type
+    {
+        return m_shape.size();
+    }
+
+    /**
+     * Returns the shape of the xstrided_view.
+     */
+    template <class CT, class S, class CD>
+    inline auto xstrided_view<CT, S, CD>::shape() const noexcept -> const shape_type&
+    {
+        return m_shape;
+    }
+
+    template <class CT, class S, class CD>
+    inline auto xstrided_view<CT, S, CD>::strides() const noexcept -> const strides_type&
+    {
+        return m_strides;
+    }
+
+    template <class CT, class S, class CD>
+    inline auto xstrided_view<CT, S, CD>::backstrides() const noexcept -> const backstrides_type&
+    {
+        return m_backstrides;
+    }
+
+    template <class CT, class S, class CD>
+    inline auto xstrided_view<CT, S, CD>::layout() const noexcept -> layout_type
+    {
+        return layout_type::row_major;
+    }
+
+    template <class CT, class S, class CD>
+    inline auto xstrided_view<CT, S, CD>::data() noexcept -> underlying_container_type&
+    {
+        return m_e.data();
+    }
+
+    template <class CT, class S, class CD>
+    inline auto xstrided_view<CT, S, CD>::data() const noexcept -> const underlying_container_type&
+    {
+        return m_e.data();
+    }
+
+    template <class CT, class S, class CD>
+    inline auto xstrided_view<CT, S, CD>::raw_data() noexcept -> value_type*
+    {
+        return m_e.raw_data();
+    }
+
+    template <class CT, class S, class CD>
+    inline auto xstrided_view<CT, S, CD>::raw_data() const noexcept -> const value_type*
+    {
+        return m_e.raw_data();
+    }
+
+    template <class CT, class S, class CD>
+    inline auto xstrided_view<CT, S, CD>::raw_data_offset() const noexcept -> size_type
+    {
+        return m_offset;
+    }
+    //@}
+
+    /**
+     * @name Data
+     */
+    template <class CT, class S, class CD>
+    inline auto xstrided_view<CT, S, CD>::operator()() -> reference
+    {
+        return m_e();
+    }
+
+    template <class CT, class S, class CD>
+    inline auto xstrided_view<CT, S, CD>::operator()() const -> const_reference
+    {
+        return m_e();
+    }
+
+    template <class CT, class S, class CD>
+    template <class... Args>
+    inline auto xstrided_view<CT, S, CD>::operator()(Args... args) -> reference
+    {
+        XTENSOR_ASSERT(check_index(shape(), args...));
+        size_type index = m_offset + data_offset<size_type>(strides(), static_cast<size_type>(args)...);
+        return m_data[index];
+    }
+
+    /**
+     * Returns the element at the specified position in the xstrided_view. 
+     * 
+     * @param args a list of indices specifying the position in the view. Indices
+     * must be unsigned integers, the number of indices should be equal or greater than
+     * the number of dimensions of the view.
+     */
+    template <class CT, class S, class CD>
+    template <class... Args>
+    inline auto xstrided_view<CT, S, CD>::operator()(Args... args) const -> const_reference
+    {
+        XTENSOR_ASSERT(check_index(shape(), args...));
+        size_type index = m_offset + data_offset<size_type>(strides(), static_cast<size_type>(args)...);
+        return m_data[index];
+    }
+
+    template <class CT, class S, class CD>
+    inline auto xstrided_view<CT, S, CD>::operator[](const xindex& index) -> reference
+    {
+        return element(index.cbegin(), index.cend());
+    }
+
+    template <class CT, class S, class CD>
+    inline auto xstrided_view<CT, S, CD>::operator[](size_type i) -> reference
+    {
+        return operator()(i);
+    }
+
+    template <class CT, class S, class CD>
+    inline auto xstrided_view<CT, S, CD>::operator[](const xindex& index) const -> const_reference
+    {
+        return element(index.cbegin(), index.cend());
+    }
+
+    template <class CT, class S, class CD>
+    inline auto xstrided_view<CT, S, CD>::operator[](size_type i) const -> const_reference
+    {
+        return operator()(i);
+    }
+
+    /**
+     * Returns a reference to the element at the specified position in the xstrided_view.
+     * @param first iterator starting the sequence of indices
+     * @param last iterator ending the sequence of indices
+     * The number of indices in the squence should be equal to or greater than the the number
+     * of dimensions of the container..
+     */
+    template <class CT, class S, class CD>
+    template <class It>
+    inline auto xstrided_view<CT, S, CD>::element(It first, It last) -> reference
+    {
+        return m_data[m_offset + element_offset<size_type>(strides(), first, last)];
+    }
+
+    template <class CT, class S, class CD>
+    template <class It>
+    inline auto xstrided_view<CT, S, CD>::element(It first, It last) const -> const_reference
+    {
+        return m_data[m_offset + element_offset<size_type>(strides(), first, last)];
+    }
+    //@}
+
+    /**
+     * @name Broadcasting
+     */
+    //@{
+    /**
+     * Broadcast the shape of the xstrided_view to the specified parameter.
+     * @param shape the result shape
+     * @return a boolean indicating whether the broadcasting is trivial
+     */
+    template <class CT, class S, class CD>
+    template <class O>
+    inline bool xstrided_view<CT, S, CD>::broadcast_shape(O& shape) const
+    {
+        return xt::broadcast_shape(m_shape, shape);
+    }
+
+    /**
+     * Compares the specified strides with those of the container to see whether
+     * the broadcasting is trivial.
+     * @return a boolean indicating whether the broadcasting is trivial
+     */
+    template <class CT, class S, class CD>
+    template <class O>
+    inline bool xstrided_view<CT, S, CD>::is_trivial_broadcast(const O& str) const noexcept
+    {
+        return str.size() == strides().size() &&
+            std::equal(str.cbegin(), str.cend(), strides().begin());
+    }
+    //@}
+
+    /***************
+     * stepper api *
+     ***************/
+
+    template <class CT, class S, class CD>
+    template <class ST>
+    inline auto xstrided_view<CT, S, CD>::stepper_begin(const ST& shape) -> stepper
+    {
+        size_type offset = shape.size() - dimension();
+        return stepper(this, data_xbegin(), offset);
+    }
+
+    template <class CT, class S, class CD>
+    template <class ST>
+    inline auto xstrided_view<CT, S, CD>::stepper_end(const ST& shape) -> stepper
+    {
+        size_type offset = shape.size() - dimension();
+        return stepper(this, data_xend(), offset);
+    }
+
+    template <class CT, class S, class CD>
+    template <class ST>
+    inline auto xstrided_view<CT, S, CD>::stepper_begin(const ST& shape) const -> const_stepper
+    {
+        size_type offset = shape.size() - dimension();
+        return const_stepper(this, data_xbegin(), offset);
+    }
+
+    template <class CT, class S, class CD>
+    template <class ST>
+    inline auto xstrided_view<CT, S, CD>::stepper_end(const ST& shape) const -> const_stepper
+    {
+        size_type offset = shape.size() - dimension();
+        return const_stepper(this, data_xend(), offset);
+    }
+
+    template <class CT, class S, class CD>
+    template <class It>
+    inline It xstrided_view<CT, S, CD>::data_xbegin_impl(It begin) const noexcept
+    {
+        return begin + m_offset;
+    }
+
+    template <class CT, class S, class CD>
+    template <class It>
+    inline It xstrided_view<CT, S, CD>::data_xend_impl(It end) const noexcept
+    {
+        return m_offset + (strides().size() != 0 ? end - 1 + strides().back() : end);
+    }
+
+    template <class CT, class S, class CD>
+    inline auto xstrided_view<CT, S, CD>::data_xbegin() noexcept -> container_iterator
+    {
+        return data_xbegin_impl(m_data.begin());
+    }
+
+    template <class CT, class S, class CD>
+    inline auto xstrided_view<CT, S, CD>::data_xbegin() const noexcept -> const_container_iterator
+    {
+        return data_xbegin_impl(m_data.begin());
+    }
+
+    template <class CT, class S, class CD>
+    inline auto xstrided_view<CT, S, CD>::data_xend() noexcept -> container_iterator
+    {
+        return data_xend_impl(m_data.end());
+    }
+
+    template <class CT, class S, class CD>
+    inline auto xstrided_view<CT, S, CD>::data_xend() const noexcept -> const_container_iterator
+    {
+        return data_xend_impl(m_data.end());
+    }
+
+    /**
+     * Construct a strided view from an xexpression, shape, strides and offset.
+     *
+     * @param e xexpression
+     * @param shape the shape of the view
+     * @param strides the new strides of the view
+     * @param offset the offset of the first element in the underlying container
+     *
+     * @tparam E type of xexpression
+     * @tparam I shape and strides type
+     *
+     * @return the view
+     */
+    template <class E, class I>
+    inline auto strided_view(E&& e, I&& shape, I&& strides, std::size_t offset = 0) noexcept
+    {
+        using view_type = xstrided_view<xclosure_t<E>, I, decltype(e.data())>;
+        return view_type(std::forward<E>(e), std::forward<I>(shape), std::forward<I>(strides), offset);
+    }
+
+    /****************************
+     * transpose implementation *
+     ****************************/
+
+    namespace detail
+    {
+        template <class E, class S>
+        inline auto transpose_impl(E&& e, S&& permutation, check_policy::none)
+        {
+            if (container_size(permutation) != e.dimension())
+            {
+                throw transpose_error("Permutation does not have the same size as shape");
+            }
+
+            // permute stride and shape
+            using strides_type = typename std::decay_t<E>::strides_type;
+            strides_type temp_strides;
+            resize_container(temp_strides, e.strides().size());
+
+            using shape_type = typename std::decay_t<E>::shape_type;
+            shape_type temp_shape;
+            resize_container(temp_shape, e.shape().size());
+
+            for (std::size_t i = 0; i < e.shape().size(); ++i)
+            {
+                if (std::size_t(permutation[i]) >= e.dimension())
+                {
+                    throw transpose_error("Permutation contains wrong axis");
+                }
+                temp_shape[i] = e.shape()[permutation[i]];
+                temp_strides[i] = e.strides()[permutation[i]];
+            }
+            using view_type = xstrided_view<xclosure_t<E>, shape_type, decltype(e.data())>;
+            return view_type(std::forward<E>(e), std::move(temp_shape), std::move(temp_strides), 0);
+        }
+
+        template <class E, class S>
+        inline auto transpose_impl(E&& e, S&& permutation, check_policy::full)
+        {
+            // check if axis appears twice in permutation
+            for (std::size_t i = 0; i < container_size(permutation); ++i)
+            {
+                for (std::size_t j = i + 1; j < container_size(permutation); ++j)
+                {
+                    if (permutation[i] == permutation[j])
+                    {
+                        throw transpose_error("Permutation contains axis more than once");
+                    }
+                }
+            }
+            return transpose_impl(std::forward<E>(e), std::forward<S>(permutation), check_policy::none());
+        }
+    }
+
+    template <class E>
+    inline auto transpose(E&& e) noexcept
+    {
+        using shape_type = typename std::decay_t<E>::shape_type;
+
+        shape_type shape;
+        resize_container(shape, e.shape().size());
+        std::copy(e.shape().rbegin(), e.shape().rend(), shape.begin());
+
+        shape_type strides;
+        resize_container(strides, e.strides().size());
+        std::copy(e.strides().rbegin(), e.strides().rend(), strides.begin());
+
+        using view_type = xstrided_view<xclosure_t<E>, shape_type, decltype(e.data())>;
+        return view_type(std::forward<E>(e), std::move(shape), std::move(strides), 0);
+    }
+
+    /**
+     * Returns a transpose view by permuting the xexpression e with @p permutation.
+     * @param e the input expression
+     * @param permutation the sequence containing permutation
+     * @param check_policy the check level (check_policy::full() or check_policy::none())
+     * @tparam Tag selects the level of error checking on permutation vector defaults to check_policy::none.
+     */
+    template <class E, class S, class Tag = check_policy::none>
+    inline auto transpose(E&& e, S&& permutation, Tag check_policy = Tag())
+    {
+        return detail::transpose_impl(std::forward<E>(e), std::forward<S>(permutation), check_policy);
+    }
+
+#ifdef X_OLD_CLANG
+    template <class E, class I, class Tag = check_policy::none>
+    inline auto transpose(E&& e, std::initializer_list<I> permutation, Tag check_policy = Tag())
+    {
+        std::vector<I> perm(permutation);
+        return detail::transpose_impl(std::forward<E>(e), std::move(perm), check_policy);
+    }
+#else
+    template <class E, class I, std::size_t N, class Tag = check_policy::none>
+    inline auto transpose(E&& e, const I (&permutation)[N], Tag check_policy = Tag())
+    {
+        return detail::transpose_impl(std::forward<E>(e), permutation, check_policy);
+    }
+#endif
+
+    namespace detail
+    {
+        template <class CT>
+        class expression_adaptor
+        {
+        public:
+            using xexpression_type = std::decay_t<CT>;
+            using shape_type = typename xexpression_type::shape_type;
+            using index_type = xindex_type_t<shape_type>;
+            using size_type = typename xexpression_type::size_type;
+            using value_type = typename xexpression_type::value_type;
+            using reference = typename xexpression_type::reference;
+
+            expression_adaptor(CT&& e) : m_e(e)
+            {
+                resize_container(m_index, m_e.dimension());
+                m_size = compute_size(m_e.shape());
+                compute_strides(m_e.shape(), layout_type::row_major, m_strides);
+            }
+
+            const reference operator[](std::size_t idx) const
+            {
+                std::div_t dv{};
+                for (size_type i = 0; i < m_strides.size(); ++i)
+                {
+                    dv = std::div((int) idx, (int) m_strides[i]);
+                    idx = dv.rem;
+                    m_index[i] = dv.quot;
+                }
+                return m_e.element(m_index.begin(), m_index.end());
+            }
+
+            size_type size() const
+            {
+                return m_size;
+            }
+
+        private:
+            CT m_e;
+            shape_type m_strides;
+            mutable index_type m_index;
+            size_type m_size;
+        };
+    }
+
+    class slice_vector : private std::vector<std::array<long int, 3>>
+    {
+
+    public:
+        using index_type = long int;
+        using base_type = std::vector<std::array<index_type, 3>>;
+
+        // propagating interface
+        using base_type::begin;
+        using base_type::cbegin;
+        using base_type::end;
+        using base_type::cend;
+        using base_type::size;
+        using base_type::operator[];
+        using base_type::push_back;
+
+        inline slice_vector() = default;
+
+        template <class E, class... Args>
+        inline slice_vector(const xexpression<E>& e, Args... args)
+        {
+            const auto& de = e.derived_cast();
+            m_shape.resize(de.shape().size());
+            std::copy(de.shape().begin(), de.shape().end(), m_shape.begin());
+            append(args...);
+        }
+
+        template <class... Args>
+        inline slice_vector(const std::vector<std::size_t>& shape, Args... args)
+        {
+            m_shape = shape;
+            append(args...);
+        }
+
+        template <class T, class... Args>
+        inline void append(const T& s, Args... args)
+        {
+            push_back(s);
+            append(args...);
+        }
+
+        inline void append()
+        {
+        }
+
+        template <class T>
+        inline void push_back(const xslice<T>& s)
+        {
+            auto ds = s.derived_cast();
+            base_type::push_back({ds(0), (index_type) ds.size(), (index_type) ds.step_size()});
+        }
+
+        template <class A, class B, class C>
+        inline void push_back(const xrange_adaptor<A, B, C>& s)
+        {
+            auto idx = size() - newaxis_count;
+            if (idx >= m_shape.size())
+            {
+                throw std::runtime_error("Too many slices in slice vector for shape");
+            }
+            auto ds = s.get(m_shape[idx]);
+            base_type::push_back({(index_type) ds(0), (index_type) ds.size(), (index_type) ds.step_size()});
+        }
+
+        inline void push_back(xall_tag /*s*/)
+        {
+            auto idx = size() - newaxis_count;
+            if (idx >= m_shape.size())
+            {
+                throw std::runtime_error("Too many slices in slice vector for shape");
+            }
+            base_type::push_back({0, (index_type) m_shape[idx], 1});
+        }
+
+        inline void push_back(xnewaxis_tag /*s*/)
+        {
+            ++newaxis_count;
+            base_type::push_back({-1, 0, 0});
+        }
+
+        inline void push_back(index_type i)
+        {
+            base_type::push_back({i, 0, 0});
+        }
+
+    private:
+         std::vector<std::size_t> m_shape;
+         std::size_t newaxis_count = 0;
+    };
+
+    namespace detail
+    {
+        template <class E, std::enable_if_t<has_raw_data_interface<std::decay_t<E>>::value>* = nullptr>
+        inline auto&& get_data(E&& e)
+        {
+            return e.data();
+        }
+
+        template <class E, std::enable_if_t<has_raw_data_interface<std::decay_t<E>>::value>* = nullptr>
+        inline std::size_t get_offset(E&& e)
+        {
+            return e.raw_data_offset();
+        }
+
+        template <class E, std::enable_if_t<has_raw_data_interface<std::decay_t<E>>::value>* = nullptr>
+        inline auto&& get_strides(E&& e)
+        {
+            return e.strides();
+        }
+
+        template <class E, std::enable_if_t<!has_raw_data_interface<std::decay_t<E>>::value>* = nullptr>
+        inline auto get_data(E&& e) -> expression_adaptor<xclosure_t<E>>
+        {
+            return std::move(expression_adaptor<xclosure_t<E>>(e));
+        }
+
+        template <class E, std::enable_if_t<!has_raw_data_interface<std::decay_t<E>>::value>* = nullptr>
+        inline std::size_t get_offset(E&& /*e*/)
+        {
+            return 0;
+        }
+
+        template <class E, std::enable_if_t<!has_raw_data_interface<std::decay_t<E>>::value>* = nullptr>
+        inline auto get_strides(E&& e)
+        {
+            std::vector<std::size_t> strides;
+            strides.resize(e.shape().size());
+            compute_strides(e.shape(), layout_type::row_major, strides);
+            return strides;
+        }
+    }
+
+    template <class E, class S>
+    inline auto dynamic_view(E&& e, S&& slices)
+    {
+        std::size_t offset = detail::get_offset(e);
+        using shape_type = typename std::vector<std::size_t>;
+
+        auto old_shape = e.shape();
+        auto&& old_strides = detail::get_strides(e);
+
+        shape_type new_shape;
+        shape_type new_strides;
+
+        std::size_t shape_size = old_shape.size();
+
+        for (const auto& el : slices)
+        {
+            if (el[0] >= 0 && el[1] == 0)
+            {
+                // treat this like a single int and remove from shape
+                shape_size = shape_size - 1;
+            }
+            else if (el[0] == -1 && el[1] == 0)
+            {
+                // treat this like a new axis
+                shape_size += 1;
+            }
+        }
+
+        new_shape.resize(shape_size);
+        new_strides.resize(shape_size);
+
+        std::size_t i = 0;
+        std::size_t idx = 0;
+        std::size_t newaxis_skip = 0;
+
+        for (; i < slices.size(); ++i) {
+            if (slices[i][0] >= 0)
+            {
+                offset += slices[i][0] * old_strides[i];
+            }
+
+            if (slices[i][1] != 0 && slices[i][2] != 0)
+            {
+                new_shape[idx] = slices[i][1];
+                new_strides[idx] = slices[i][2] * old_strides[i - newaxis_skip];
+                idx++;
+            }
+            else if (slices[i][0] == -1) // newaxis
+            {
+                new_shape[idx] = 1;
+                new_strides[idx] = 0;
+                newaxis_skip++;
+                idx++;
+            }
+        }
+
+        for (; i < old_shape.size(); ++i)
+        {
+            new_shape[idx] = old_shape[i];
+            new_strides[idx] = old_strides[i];
+            idx++;
+        }
+
+        auto data = detail::get_data(e);
+
+        using view_type = xstrided_view<xclosure_t<E>, shape_type, decltype(data)>;
+        return view_type(std::forward<E>(e), std::forward<decltype(data)>(data), std::move(new_shape), std::move(new_strides), offset);
+    }
+}
+
+#endif

--- a/inst/include/xtensor/xstrides.hpp
+++ b/inst/include/xtensor/xstrides.hpp
@@ -1,0 +1,216 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XSTRIDES_HPP
+#define XSTRIDES_HPP
+
+#include <cstddef>
+#include <functional>
+#include <numeric>
+
+#include "xexception.hpp"
+#include "xtensor_forward.hpp"
+
+namespace xt
+{
+
+    template <class shape_type>
+    auto compute_size(const shape_type& shape) noexcept;
+
+    /***************
+     * data offset *
+     ***************/
+
+    template <class size_type, class S, size_t dim = 0>
+    size_type data_offset(const S& strides) noexcept;
+
+    template <class size_type, class S, size_t dim = 0, class... Args>
+    size_type data_offset(const S& strides, size_type i, Args... args) noexcept;
+
+    template <class size_type, class S, class It>
+    size_type element_offset(const S& strides, It first, It last) noexcept;
+
+    /*******************
+     * strides builder *
+     *******************/
+
+    template <class shape_type, class strides_type>
+    std::size_t compute_strides(const shape_type& shape, layout_type l, strides_type& strides);
+
+    template <class shape_type, class strides_type, class backstrides_type>
+    std::size_t compute_strides(const shape_type& shape, layout_type l,
+                                strides_type& strides, backstrides_type& backstrides);
+
+    template <class shape_type, class strides_type>
+    void adapt_strides(const shape_type& shape, strides_type& strides) noexcept;
+
+    template <class shape_type, class strides_type, class backstrides_type>
+    void adapt_strides(const shape_type& shape, strides_type& strides,
+                       backstrides_type& backstrides) noexcept;
+
+    /***********************
+     * broadcast functions *
+     ***********************/
+
+    template <class S1, class S2>
+    bool broadcast_shape(const S1& input, S2& output);
+
+    template <class S1, class S2>
+    bool broadcastable(const S1& s1, S2& s2);
+
+    /******************
+     * Implementation *
+     ******************/
+
+    template <class shape_type>
+    inline auto compute_size(const shape_type& shape) noexcept
+    {
+        using size_type = std::decay_t<typename shape_type::value_type>;
+        return std::accumulate(shape.begin(), shape.end(), size_type(1), std::multiplies<size_type>());
+    }
+
+    template <class size_type, class S, size_t dim>
+    inline size_type data_offset(const S& /*strides*/) noexcept
+    {
+        return 0;
+    }
+
+    template <class size_type, class S, size_t dim, class... Args>
+    inline size_type data_offset(const S& strides, size_type i, Args... args) noexcept
+    {
+        if (sizeof...(Args) + 1 > strides.size())
+            return data_offset<size_type, S, dim>(strides, args...);
+        else
+            return i * strides[dim] + data_offset<size_type, S, dim + 1>(strides, args...);
+    }
+
+    template <class size_type, class S, class It>
+    inline size_type element_offset(const S& strides, It first, It last) noexcept
+    {
+        auto dst = static_cast<typename S::size_type>(std::distance(first, last));
+        It efirst = last - std::min(strides.size(), dst);
+        return std::inner_product(efirst, last, strides.begin(), size_type(0));
+    }
+
+    namespace detail
+    {
+        template <class shape_type, class strides_type, class bs_ptr>
+        inline void adapt_strides(const shape_type& shape, strides_type& strides,
+                                  bs_ptr backstrides, typename strides_type::size_type i) noexcept
+        {
+            if (shape[i] == 1)
+                strides[i] = 0;
+            (*backstrides)[i] = strides[i] * (shape[i] - 1);
+        }
+
+        template <class shape_type, class strides_type>
+        inline void adapt_strides(const shape_type& shape, strides_type& strides,
+                                  std::nullptr_t, typename strides_type::size_type i) noexcept
+        {
+            if (shape[i] == 1)
+                strides[i] = 0;
+        }
+
+        template <class shape_type, class strides_type, class bs_ptr>
+        inline std::size_t compute_strides(const shape_type& shape, layout_type l,
+                                           strides_type& strides, bs_ptr bs)
+        {
+            std::size_t data_size = 1;
+            if (l == layout_type::row_major)
+            {
+                for (std::size_t i = strides.size(); i != 0; --i)
+                {
+                    strides[i - 1] = data_size;
+                    data_size = strides[i - 1] * shape[i - 1];
+                    adapt_strides(shape, strides, bs, i - 1);
+                }
+            }
+            else
+            {
+                for (std::size_t i = 0; i < strides.size(); ++i)
+                {
+                    strides[i] = data_size;
+                    data_size = strides[i] * shape[i];
+                    adapt_strides(shape, strides, bs, i);
+                }
+            }
+            return data_size;
+        }
+    }
+
+    template <class shape_type, class strides_type>
+    inline std::size_t compute_strides(const shape_type& shape, layout_type l, strides_type& strides)
+    {
+        return detail::compute_strides(shape, l, strides, nullptr);
+    }
+
+    template <class shape_type, class strides_type, class backstrides_type>
+    inline std::size_t compute_strides(const shape_type& shape, layout_type l,
+                                       strides_type& strides,
+                                       backstrides_type& backstrides)
+    {
+        return detail::compute_strides(shape, l, strides, &backstrides);
+    }
+
+    template <class shape_type, class strides_type>
+    inline void adapt_strides(const shape_type& shape, strides_type& strides) noexcept
+    {
+        for (typename shape_type::size_type i = 0; i < shape.size(); ++i)
+        {
+            detail::adapt_strides(shape, strides, nullptr, i);
+        }
+    }
+
+    template <class shape_type, class strides_type, class backstrides_type>
+    inline void adapt_strides(const shape_type& shape, strides_type& strides,
+                              backstrides_type& backstrides) noexcept
+    {
+        for (typename shape_type::size_type i = 0; i < shape.size(); ++i)
+        {
+            detail::adapt_strides(shape, strides, &backstrides, i);
+        }
+    }
+
+    template <class S1, class S2>
+    inline bool broadcast_shape(const S1& input, S2& output)
+    {
+        bool trivial_broadcast = (input.size() == output.size());
+        auto input_iter = input.crbegin();
+        auto output_iter = output.rbegin();
+        for (; input_iter != input.crend(); ++input_iter, ++output_iter)
+        {
+            if (*output_iter == 1)
+            {
+                *output_iter = *input_iter;
+            }
+            else if ((*input_iter != 1) && (*output_iter != *input_iter))
+            {
+                throw broadcast_error(output, input);
+            }
+            trivial_broadcast = trivial_broadcast && (*output_iter == *input_iter);
+        }
+        return trivial_broadcast;
+    }
+
+    template <class S1, class S2>
+    inline bool broadcastable(const S1& s1, const S2& s2)
+    {
+        auto iter1 = s1.crbegin();
+        auto iter2 = s2.crbegin();
+        for (; iter1 != s1.crend() && iter2 != s2.crend(); ++iter1, ++iter2)
+        {
+            if ((*iter2 != 1) && (*iter1 != 1) && (*iter2 != *iter1))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+#endif

--- a/inst/include/xtensor/xtensor.hpp
+++ b/inst/include/xtensor/xtensor.hpp
@@ -1,0 +1,455 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XTENSOR_HPP
+#define XTENSOR_HPP
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+#include "xbuffer_adaptor.hpp"
+#include "xcontainer.hpp"
+#include "xsemantic.hpp"
+
+namespace xt
+{
+
+    /***********************
+     * xtensor declaration *
+     ***********************/
+
+    template <class EC, std::size_t N, layout_type L>
+    struct xcontainer_inner_types<xtensor_container<EC, N, L>>
+    {
+        using container_type = EC;
+        using shape_type = std::array<typename container_type::size_type, N>;
+        using strides_type = shape_type;
+        using backstrides_type = shape_type;
+        using inner_shape_type = shape_type;
+        using inner_strides_type = strides_type;
+        using inner_backstrides_type = backstrides_type;
+        using temporary_type = xtensor_container<EC, N, L>;
+    };
+
+    template <class EC, std::size_t N, layout_type L>
+    struct xiterable_inner_types<xtensor_container<EC, N, L>>
+        : xcontainer_iterable_types<xtensor_container<EC, N, L>>
+    {
+    };
+
+    /**
+     * @class xtensor_container
+     * @brief Dense multidimensional container with tensor semantic and fixed
+     * dimension.
+     *
+     * The xtensor_container class implements a dense multidimensional container
+     * with tensor semantic and fixed dimension
+     *
+     * @tparam EC The type of the container holding the elements.
+     * @tparam N The dimension of the container.
+     * @tparam L The layout_type of the tensor.
+     * @sa xtensor
+     */
+    template <class EC, size_t N, layout_type L>
+    class xtensor_container : public xstrided_container<xtensor_container<EC, N, L>, L>,
+                              public xcontainer_semantic<xtensor_container<EC, N, L>>
+    {
+    public:
+
+        using self_type = xtensor_container<EC, N, L>;
+        using base_type = xstrided_container<self_type, L>;
+        using semantic_base = xcontainer_semantic<self_type>;
+        using container_type = typename base_type::container_type;
+        using value_type = typename base_type::value_type;
+        using reference = typename base_type::reference;
+        using const_reference = typename base_type::const_reference;
+        using pointer = typename base_type::pointer;
+        using const_pointer = typename base_type::const_pointer;
+        using shape_type = typename base_type::shape_type;
+        using inner_shape_type = typename base_type::inner_shape_type;
+        using strides_type = typename base_type::strides_type;
+        using inner_strides_type = typename base_type::inner_strides_type;
+
+        xtensor_container();
+        xtensor_container(nested_initializer_list_t<value_type, N> t);
+        explicit xtensor_container(const shape_type& shape, layout_type l = L);
+        explicit xtensor_container(const shape_type& shape, const_reference value, layout_type l = L);
+        explicit xtensor_container(const shape_type& shape, const strides_type& strides);
+        explicit xtensor_container(const shape_type& shape, const strides_type& strides, const_reference value);
+        explicit xtensor_container(container_type&& data, inner_shape_type&& shape, inner_strides_type&& strides);
+
+        template <class S = shape_type>
+        static xtensor_container from_shape(S&& s);
+
+        ~xtensor_container() = default;
+
+        xtensor_container(const xtensor_container&) = default;
+        xtensor_container& operator=(const xtensor_container&) = default;
+
+        xtensor_container(xtensor_container&&) = default;
+        xtensor_container& operator=(xtensor_container&&) = default;
+
+        template <class E>
+        xtensor_container(const xexpression<E>& e);
+
+        template <class E>
+        xtensor_container& operator=(const xexpression<E>& e);
+
+    private:
+
+        container_type m_data;
+
+        container_type& data_impl() noexcept;
+        const container_type& data_impl() const noexcept;
+
+        friend class xcontainer<xtensor_container<EC, N, L>>;
+    };
+
+    /*****************************************
+     * xtensor_container_adaptor declaration *
+     *****************************************/
+
+    template <class EC, std::size_t N, layout_type L = DEFAULT_LAYOUT>
+    class xtensor_adaptor;
+
+    template <class EC, std::size_t N, layout_type L>
+    struct xcontainer_inner_types<xtensor_adaptor<EC, N, L>>
+    {
+        using container_type = EC;
+        using shape_type = std::array<typename container_type::size_type, N>;
+        using strides_type = shape_type;
+        using backstrides_type = shape_type;
+        using inner_shape_type = shape_type;
+        using inner_strides_type = strides_type;
+        using inner_backstrides_type = backstrides_type;
+        using temporary_type = xtensor_container<EC, N, L>;
+    };
+
+    template <class EC, std::size_t N, layout_type L>
+    struct xiterable_inner_types<xtensor_adaptor<EC, N, L>>
+        : xcontainer_iterable_types<xtensor_adaptor<EC, N, L>>
+    {
+    };
+
+    /**
+     * @class xtensor_adaptor
+     * @brief Dense multidimensional container adaptor with tensor semantic
+     * and fixed dimension.
+     *
+     * The xtensor_adaptor class implements a dense multidimensional
+     * container adaptor with tensor semantic and fixed dimension. It
+     * is used to provide a multidimensional container semantic and a
+     * tensor semantic to stl-like containers.
+     *
+     * @tparam EC The container type to adapt.
+     * @tparam N The dimension of the adaptor.
+     * @tparam L The layout_type of the adaptor.
+     */
+    template <class EC, std::size_t N, layout_type L>
+    class xtensor_adaptor : public xstrided_container<xtensor_adaptor<EC, N, L>, L>,
+                            public xadaptor_semantic<xtensor_adaptor<EC, N, L>>
+    {
+    public:
+
+        using self_type = xtensor_adaptor<EC, N, L>;
+        using base_type = xstrided_container<self_type, L>;
+        using semantic_base = xadaptor_semantic<self_type>;
+        using container_type = typename base_type::container_type;
+        using shape_type = typename base_type::shape_type;
+        using strides_type = typename base_type::strides_type;
+
+        using container_closure_type = adaptor_closure_t<container_type>;
+
+        xtensor_adaptor(container_closure_type data);
+        xtensor_adaptor(container_closure_type data, const shape_type& shape, layout_type l = layout_type::row_major);
+        xtensor_adaptor(container_closure_type data, const shape_type& shape, const strides_type& strides);
+
+        ~xtensor_adaptor() = default;
+
+        xtensor_adaptor(const xtensor_adaptor&) = default;
+        xtensor_adaptor& operator=(const xtensor_adaptor&);
+
+        xtensor_adaptor(xtensor_adaptor&&) = default;
+        xtensor_adaptor& operator=(xtensor_adaptor&&);
+
+        template <class E>
+        xtensor_adaptor& operator=(const xexpression<E>& e);
+
+    private:
+
+        container_closure_type m_data;
+
+        container_type& data_impl() noexcept;
+        const container_type& data_impl() const noexcept;
+
+        using temporary_type = typename xcontainer_inner_types<self_type>::temporary_type;
+        void assign_temporary_impl(temporary_type& tmp);
+
+        friend class xcontainer<xtensor_adaptor<EC, N, L>>;
+        friend class xadaptor_semantic<xtensor_adaptor<EC, N, L>>;
+    };
+
+    /************************************
+     * xtensor_container implementation *
+     ************************************/
+
+    /**
+     * @name Constructors
+     */
+    //@{
+    /**
+     * Allocates an uninitialized xtensor_container that holds 0 element.
+     */
+    template <class EC, std::size_t N, layout_type L>
+    inline xtensor_container<EC, N, L>::xtensor_container()
+        : base_type(), m_data(1, value_type())
+    {
+    }
+
+    /**
+     * Allocates an xtensor_container with nested initializer lists.
+     */
+    template <class EC, std::size_t N, layout_type L>
+    inline xtensor_container<EC, N, L>::xtensor_container(nested_initializer_list_t<value_type, N> t)
+        : base_type()
+    {
+        base_type::reshape(xt::shape<shape_type>(t), true);
+        L == layout_type::row_major ? nested_copy(m_data.begin(), t) : nested_copy(this->xbegin(), t);
+    }
+
+    /**
+     * Allocates an uninitialized xtensor_container with the specified shape and
+     * layout_type.
+     * @param shape the shape of the xtensor_container
+     * @param l the layout_type of the xtensor_container
+     */
+    template <class EC, std::size_t N, layout_type L>
+    inline xtensor_container<EC, N, L>::xtensor_container(const shape_type& shape, layout_type l)
+        : base_type()
+    {
+        base_type::reshape(shape, l);
+    }
+
+    /**
+     * Allocates an xtensor_container with the specified shape and layout_type. Elements
+     * are initialized to the specified value.
+     * @param shape the shape of the xtensor_container
+     * @param value the value of the elements
+     * @param l the layout_type of the xtensor_container
+     */
+    template <class EC, std::size_t N, layout_type L>
+    inline xtensor_container<EC, N, L>::xtensor_container(const shape_type& shape, const_reference value, layout_type l)
+        : base_type()
+    {
+        base_type::reshape(shape, l);
+        std::fill(m_data.begin(), m_data.end(), value);
+    }
+
+    /**
+     * Allocates an uninitialized xtensor_container with the specified shape and strides.
+     * @param shape the shape of the xtensor_container
+     * @param strides the strides of the xtensor_container
+     */
+    template <class EC, std::size_t N, layout_type L>
+    inline xtensor_container<EC, N, L>::xtensor_container(const shape_type& shape, const strides_type& strides)
+        : base_type()
+    {
+        base_type::reshape(shape, strides);
+    }
+
+    /**
+     * Allocates an uninitialized xtensor_container with the specified shape and strides.
+     * Elements are initialized to the specified value.
+     * @param shape the shape of the xtensor_container
+     * @param strides the strides of the xtensor_container
+     * @param value the value of the elements
+     */
+    template <class EC, std::size_t N, layout_type L>
+    inline xtensor_container<EC, N, L>::xtensor_container(const shape_type& shape, const strides_type& strides, const_reference value)
+        : base_type()
+    {
+        base_type::reshape(shape, strides);
+        std::fill(m_data.begin(), m_data.end(), value);
+    }
+
+    /**
+     * Allocates an xtensor_container by moving specified data, shape and strides
+     *
+     * @param data the data for the xtensor_container
+     * @param shape the shape of the xtensor_container
+     * @param strides the strides of the xtensor_container
+     */
+    template <class EC, std::size_t N, layout_type L>
+    inline xtensor_container<EC, N, L>::xtensor_container(container_type&& data, inner_shape_type&& shape, inner_strides_type&& strides)
+        : base_type(std::move(shape), std::move(strides)), m_data(std::move(data))
+    {
+    }
+
+    template <class EC, std::size_t N, layout_type L>
+    template <class S>
+    inline xtensor_container<EC, N, L> xtensor_container<EC, N, L>::from_shape(S&& s)
+    {
+        if (s.size() != N)
+        {
+            throw std::runtime_error("Cannot change dimension of xtensor.");
+        }
+        shape_type shape = forward_sequence<shape_type>(s);
+        return self_type(shape);
+    }
+    //@}
+
+    /**
+     * @name Extended copy semantic
+     */
+    //@{
+    /**
+     * The extended copy constructor.
+     */
+    template <class EC, std::size_t N, layout_type L>
+    template <class E>
+    inline xtensor_container<EC, N, L>::xtensor_container(const xexpression<E>& e)
+        : base_type()
+    {
+        // Avoids unintialized data because of (m_shape == shape) condition
+        // in reshape (called by assign), which is always true when dimension == 0.
+        if (e.derived_cast().dimension() == 0)
+        {
+            m_data.resize(1);
+        }
+        semantic_base::assign(e);
+    }
+
+    /**
+     * The extended assignment operator.
+     */
+    template <class EC, std::size_t N, layout_type L>
+    template <class E>
+    inline auto xtensor_container<EC, N, L>::operator=(const xexpression<E>& e) -> self_type&
+    {
+        return semantic_base::operator=(e);
+    }
+    //@}
+
+    template <class EC, std::size_t N, layout_type L>
+    inline auto xtensor_container<EC, N, L>::data_impl() noexcept -> container_type&
+    {
+        return m_data;
+    }
+
+    template <class EC, std::size_t N, layout_type L>
+    inline auto xtensor_container<EC, N, L>::data_impl() const noexcept -> const container_type&
+    {
+        return m_data;
+    }
+
+    /*******************
+     * xtensor_adaptor *
+     *******************/
+
+    /**
+     * @name Constructors
+     */
+    //@{
+    /**
+     * Constructs an xtensor_adaptor of the given stl-like container.
+     * @param data the container to adapt
+     */
+    template <class EC, std::size_t N, layout_type L>
+    inline xtensor_adaptor<EC, N, L>::xtensor_adaptor(container_closure_type data)
+        : base_type(), m_data(std::forward<container_closure_type>(data))
+    {
+    }
+
+    /**
+     * Constructs an xtensor_adaptor of the given stl-like container,
+     * with the specified shape and layout_type.
+     * @param data the container to adapt
+     * @param shape the shape of the xtensor_adaptor
+     * @param l the layout_type of the xtensor_adaptor
+     */
+    template <class EC, std::size_t N, layout_type L>
+    inline xtensor_adaptor<EC, N, L>::xtensor_adaptor(container_closure_type data, const shape_type& shape, layout_type l)
+        : base_type(), m_data(std::forward<container_closure_type>(data))
+    {
+        base_type::reshape(shape, l);
+    }
+
+    /**
+     * Constructs an xtensor_adaptor of the given stl-like container,
+     * with the specified shape and strides.
+     * @param data the container to adapt
+     * @param shape the shape of the xtensor_adaptor
+     * @param strides the strides of the xtensor_adaptor
+     */
+    template <class EC, std::size_t N, layout_type L>
+    inline xtensor_adaptor<EC, N, L>::xtensor_adaptor(container_closure_type data, const shape_type& shape, const strides_type& strides)
+        : base_type(), m_data(std::forward<container_closure_type>(data))
+    {
+        base_type::reshape(shape, strides);
+    }
+    //@}
+
+    template <class EC, std::size_t N, layout_type L>
+    inline auto xtensor_adaptor<EC, N, L>::operator=(const xtensor_adaptor& rhs) -> self_type&
+    {
+        base_type::operator=(rhs);
+        m_data = rhs.m_data;
+        return *this;
+    }
+
+    template <class EC, std::size_t N, layout_type L>
+    inline auto xtensor_adaptor<EC, N, L>::operator=(xtensor_adaptor&& rhs) -> self_type&
+    {
+        base_type::operator=(std::move(rhs));
+        m_data = rhs.m_data;
+        return *this;
+    }
+
+    /**
+     * @name Extended copy semantic
+     */
+    //@{
+    /**
+     * The extended assignment operator.
+     */
+    template <class EC, std::size_t N, layout_type L>
+    template <class E>
+    inline auto xtensor_adaptor<EC, N, L>::operator=(const xexpression<E>& e) -> self_type&
+    {
+        return semantic_base::operator=(e);
+    }
+    //@}
+
+    template <class EC, std::size_t N, layout_type L>
+    inline auto xtensor_adaptor<EC, N, L>::data_impl() noexcept -> container_type&
+    {
+        return m_data;
+    }
+
+    template <class EC, std::size_t N, layout_type L>
+    inline auto xtensor_adaptor<EC, N, L>::data_impl() const noexcept -> const container_type&
+    {
+        return m_data;
+    }
+
+    template <class EC, std::size_t N, layout_type L>
+    inline void xtensor_adaptor<EC, N, L>::assign_temporary_impl(temporary_type& tmp)
+    {
+        // TODO (performance improvement) : consider moving tmps shape and strides
+        base_type::shape_impl() = tmp.shape();
+        base_type::strides_impl() = tmp.strides();
+        base_type::backstrides_impl() = tmp.backstrides();
+        m_data.resize(tmp.size());
+        std::copy(tmp.data().cbegin(), tmp.data().cend(), m_data.begin());
+    }
+}
+
+#endif

--- a/inst/include/xtensor/xtensor_config.hpp
+++ b/inst/include/xtensor/xtensor_config.hpp
@@ -1,0 +1,38 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XTENSOR_CONFIG_HPP
+#define XTENSOR_CONFIG_HPP
+
+#define XTENSOR_VERSION_MAJOR 0
+#define XTENSOR_VERSION_MINOR 10
+#define XTENSOR_VERSION_PATCH 3
+
+// DETECT 3.6 <= clang < 3.8 for compiler bug workaround.
+#ifdef __clang__
+    #if __clang_major__ == 3 && __clang_minor__ < 8
+        #define X_OLD_CLANG
+        #include <initializer_list>
+        #include <vector>
+    #endif
+#endif
+
+#ifndef DEFAULT_DATA_CONTAINER
+#define DEFAULT_DATA_CONTAINER(T, A) uvector<T, A>
+#endif
+
+#ifndef DEFAULT_SHAPE_CONTAINER
+#define DEFAULT_SHAPE_CONTAINER(T, EA, SA) \
+    std::vector<typename DEFAULT_DATA_CONTAINER(T, EA)::size_type, SA>
+#endif
+
+#ifndef DEFAULT_LAYOUT
+#define DEFAULT_LAYOUT layout_type::row_major
+#endif
+
+#endif

--- a/inst/include/xtensor/xtensor_forward.hpp
+++ b/inst/include/xtensor/xtensor_forward.hpp
@@ -1,0 +1,127 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XTENSOR_FORWARD_HPP
+#define XTENSOR_FORWARD_HPP
+
+#include "xtensor_config.hpp"
+#include "xstorage.hpp"
+#include "xlayout.hpp"
+#include <memory>
+#include <vector>
+
+namespace xt
+{
+    template <class C>
+    struct xcontainer_inner_types;
+
+    template <class EC, layout_type L = DEFAULT_LAYOUT,
+              class SC = DEFAULT_SHAPE_CONTAINER(typename EC::value_type,
+                                                 typename EC::allocator_type,
+                                                 std::allocator<typename EC::size_type>)>
+    class xarray_container;
+
+    /**
+     * @typedef xarray
+     * Alias template on xarray_container with default parameters for data container
+     * type and shape / strides container type. This allows to write
+     *
+     * \code{.cpp}
+     * xt::xarray<double> a = {{1., 2.}, {3., 4.}};
+     * \endcode
+     *
+     * instead of the heavier syntax
+     *
+     * \code{.cpp}
+     * xt::xarray_container<std::vector<double>, std::vector<std::size_t>> a = ...
+     * \endcode
+     * 
+     * @tparam T The value type of the elements.
+     * @tparam L The layout_type of the xarray_container (default: row_major).
+     * @tparam A The allocator of the container holding the elements.
+     * @tparam SA The allocator of the containers holding the shape and the strides.
+     */
+    template <class T, layout_type L = DEFAULT_LAYOUT,
+              class A = std::allocator<T>,
+              class SA = std::allocator<typename std::vector<T, A>::size_type>>
+    using xarray = xarray_container<DEFAULT_DATA_CONTAINER(T, A), L, DEFAULT_SHAPE_CONTAINER(T, A, SA)>;
+
+    template <class EC, std::size_t N, layout_type L = DEFAULT_LAYOUT>
+    class xtensor_container;
+
+    /**
+     * @typedef xtensor
+     * Alias template on xtensor_container with default parameters for data container
+     * type. This allows to write
+     *
+     * \code{.cpp}
+     * xt::xtensor<double, 2> a = {{1., 2.}, {3., 4.}};
+     * \endcode
+     *
+     * instead of the heavier syntax
+     *
+     * \code{.cpp}
+     * xt::xtensor_container<std::vector<double>, 2> a = ...
+     * \endcode
+     *
+     * @tparam T The value type of the elements.
+     * @tparam N The dimension of the tensor.
+     * @tparam L The layout_type of the tensor (default: row_major).
+     * @tparam A The allocator of the containers holding the elements.
+     */
+    template <class T, std::size_t N, layout_type L = DEFAULT_LAYOUT, class A = std::allocator<T>>
+    using xtensor = xtensor_container<DEFAULT_DATA_CONTAINER(T, A), N, L>;
+
+    template <class CT, class... S>
+    class xview;
+
+    template <class T, class A, class BA>
+    class xoptional_vector;
+
+    /**
+     * @typedef xarray_optional
+     * Alias template on xarray_container for handling missing values
+     *
+     * @tparam T The value type of the elements.
+     * @tparam L The layout_type of the container (default: row_major).
+     * @tparam A The allocator of the container holding the elements.
+     * @tparam BA The allocator of the container holding the missing flags.
+     * @tparam SA The allocator of the containers holding the shape and the strides.
+     */
+    template <class T, layout_type L = DEFAULT_LAYOUT,
+              class A = std::allocator<T>,
+              class BA = std::allocator<bool>,
+              class SA = std::allocator<typename std::vector<T, A>::size_type>>
+    using xarray_optional = xarray_container<xoptional_vector<T, A, BA>, L, DEFAULT_SHAPE_CONTAINER(T, A, SA)>;
+
+    /**
+     * @typedef xtensor_optional
+     * Alias template on xtensor_container for handling missing values
+     *
+     * @tparam T The value type of the elements.
+     * @tparam N The dimension of the tensor.
+     * @tparam L The layout_type of the container (default: row_major).
+     * @tparam A The allocator of the containers holding the elements.
+     * @tparam BA The allocator of the container holding the missing flags.
+     */
+    template <class T, std::size_t N, layout_type L = DEFAULT_LAYOUT, class A = std::allocator<T>, class BA = std::allocator<bool>>
+    using xtensor_optional = xtensor_container<xoptional_vector<T, A, BA>, N, L>;
+
+    namespace check_policy
+    {
+        struct none
+        {
+        };
+        struct full
+        {
+        };
+    }
+
+}
+
+#endif

--- a/inst/include/xtensor/xutils.hpp
+++ b/inst/include/xtensor/xutils.hpp
@@ -1,0 +1,919 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XUTILS_HPP
+#define XUTILS_HPP
+
+#include <algorithm>
+#include <array>
+#include <complex>
+#include <cstddef>
+#include <initializer_list>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "xtensor_config.hpp"
+
+namespace xt
+{
+    /****************
+     * declarations *
+     ****************/
+
+    template <class T>
+    struct remove_class;
+
+    template <class F, class... T>
+    void for_each(F&& f, std::tuple<T...>& t) noexcept(noexcept(std::declval<F>()));
+
+    template <class F, class R, class... T>
+    R accumulate(F&& f, R init, const std::tuple<T...>& t) noexcept(noexcept(std::declval<F>()));
+
+    template <class... T>
+    struct or_;
+
+    template <class... T>
+    struct and_;
+
+    template <bool... B>
+    struct or_c;
+
+    template <bool... B>
+    struct and_c;
+
+    template <std::size_t I, class... Args>
+    constexpr decltype(auto) argument(Args&&... args) noexcept;
+
+    template <class R, class F, class... S>
+    R apply(std::size_t index, F&& func, const std::tuple<S...>& s) noexcept(noexcept(std::declval<F>()));
+
+    template <class T, class S>
+    void nested_copy(T&& iter, const S& s);
+
+    template <class T, class S>
+    void nested_copy(T&& iter, std::initializer_list<S> s);
+
+    template <class U>
+    struct initializer_dimension;
+
+    template <class R, class T>
+    constexpr R shape(T t);
+
+    template <class T, class S>
+    constexpr bool check_shape(T t, S first, S last);
+
+    template <class C>
+    bool resize_container(C& c, typename C::size_type size);
+
+    template <class T, std::size_t N>
+    bool resize_container(std::array<T, N>& a, typename std::array<T, N>::size_type size);
+
+    template <class S>
+    S make_sequence(typename S::size_type size, typename S::value_type v);
+
+    template <class R, class A>
+    decltype(auto) forward_sequence(A&& s);
+
+    // equivalent to std::size(c) in c++17
+    template <class C>
+    constexpr auto container_size(const C& c) -> decltype(c.size());
+
+    // equivalent to std::size(a) in c++17
+    template <class T, std::size_t N>
+    constexpr std::size_t container_size(const T (&a)[N]);
+
+    /*******************************
+     * remove_class implementation *
+     *******************************/
+
+    template <class T>
+    struct remove_class
+    {
+    };
+
+    template <class C, class R, class... Args>
+    struct remove_class<R (C::*)(Args...)>
+    {
+        typedef R type(Args...);
+    };
+
+    template <class C, class R, class... Args>
+    struct remove_class<R (C::*)(Args...) const>
+    {
+        typedef R type(Args...);
+    };
+
+    template <class T>
+    using remove_class_t = typename remove_class<T>::type;
+
+    /***************************
+     * for_each implementation *
+     ***************************/
+
+    namespace detail
+    {
+        template <std::size_t I, class F, class... T>
+        inline typename std::enable_if<I == sizeof...(T), void>::type
+        for_each_impl(F&& /*f*/, std::tuple<T...>& /*t*/) noexcept(noexcept(std::declval<F>()))
+        {
+        }
+
+        template <std::size_t I, class F, class... T>
+        inline typename std::enable_if<I < sizeof...(T), void>::type
+        for_each_impl(F&& f, std::tuple<T...>& t) noexcept(noexcept(std::declval<F>()))
+        {
+            f(std::get<I>(t));
+            for_each_impl<I + 1, F, T...>(std::forward<F>(f), t);
+        }
+    }
+
+    template <class F, class... T>
+    inline void for_each(F&& f, std::tuple<T...>& t) noexcept(noexcept(std::declval<F>()))
+    {
+        detail::for_each_impl<0, F, T...>(std::forward<F>(f), t);
+    }
+
+    /*****************************
+     * accumulate implementation *
+     *****************************/
+
+    namespace detail
+    {
+        template <std::size_t I, class F, class R, class... T>
+        inline std::enable_if_t<I == sizeof...(T), R>
+        accumulate_impl(F&& /*f*/, R init, const std::tuple<T...>& /*t*/) noexcept(noexcept(std::declval<F>()))
+        {
+            return init;
+        }
+
+        template <std::size_t I, class F, class R, class... T>
+        inline std::enable_if_t<I < sizeof...(T), R>
+        accumulate_impl(F&& f, R init, const std::tuple<T...>& t) noexcept(noexcept(std::declval<F>()))
+        {
+            R res = f(init, std::get<I>(t));
+            return accumulate_impl<I + 1, F, R, T...>(std::forward<F>(f), res, t);
+        }
+    }
+
+    template <class F, class R, class... T>
+    inline R accumulate(F&& f, R init, const std::tuple<T...>& t) noexcept(noexcept(std::declval<F>()))
+    {
+        return detail::accumulate_impl<0, F, R, T...>(f, init, t);
+    }
+
+    /**********************
+     * or_ implementation *
+     **********************/
+
+    template <>
+    struct or_<> : std::integral_constant<bool, false>
+    {
+    };
+
+    template <class T, class... Ts>
+    struct or_<T, Ts...>
+        : std::integral_constant<bool, T::value || or_<Ts...>::value>
+    {
+    };
+
+    /***********************
+     * and_ implementation *
+     ***********************/
+
+    template <>
+    struct and_<> : std::integral_constant<bool, true>
+    {
+    };
+
+    template <class T, class... Ts>
+    struct and_<T, Ts...>
+        : std::integral_constant<bool, T::value && and_<Ts...>::value>
+    {
+    };
+
+    /**********************************
+     * or_c and and_c implementations *
+     **********************************/
+
+    template <bool... B>
+    struct or_c : or_<std::integral_constant<bool, B>...>
+    {
+    };
+
+    template <bool... B>
+    struct and_c : and_<std::integral_constant<bool, B>...>
+    {
+    };
+
+    /***************************
+     * argument implementation *
+     ***************************/
+
+    namespace detail
+    {
+        template <std::size_t I>
+        struct getter
+        {
+            template <class Arg, class... Args>
+            static constexpr decltype(auto) get(Arg&& /*arg*/, Args&&... args) noexcept
+            {
+                return getter<I - 1>::get(std::forward<Args>(args)...);
+            }
+        };
+
+        template <>
+        struct getter<0>
+        {
+            template <class Arg, class... Args>
+            static constexpr Arg&& get(Arg&& arg, Args&&... /*args*/) noexcept
+            {
+                return std::forward<Arg>(arg);
+            }
+        };
+    }
+
+    template <std::size_t I, class... Args>
+    constexpr decltype(auto) argument(Args&&... args) noexcept
+    {
+        static_assert(I < sizeof...(Args), "I should be lesser than sizeof...(Args)");
+        return detail::getter<I>::get(std::forward<Args>(args)...);
+    }
+
+    /************************
+     * apply implementation *
+     ************************/
+
+    namespace detail
+    {
+        template <class R, class F, std::size_t I, class... S>
+        R apply_one(F&& func, const std::tuple<S...>& s) noexcept(noexcept(std::declval<F>()))
+        {
+            return func(std::get<I>(s));
+        }
+
+        template <class R, class F, std::size_t... I, class... S>
+        R apply(std::size_t index, F&& func, std::index_sequence<I...> /*seq*/, const std::tuple<S...>& s) noexcept(noexcept(std::declval<F>()))
+        {
+            using FT = std::add_pointer_t<R(F&&, const std::tuple<S...>&)>;
+            static const std::array<FT, sizeof...(I)> ar = {{&apply_one<R, F, I, S...>...}};
+            return ar[index](std::forward<F>(func), s);
+        }
+    }
+
+    template <class R, class F, class... S>
+    inline R apply(std::size_t index, F&& func, const std::tuple<S...>& s) noexcept(noexcept(std::declval<F>()))
+    {
+        return detail::apply<R>(index, std::forward<F>(func), std::make_index_sequence<sizeof...(S)>(), s);
+    }
+
+    /***************************
+     * nested_initializer_list *
+     ***************************/
+
+    template <class T, std::size_t I>
+    struct nested_initializer_list
+    {
+        using type = std::initializer_list<typename nested_initializer_list<T, I - 1>::type>;
+    };
+
+    template <class T>
+    struct nested_initializer_list<T, 0>
+    {
+        using type = T;
+    };
+
+    template <class T, std::size_t I>
+    using nested_initializer_list_t = typename nested_initializer_list<T, I>::type;
+
+    /******************************
+     * nested_copy implementation *
+     ******************************/
+
+    template <class T, class S>
+    inline void nested_copy(T&& iter, const S& s)
+    {
+        *iter++ = s;
+    }
+
+    template <class T, class S>
+    inline void nested_copy(T&& iter, std::initializer_list<S> s)
+    {
+        for (auto it = s.begin(); it != s.end(); ++it)
+        {
+            nested_copy(std::forward<T>(iter), *it);
+        }
+    }
+
+    /****************************************
+     * initializer_dimension implementation *
+     ****************************************/
+
+    namespace detail
+    {
+        template <class U>
+        struct initializer_depth_impl
+        {
+            static constexpr std::size_t value = 0;
+        };
+
+        template <class T>
+        struct initializer_depth_impl<std::initializer_list<T>>
+        {
+            static constexpr std::size_t value = 1 + initializer_depth_impl<T>::value;
+        };
+    }
+
+    template <class U>
+    struct initializer_dimension
+    {
+        static constexpr std::size_t value = detail::initializer_depth_impl<U>::value;
+    };
+
+    /************************************
+     * initializer_shape implementation *
+     ************************************/
+
+    namespace detail
+    {
+        template <std::size_t I>
+        struct initializer_shape_impl
+        {
+            template <class T>
+            static constexpr std::size_t value(T t)
+            {
+                return t.size() == 0 ? 0 : initializer_shape_impl<I - 1>::value(*t.begin());
+            }
+        };
+
+        template <>
+        struct initializer_shape_impl<0>
+        {
+            template <class T>
+            static constexpr std::size_t value(T t)
+            {
+                return t.size();
+            }
+        };
+
+        template <class R, class U, std::size_t... I>
+        constexpr R initializer_shape(U t, std::index_sequence<I...>)
+        {
+            using size_type = typename R::value_type;
+            return { size_type(initializer_shape_impl<I>::value(t))... };
+        }
+    }
+
+    template <class R, class T>
+    constexpr R shape(T t)
+    {
+        return detail::initializer_shape<R, decltype(t)>(t, std::make_index_sequence<initializer_dimension<decltype(t)>::value>());
+    }
+
+    /******************************
+     * check_shape implementation *
+     ******************************/
+
+    namespace detail
+    {
+        template <class T, class S>
+        struct predshape
+        {
+            constexpr predshape(S first, S last)
+                : m_first(first), m_last(last)
+            {
+            }
+
+            constexpr bool operator()(const T&) const
+            {
+                return m_first == m_last;
+            }
+
+            S m_first;
+            S m_last;
+        };
+
+        template <class T, class S>
+        struct predshape<std::initializer_list<T>, S>
+        {
+            constexpr predshape(S first, S last)
+                : m_first(first), m_last(last)
+            {
+            }
+
+            constexpr bool operator()(std::initializer_list<T> t) const
+            {
+                return *m_first == t.size() && std::all_of(t.begin(), t.end(), predshape<T, S>(m_first + 1, m_last));
+            }
+
+            S m_first;
+            S m_last;
+        };
+    }
+
+    template <class T, class S>
+    constexpr bool check_shape(T t, S first, S last)
+    {
+        return detail::predshape<decltype(t), S>(first, last)(t);
+    }
+
+    /***********************************
+     * resize_container implementation *
+     ***********************************/
+
+    template <class C>
+    inline bool resize_container(C& c, typename C::size_type size)
+    {
+        c.resize(size);
+        return true;
+    }
+
+    template <class T, std::size_t N>
+    inline bool resize_container(std::array<T, N>& /*a*/, typename std::array<T, N>::size_type size)
+    {
+        return size == N;
+    }
+
+    /********************************
+     * make_sequence implementation *
+     ********************************/
+
+    namespace detail
+    {
+        template <class S>
+        struct sequence_builder
+        {
+            using value_type = typename S::value_type;
+            using size_type = typename S::size_type;
+
+            inline static S make(size_type size, value_type v)
+            {
+                return S(size, v);
+            }
+        };
+
+        template <class T, std::size_t N>
+        struct sequence_builder<std::array<T, N>>
+        {
+            using sequence_type = std::array<T, N>;
+            using value_type = typename sequence_type::value_type;
+            using size_type = typename sequence_type::size_type;
+
+            inline static sequence_type make(size_type /*size*/, value_type v)
+            {
+                sequence_type s;
+                s.fill(v);
+                return s;
+            }
+        };
+    }
+
+    template <class S>
+    inline S make_sequence(typename S::size_type size, typename S::value_type v)
+    {
+        return detail::sequence_builder<S>::make(size, v);
+    }
+
+    /***********************************
+     * forward_sequence implementation *
+     ***********************************/
+
+    namespace detail
+    {
+        template <class R, class A, class E = void>
+        struct sequence_forwarder
+        {
+            template <class T>
+            static inline R forward(const T& r)
+            {
+                return R(std::begin(r), std::end(r));
+            }
+        };
+
+        template <class I, std::size_t L, class A>
+        struct sequence_forwarder<std::array<I, L>, A,
+                                  std::enable_if_t<!std::is_same<std::array<I, L>, A>::value>>
+        {
+            using R = std::array<I, L>;
+
+            template <class T>
+            static inline R forward(const T& r)
+            {
+                R ret;
+                std::copy(std::begin(r), std::end(r), std::begin(ret));
+                return ret;
+            }
+        };
+
+        template <class R>
+        struct sequence_forwarder<R, R>
+        {
+            template <class T>
+            static inline T&& forward(typename std::remove_reference<T>::type& t) noexcept
+            {
+                return static_cast<T&&>(t);
+            }
+
+            template <class T>
+            static inline T&& forward(typename std::remove_reference<T>::type&& t) noexcept
+            {
+                return static_cast<T&&>(t);
+            }
+        };
+    }
+
+    template <class R, class A>
+    inline decltype(auto) forward_sequence(A&& s)
+    {
+        using forwarder = detail::sequence_forwarder<
+            std::decay_t<R>,
+            std::remove_cv_t<std::remove_reference_t<A>>
+        >;
+        return forwarder::template forward<A>(s);
+    }
+
+    /*************************************
+     * promote_shape and promote_strides *
+     *************************************/
+
+    namespace detail
+    {
+        template <class T1, class T2>
+        constexpr std::common_type_t<T1, T2> imax(const T1& a, const T2& b)
+        {
+            return a > b ? a : b;
+        }
+
+        // Variadic meta-function returning the maximal size of std::arrays.
+        template <class... T>
+        struct max_array_size;
+
+        template <>
+        struct max_array_size<>
+        {
+            static constexpr std::size_t value = 0;
+        };
+
+        template <class T, class... Ts>
+        struct max_array_size<T, Ts...> : std::integral_constant<std::size_t, imax(std::tuple_size<T>::value, max_array_size<Ts...>::value)>
+        {
+        };
+
+        // Simple is_array and only_array meta-functions
+        template <class S>
+        struct is_array
+        {
+            static constexpr bool value = false;
+        };
+
+        template <class T, std::size_t N>
+        struct is_array<std::array<T, N>>
+        {
+            static constexpr bool value = true;
+        };
+
+        template <class... S>
+        using only_array = and_<is_array<S>...>;
+
+        // The promote_index meta-function returns std::vector<promoted_value_type> in the
+        // general case and an array of the promoted value type and maximal size if all
+        // arguments are of type std::array
+
+        template <bool A, class... S>
+        struct promote_index_impl;
+
+        template <class... S>
+        struct promote_index_impl<false, S...>
+        {
+            using type = std::vector<typename std::common_type<typename S::value_type...>::type>;
+        };
+
+        template <class... S>
+        struct promote_index_impl<true, S...>
+        {
+            using type = std::array<typename std::common_type<typename S::value_type...>::type, max_array_size<S...>::value>;
+        };
+
+        template <>
+        struct promote_index_impl<true>
+        {
+            using type = std::array<std::size_t, 0>;
+        };
+
+        template <class... S>
+        struct promote_index
+        {
+            using type = typename promote_index_impl<only_array<S...>::value, S...>::type;
+        };
+    }
+
+    template <class... S>
+    using promote_shape_t = typename detail::promote_index<S...>::type;
+
+    template <class... S>
+    using promote_strides_t = typename detail::promote_index<S...>::type;
+
+
+    /**************************
+     * closure implementation *
+     **************************/
+
+    template <class S>
+    struct closure
+    {
+        using underlying_type = std::conditional_t<std::is_const<std::remove_reference_t<S>>::value,
+                                                   const std::decay_t<S>,
+                                                   std::decay_t<S>>;
+        using type = typename std::conditional<std::is_lvalue_reference<S>::value,
+                                               underlying_type&,
+                                               underlying_type>::type;
+    };
+
+    template <class S>
+    using closure_t = typename closure<S>::type;
+
+    template <class S>
+    struct const_closure
+    {
+        using underlying_type = const std::decay_t<S>;
+        using type = typename std::conditional<std::is_lvalue_reference<S>::value,
+                                               underlying_type&,
+                                               underlying_type>::type;
+    };
+
+    template <class S>
+    using const_closure_t = typename const_closure<S>::type;
+
+    /******************************
+     * ptr_closure implementation *
+     ******************************/
+
+    template <class S>
+    struct ptr_closure
+    {
+        using underlying_type = std::conditional_t<std::is_const<std::remove_reference_t<S>>::value,
+                                                   const std::decay_t<S>,
+                                                   std::decay_t<S>>;
+        using type = std::conditional_t<std::is_lvalue_reference<S>::value,
+                                        underlying_type*,
+                                        underlying_type>;
+    };
+
+    template <class S>
+    using ptr_closure_t = typename ptr_closure<S>::type;
+
+    template <class S>
+    struct const_ptr_closure
+    {
+        using underlying_type = const std::decay_t<S>;
+        using type = std::conditional_t<std::is_lvalue_reference<S>::value,
+                                        underlying_type*,
+                                        underlying_type>;
+    };
+
+    template <class S>
+    using const_ptr_closure_t = typename const_ptr_closure<S>::type;
+
+    /***************************
+     * apply_cv implementation *
+     ***************************/
+
+    namespace detail
+    {
+        template <class T, class U, bool = std::is_const<std::remove_reference_t<T>>::value,
+                  bool = std::is_volatile<std::remove_reference_t<T>>::value>
+        struct apply_cv_impl
+        {
+            using type = U;
+        };
+
+        template <class T, class U>
+        struct apply_cv_impl<T, U, true, false>
+        {
+            using type = const U;
+        };
+
+        template <class T, class U>
+        struct apply_cv_impl<T, U, false, true>
+        {
+            using type = volatile U;
+        };
+
+        template <class T, class U>
+        struct apply_cv_impl<T, U, true, true>
+        {
+            using type = const volatile U;
+        };
+
+        template <class T, class U>
+        struct apply_cv_impl<T&, U, false, false>
+        {
+            using type = U&;
+        };
+
+        template <class T, class U>
+        struct apply_cv_impl<T&, U, true, false>
+        {
+            using type = const U&;
+        };
+
+        template <class T, class U>
+        struct apply_cv_impl<T&, U, false, true>
+        {
+            using type = volatile U&;
+        };
+
+        template <class T, class U>
+        struct apply_cv_impl<T&, U, true, true>
+        {
+            using type = const volatile U&;
+        };
+    }
+
+    template <class T, class U>
+    struct apply_cv
+    {
+        using type = typename detail::apply_cv_impl<T, U>::type;
+    };
+
+    template <class T, class U>
+    using apply_cv_t = typename apply_cv<T, U>::type;
+
+    /*****************************
+     * is_complex implementation *
+     *****************************/
+
+    namespace detail
+    {
+        template <typename T>
+        struct is_complex : public std::false_type
+        {
+        };
+
+        template <typename T>
+        struct is_complex<std::complex<T>> : public std::true_type
+        {
+        };
+    }
+
+    template <class T>
+    struct is_complex
+    {
+        static constexpr bool value = detail::is_complex<std::decay_t<T>>::value;
+    };
+
+    /*************************************
+     * complex_value_type implementation *
+     *************************************/
+
+    template <typename T>
+    struct complex_value_type
+    {
+        using type = T;
+    };
+
+    template <typename T>
+    struct complex_value_type<std::complex<T>>
+    {
+        using type = T;
+    };
+
+    template <class T>
+    using complex_value_type_t = typename complex_value_type<T>::type;
+
+    /*********************************
+     * forward_offset implementation *
+     *********************************/
+
+    namespace detail
+    {
+
+        template <class T, class M>
+        struct forward_type
+        {
+            using type = apply_cv_t<T, M>&&;
+        };
+
+        template <class T, class M>
+        struct forward_type<T&, M>
+        {
+            using type = apply_cv_t<T, M>&;
+        };
+
+        template <class T, class M>
+        using forward_type_t = typename forward_type<T, M>::type;
+    }
+
+    template <class M, std::size_t I, class T>
+    constexpr detail::forward_type_t<T, M> forward_offset(T&& v) noexcept
+    {
+        using forward_type = detail::forward_type_t<T, M>;
+        using cv_value_type = std::remove_reference_t<forward_type>;
+        using byte_type = apply_cv_t<std::remove_reference_t<T>, char>;
+
+        return static_cast<forward_type>(
+            *reinterpret_cast<cv_value_type*>(
+                reinterpret_cast<byte_type*>(&v) + I
+            )
+        );
+    }
+
+    /**********************************************
+     * forward_real & forward_imag implementation *
+     **********************************************/
+
+    // forward_real
+
+    template <class T>
+    auto forward_real(T&& v)
+        -> std::enable_if_t<!is_complex<T>::value, detail::forward_type_t<T, T>>  // real case -> forward
+    {
+        return static_cast<detail::forward_type_t<T, T>>(v);
+    }
+
+    template <class T>
+    auto forward_real(T&& v)
+        -> std::enable_if_t<is_complex<T>::value, detail::forward_type_t<T, typename std::decay_t<T>::value_type>>  // complex case -> forward the real part
+    {
+        return forward_offset<typename std::decay_t<T>::value_type, 0>(v);
+    }
+
+    // forward_imag
+
+    template <class T>
+    auto forward_imag(T &&)
+        -> std::enable_if_t<!is_complex<T>::value, std::decay_t<T>>  // real case -> always return 0 by value
+    {
+        return 0;
+    }
+
+    template <class T>
+    auto forward_imag(T&& v)
+        -> std::enable_if_t<is_complex<T>::value, detail::forward_type_t<T, typename std::decay_t<T>::value_type>>  // complex case -> forwards the imaginary part
+    {
+        using real_type = typename std::decay_t<T>::value_type;
+        return forward_offset<real_type, sizeof(real_type)>(v);
+    }
+
+    /**************************
+    * to_array implementation *
+    ***************************/
+
+    namespace detail
+    {
+        template <class T, std::size_t N, std::size_t... I>
+        constexpr std::array<std::remove_cv_t<T>, N> to_array_impl(T (&a)[N], std::index_sequence<I...>)
+        {
+            return {{a[I]...}};
+        }
+    }
+
+    template <class T, std::size_t N>
+    constexpr std::array<std::remove_cv_t<T>, N> to_array(T (&a)[N])
+    {
+        return detail::to_array_impl(a, std::make_index_sequence<N>{});
+    }
+
+    /*********************************
+     * container_size implementation *
+     *********************************/
+
+    // equivalent to std::size(c) in c++17
+    template <class C>
+    constexpr auto container_size(const C& c) -> decltype(c.size())
+    {
+        return c.size();
+    }
+
+    // equivalent to std::size(a) in c++17
+    template <class T, std::size_t N>
+    constexpr std::size_t container_size(const T (&)[N])
+    {
+        return N;
+    }
+
+    /*****************************************
+     * has_raw_data_interface implementation *
+     *****************************************/
+
+    template <typename T>
+    class has_raw_data_interface
+    {
+        template <typename C>
+        static std::true_type test(decltype(std::declval<C>().raw_data_offset()));
+
+        template <typename C>
+        static std::false_type test(...);
+
+    public:
+        constexpr static bool value = decltype(test<T>(std::size_t(0)))::value == true;
+    };
+}
+
+#endif

--- a/inst/include/xtensor/xvectorize.hpp
+++ b/inst/include/xtensor/xvectorize.hpp
@@ -1,0 +1,96 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XVECTORIZE_HPP
+#define XVECTORIZE_HPP
+
+#include <type_traits>
+#include <utility>
+
+#include "xutils.hpp"
+
+namespace xt
+{
+
+    /***************
+     * xvectorizer *
+     ***************/
+
+    template <class F, class R>
+    class xvectorizer
+    {
+
+    public:
+
+        template <class... E>
+        using xfunction_type = xfunction<F, R, xclosure_t<E>...>;
+
+        template <class Func, class = std::enable_if_t<!std::is_same<std::decay_t<Func>, xvectorizer>::value>>
+        xvectorizer(Func&& f);
+
+        template <class... E>
+        xfunction_type<E...> operator()(E&&... e) const;
+
+    private:
+
+        typename std::remove_reference<F>::type m_f;
+    };
+
+    namespace detail
+    {
+        template <class F>
+        using get_function_type = remove_class_t<decltype(&std::remove_reference_t<F>::operator())>;
+    }
+
+    template <class R, class... Args>
+    xvectorizer<R (*)(Args...), R> vectorize(R (*f)(Args...));
+
+    template <class F, class R, class... Args>
+    xvectorizer<F, R> vectorize(F&& f, R (*)(Args...));
+
+    template <class F>
+    auto vectorize(F&& f) -> decltype(vectorize(std::forward<F>(f), (detail::get_function_type<F>*)nullptr));
+
+    /******************************
+     * xvectorizer implementation *
+     ******************************/
+
+    template <class F, class R>
+    template <class Func, class>
+    inline xvectorizer<F, R>::xvectorizer(Func&& f)
+        : m_f(std::forward<Func>(f))
+    {
+    }
+
+    template <class F, class R>
+    template <class... E>
+    inline auto xvectorizer<F, R>::operator()(E&&... e) const -> xfunction_type<E...>
+    {
+        return xfunction_type<E...>(m_f, std::forward<E>(e)...);
+    }
+
+    template <class R, class... Args>
+    inline xvectorizer<R (*)(Args...), R> vectorize(R (*f)(Args...))
+    {
+        return xvectorizer<R (*)(Args...), R>(f);
+    }
+
+    template <class F, class R, class... Args>
+    inline xvectorizer<F, R> vectorize(F&& f, R (*)(Args...))
+    {
+        return xvectorizer<F, R>(std::forward<F>(f));
+    }
+
+    template <class F>
+    inline auto vectorize(F&& f) -> decltype(vectorize(std::forward<F>(f), (detail::get_function_type<F>*)nullptr))
+    {
+        return vectorize(std::forward<F>(f), (detail::get_function_type<F>*)nullptr);
+    }
+}
+
+#endif

--- a/inst/include/xtensor/xview.hpp
+++ b/inst/include/xtensor/xview.hpp
@@ -1,0 +1,940 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XVIEW_HPP
+#define XVIEW_HPP
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+#include "xbroadcast.hpp"
+#include "xcontainer.hpp"
+#include "xiterable.hpp"
+#include "xsemantic.hpp"
+#include "xtensor_forward.hpp"
+#include "xview_utils.hpp"
+
+namespace xt
+{
+
+    /*********************
+     * xview declaration *
+     *********************/
+
+    template <class CT, class... S>
+    struct xcontainer_inner_types<xview<CT, S...>>
+    {
+        using xexpression_type = std::decay_t<CT>;
+        using temporary_type = view_temporary_type_t<xexpression_type, S...>;
+    };
+
+    template <bool is_const, class CT, class... S>
+    class xview_stepper;
+
+    template <class ST, class... S>
+    struct xview_shape_type;
+
+    template <class CT, class... S>
+    struct xiterable_inner_types<xview<CT, S...>>
+    {
+        using xexpression_type = std::decay_t<CT>;
+        using inner_shape_type = typename xview_shape_type<typename xexpression_type::shape_type, S...>::type;
+        using stepper = xview_stepper<false, CT, S...>;
+        using const_stepper = xview_stepper<true, CT, S...>;
+        using iterator = xiterator<stepper, inner_shape_type*, DEFAULT_LAYOUT>;
+        using const_iterator = xiterator<const_stepper, inner_shape_type*, DEFAULT_LAYOUT>;
+        using reverse_iterator = std::reverse_iterator<iterator>;
+        using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+    };
+
+    /**
+     * @class xview
+     * @brief Multidimensional view with tensor semantic.
+     *
+     * The xview class implements a multidimensional view with tensor
+     * semantic. It is used to adapt the shape of an xexpression without
+     * changing it. xview is not meant to be used directly, but
+     * only with the \ref view helper functions.
+     *
+     * @tparam CT the closure type of the \ref xexpression to adapt
+     * @tparam S the slices type describing the shape adaptation
+     *
+     * @sa view, range, all, newaxis
+     */
+    template <class CT, class... S>
+    class xview : public xview_semantic<xview<CT, S...>>,
+                  public xexpression_iterable<xview<CT, S...>>
+    {
+
+    public:
+
+        using self_type = xview<CT, S...>;
+        using xexpression_type = std::decay_t<CT>;
+        using semantic_base = xview_semantic<self_type>;
+
+        using value_type = typename xexpression_type::value_type;
+        using reference = typename xexpression_type::reference;
+        using const_reference = typename xexpression_type::const_reference;
+        using pointer = typename xexpression_type::pointer;
+        using const_pointer = typename xexpression_type::const_pointer;
+        using size_type = typename xexpression_type::size_type;
+        using difference_type = typename xexpression_type::difference_type;
+
+        using iterable_base = xexpression_iterable<self_type>;
+        using inner_shape_type = typename iterable_base::inner_shape_type;
+        using shape_type = inner_shape_type;
+        using strides_type = shape_type;
+
+        using slice_type = std::tuple<S...>;
+
+        using stepper = typename iterable_base::stepper;
+        using const_stepper = typename iterable_base::const_stepper;
+
+        static constexpr layout_type static_layout = layout_type::dynamic;
+        static constexpr bool contiguous_layout = false;
+
+        template <class CTA, class... SL>
+        explicit xview(CTA&& e, SL&&... slices) noexcept;
+
+        template <class E>
+        self_type& operator=(const xexpression<E>& e);
+
+        template <class E>
+        disable_xexpression<E, self_type>& operator=(const E& e);
+
+        size_type dimension() const noexcept;
+
+        size_type size() const noexcept;
+        const inner_shape_type& shape() const noexcept;
+        const slice_type& slices() const noexcept;
+        layout_type layout() const noexcept;
+
+        template <class... Args>
+        reference operator()(Args... args);
+        reference operator[](const xindex& index);
+        reference operator[](size_type i);
+        template <class It>
+        reference element(It first, It last);
+
+        template <class... Args>
+        const_reference operator()(Args... args) const;
+        const_reference operator[](const xindex& index) const;
+        const_reference operator[](size_type i) const;
+        template <class It>
+        const_reference element(It first, It last) const;
+
+        template <class ST>
+        bool broadcast_shape(ST& shape) const;
+
+        template <class ST>
+        bool is_trivial_broadcast(const ST& strides) const;
+
+        template <class ST>
+        stepper stepper_begin(const ST& shape);
+        template <class ST>
+        stepper stepper_end(const ST& shape);
+
+        template <class ST>
+        const_stepper stepper_begin(const ST& shape) const;
+        template <class ST>
+        const_stepper stepper_end(const ST& shape) const;
+
+        template <class T = xexpression_type>
+        std::enable_if_t<has_raw_data_interface<T>::value, const typename T::container_type&>
+        data() const;
+
+        template <class T = xexpression_type>
+        std::enable_if_t<has_raw_data_interface<T>::value, const typename T::strides_type>
+        strides() const;
+
+        template <class T = xexpression_type>
+        std::enable_if_t<has_raw_data_interface<T>::value, const value_type*>
+        raw_data() const;
+
+        template <class T = xexpression_type>
+        std::enable_if_t<has_raw_data_interface<T>::value, value_type*>
+        raw_data();
+
+        template <class T = xexpression_type>
+        std::enable_if_t<has_raw_data_interface<T>::value, const std::size_t>
+        raw_data_offset() const noexcept;
+
+        size_type underlying_size(size_type dim) const;
+
+    private:
+
+        // VS 2015 workaround (yes, really)
+        template <std::size_t I>
+        struct lesser_condition
+        {
+            static constexpr bool value = (I + newaxis_count_before<S...>(I + 1) < sizeof...(S));
+        };
+
+        CT m_e;
+        slice_type m_slices;
+        inner_shape_type m_shape;
+
+        template <typename std::decay_t<CT>::size_type... I, class... Args>
+        reference access_impl(std::index_sequence<I...>, Args... args);
+
+        template <typename std::decay_t<CT>::size_type... I, class... Args>
+        const_reference access_impl(std::index_sequence<I...>, Args... args) const;
+
+        template <typename std::decay_t<CT>::size_type I, class... Args>
+        std::enable_if_t<lesser_condition<I>::value, size_type> index(Args... args) const;
+
+        template <typename std::decay_t<CT>::size_type I, class... Args>
+        std::enable_if_t<!lesser_condition<I>::value, size_type> index(Args... args) const;
+
+        template <typename std::decay_t<CT>::size_type, class T>
+        size_type sliced_access(const xslice<T>& slice) const;
+
+        template <typename std::decay_t<CT>::size_type I, class T, class Arg, class... Args>
+        size_type sliced_access(const xslice<T>& slice, Arg arg, Args... args) const;
+
+        template <typename std::decay_t<CT>::size_type I, class T, class... Args>
+        disable_xslice<T, size_type> sliced_access(const T& squeeze, Args...) const;
+
+        using temporary_type = typename xcontainer_inner_types<self_type>::temporary_type;
+        using base_index_type = xindex_type_t<shape_type>;
+
+        template <class It>
+        base_index_type make_index(It first, It last) const;
+
+        void assign_temporary_impl(temporary_type& tmp);
+
+        friend class xview_semantic<xview<CT, S...>>;
+    };
+
+    template <class E, class... S>
+    auto view(E&& e, S&&... slices);
+
+    /*****************************
+     * xview_stepper declaration *
+     *****************************/
+
+    namespace detail
+    {
+        template <class V>
+        struct get_stepper_impl
+        {
+            using xexpression_type = typename V::xexpression_type;
+            using type = typename xexpression_type::stepper;
+        };
+
+        template <class V>
+        struct get_stepper_impl<const V>
+        {
+            using xexpression_type = typename V::xexpression_type;
+            using type = typename xexpression_type::const_stepper;
+        };
+    }
+
+    template <class V>
+    using get_stepper = typename detail::get_stepper_impl<V>::type;
+
+    template <bool is_const, class CT, class... S>
+    class xview_stepper
+    {
+
+    public:
+
+        using view_type = std::conditional_t<is_const,
+                                             const xview<CT, S...>,
+                                             xview<CT, S...>>;
+        using substepper_type = get_stepper<view_type>;
+
+        using value_type = typename substepper_type::value_type;
+        using reference = typename substepper_type::reference;
+        using pointer = typename substepper_type::pointer;
+        using difference_type = typename substepper_type::difference_type;
+        using size_type = typename view_type::size_type;
+
+        using shape_type = typename substepper_type::shape_type;
+
+        xview_stepper() = default;
+        xview_stepper(view_type* view, substepper_type it,
+                      size_type offset, bool end = false);
+
+        reference operator*() const;
+
+        void step(size_type dim, size_type n = 1);
+        void step_back(size_type dim, size_type n = 1);
+        void reset(size_type dim);
+        void reset_back(size_type dim);
+
+        void to_begin();
+        void to_end();
+
+        bool equal(const xview_stepper& rhs) const;
+
+    private:
+
+        bool is_newaxis_slice(size_type index) const noexcept;
+        void to_end_impl();
+
+        template <class F>
+        void common_step(size_type dim, size_type n, F f);
+
+        template <class F>
+        void common_reset(size_type dim, F f);
+
+        view_type* p_view;
+        substepper_type m_it;
+        size_type m_offset;
+    };
+
+    template <bool is_const, class CT, class... S>
+    bool operator==(const xview_stepper<is_const, CT, S...>& lhs,
+                    const xview_stepper<is_const, CT, S...>& rhs);
+
+    template <bool is_const, class CT, class... S>
+    bool operator!=(const xview_stepper<is_const, CT, S...>& lhs,
+                    const xview_stepper<is_const, CT, S...>& rhs);
+
+
+    // meta-function returning the shape type for an xview
+    template <class ST, class... S>
+    struct xview_shape_type
+    {
+        using type = ST;
+    };
+
+    template <class I, std::size_t L, class... S>
+    struct xview_shape_type<std::array<I, L>, S...>
+    {
+        using type = std::array<I, L - integral_count<S...>() + newaxis_count<S...>()>;
+    };
+
+    /************************
+     * xview implementation *
+     ************************/
+
+    /**
+     * @name Constructor
+     */
+    //@{
+    /**
+     * Constructs a view on the specified xexpression.
+     * Users should not call directly this constructor but
+     * use the view function instead.
+     * @param e the xexpression to adapt
+     * @param slices the slices list describing the view
+     * @sa view
+     */
+    template <class CT, class... S>
+    template <class CTA, class... SL>
+    inline xview<CT, S...>::xview(CTA&& e, SL&&... slices) noexcept
+        : m_e(std::forward<CTA>(e)), m_slices(std::forward<SL>(slices)...),
+          m_shape(make_sequence<shape_type>(m_e.dimension() - integral_count<S...>() + newaxis_count<S...>(), 0))
+    {
+        auto func = [](const auto& s) noexcept { return get_size(s); };
+        for (size_type i = 0; i != dimension(); ++i)
+        {
+            size_type index = integral_skip<S...>(i);
+            m_shape[i] = index < sizeof...(S) ?
+                apply<std::size_t>(index, func, m_slices) : m_e.shape()[index - newaxis_count_before<S...>(index)];
+        }
+    }
+    //@}
+
+    /**
+     * @name Extended copy semantic
+     */
+    //@{
+    /**
+     * The extended assignment operator.
+     */
+    template <class CT, class... S>
+    template <class E>
+    inline auto xview<CT, S...>::operator=(const xexpression<E>& e) -> self_type&
+    {
+        bool cond = (e.derived_cast().shape().size() == dimension()) &&
+                    std::equal(shape().begin(), shape().end(), e.derived_cast().shape().begin());
+        if (!cond)
+        {
+            semantic_base::operator=(broadcast(e.derived_cast(), shape()));
+        }
+        else
+        {
+            semantic_base::operator=(e);
+        }
+        return *this;
+    }
+    //@}
+
+    template <class CT, class... S>
+    template <class E>
+    inline auto xview<CT, S...>::operator=(const E& e) -> disable_xexpression<E, self_type>&
+    {
+        std::fill(this->begin(), this->end(), e);
+        return *this;
+    }
+
+    /**
+     * @name Size and shape
+     */
+    //@{
+    /**
+     * Returns the size of the expression.
+     */
+    template <class CT, class... S>
+    inline auto xview<CT, S...>::size() const noexcept -> size_type
+    {
+        return compute_size(shape());
+    }
+
+    /**
+     * Returns the number of dimensions of the view.
+     */
+    template <class CT, class... S>
+    inline auto xview<CT, S...>::dimension() const noexcept -> size_type
+    {
+        return m_shape.size();
+    }
+
+    /**
+     * Returns the shape of the view.
+     */
+    template <class CT, class... S>
+    inline auto xview<CT, S...>::shape() const noexcept -> const inner_shape_type&
+    {
+        return m_shape;
+    }
+
+    /**
+     * Returns the slices of the view.
+     */
+    template <class CT, class... S>
+    inline auto xview<CT, S...>::slices() const noexcept -> const slice_type&
+    {
+        return m_slices;
+    }
+        
+    /**
+     * Returns the slices of the view.
+     */
+    template <class CT, class... S>
+    inline layout_type xview<CT, S...>::layout() const noexcept
+    {
+        return static_layout;
+    }
+    //@}
+
+    /**
+     * @name Data
+     */
+    //@{
+    /**
+     * Returns a reference to the element at the specified position in the view.
+     * @param args a list of indices specifying the position in the view. Indices
+     * must be unsigned integers, the number of indices should be equal or greater
+     * than the number of dimensions of the view.
+     */
+    template <class CT, class... S>
+    template <class... Args>
+    inline auto xview<CT, S...>::operator()(Args... args) -> reference
+    {
+        return access_impl(std::make_index_sequence<(sizeof...(Args) + integral_count<S...>() > newaxis_count<S...>() ?
+                                                        sizeof...(Args) + integral_count<S...>() - newaxis_count<S...>() :
+                                                        0)>(),
+                           args...);
+    }
+
+    template <class CT, class... S>
+    inline auto xview<CT, S...>::operator[](const xindex& index) -> reference
+    {
+        return element(index.cbegin(), index.cend());
+    }
+
+    template <class CT, class... S>
+    inline auto xview<CT, S...>::operator[](size_type i) -> reference
+    {
+        return operator()(i);
+    }
+
+    template <class CT, class... S>
+    template <class It>
+    inline auto xview<CT, S...>::element(It first, It last) -> reference
+    {
+        auto index = make_index(first, last);
+        return m_e.element(index.cbegin(), index.cend());
+    }
+
+    /**
+     * Returns a constant reference to the element at the specified position in the view.
+     * @param args a list of indices specifying the position in the view. Indices must be
+     * unsigned integers, the number of indices should be equal or greater than the number
+     * of dimensions of the view.
+     */
+    template <class CT, class... S>
+    template <class... Args>
+    inline auto xview<CT, S...>::operator()(Args... args) const -> const_reference
+    {
+        return access_impl(std::make_index_sequence<(sizeof...(Args) + integral_count<S...>() > newaxis_count<S...>() ?
+                                                        sizeof...(Args) + integral_count<S...>() - newaxis_count<S...>() :
+                                                        0)>(),
+                           args...);
+    }
+
+    template <class CT, class... S>
+    inline auto xview<CT, S...>::operator[](const xindex& index) const -> const_reference
+    {
+        return element(index.cbegin(), index.cend());
+    }
+
+    template <class CT, class... S>
+    inline auto xview<CT, S...>::operator[](size_type i) const -> const_reference
+    {
+        return operator()(i);
+    }
+
+    template <class CT, class... S>
+    template <class It>
+    inline auto xview<CT, S...>::element(It first, It last) const -> const_reference
+    {
+        auto index = make_index(first, last);
+        return m_e.element(index.cbegin(), index.cend());
+    }
+
+    /**
+     * Returns the data holder of the underlying container (only if the view is on a realized
+     * container). ``xt::eval`` will make sure that the underlying xexpression is
+     * on a realized container.
+     */
+    template <class CT, class... S>
+    template <class T>
+    inline auto xview<CT, S...>::data() const ->
+        std::enable_if_t<has_raw_data_interface<T>::value, const typename T::container_type&>
+    {
+        return m_e.data();
+    }
+
+    /**
+     * Return the strides for the underlying container of the view.
+     */
+    template <class CT, class... S>
+    template <class T>
+    inline auto xview<CT, S...>::strides() const ->
+        std::enable_if_t<has_raw_data_interface<T>::value, const typename T::strides_type>
+    {
+        using strides_type = typename T::strides_type;
+        strides_type temp = m_e.strides();
+        strides_type strides = make_sequence<strides_type>(m_e.dimension() - integral_count<S...>(), 0);
+
+        auto func = [](const auto& s) { return xt::step_size(s); };
+        size_type i = 0, idx;
+
+        for (; i < sizeof...(S); ++i) {
+            idx = integral_skip<S...>(i);
+            if (idx >= sizeof...(S))
+            {
+                break;
+            }
+            strides[i] = m_e.strides()[idx] * apply<size_type>(idx, func, m_slices);
+        }
+        for (; i < strides.size(); ++i) {
+            strides[i] = m_e.strides()[idx++];
+        }
+
+        return strides;
+    }
+
+    /**
+     * Return the pointer to the underlying buffer.
+     */
+    template <class CT, class... S>
+    template <class T>
+    inline auto xview<CT, S...>::raw_data() const ->
+        std::enable_if_t<has_raw_data_interface<T>::value, const value_type*>
+    {
+        return m_e.raw_data();
+    }
+
+    template <class CT, class... S>
+    template <class T>
+    inline auto xview<CT, S...>::raw_data() ->
+        std::enable_if_t<has_raw_data_interface<T>::value, value_type*>
+    {
+        return m_e.raw_data();
+    }
+
+    /**
+     * Return the offset to the first element of the view in the underlying container.
+     */
+    template <class CT, class... S>
+    template <class T>
+    inline auto xview<CT, S...>::raw_data_offset() const noexcept ->
+        std::enable_if_t<has_raw_data_interface<T>::value, const std::size_t>
+    {
+        auto func = [](const auto& s) { return xt::value(s, 0); };
+        typename T::size_type offset = m_e.raw_data_offset();
+
+        for (size_type i = 0; i < sizeof...(S); ++i)
+        {
+            size_type s = apply<size_type>(i, func, m_slices) * m_e.strides()[i];
+            offset += s;
+        }
+        return offset;
+    }
+    //@}
+
+    template <class CT, class... S>
+    inline auto xview<CT, S...>::underlying_size(size_type dim) const -> size_type
+    {
+        return m_e.shape()[dim];
+    }
+
+    /**
+     * @name Broadcasting
+     */
+    //@{
+    /**
+     * Broadcast the shape of the view to the specified parameter.
+     * @param shape the result shape
+     * @return a boolean indicating whether the broadcasting is trivial
+     */
+    template <class CT, class... S>
+    template <class ST>
+    inline bool xview<CT, S...>::broadcast_shape(ST& shape) const
+    {
+        return xt::broadcast_shape(m_shape, shape);
+    }
+
+    /**
+     * Compares the specified strides with those of the view to see whether
+     * the broadcasting is trivial.
+     * @return a boolean indicating whether the broadcasting is trivial
+     */
+    template <class CT, class... S>
+    template <class ST>
+    inline bool xview<CT, S...>::is_trivial_broadcast(const ST& /*strides*/) const
+    {
+        return false;
+    }
+    //@}
+
+    template <class CT, class... S>
+    template <typename std::decay_t<CT>::size_type... I, class... Args>
+    inline auto xview<CT, S...>::access_impl(std::index_sequence<I...>, Args... args) -> reference
+    {
+        return m_e(index<I>(args...)...);
+    }
+
+    template <class CT, class... S>
+    template <typename std::decay_t<CT>::size_type... I, class... Args>
+    inline auto xview<CT, S...>::access_impl(std::index_sequence<I...>, Args... args) const -> const_reference
+    {
+        return m_e(index<I>(args...)...);
+    }
+
+    template <class CT, class... S>
+    template <typename std::decay_t<CT>::size_type I, class... Args>
+    inline auto xview<CT, S...>::index(Args... args) const -> std::enable_if_t<lesser_condition<I>::value, size_type>
+    {
+        return sliced_access<I - integral_count_before<S...>(I) + newaxis_count_before<S...>(I + 1)>
+            (std::get<I + newaxis_count_before<S...>(I + 1)>(m_slices), args...);
+    }
+
+    template <class CT, class... S>
+    template <typename std::decay_t<CT>::size_type I, class... Args>
+    inline auto xview<CT, S...>::index(Args... args) const -> std::enable_if_t<!lesser_condition<I>::value, size_type>
+    {
+        return argument<I - integral_count<S...>() + newaxis_count<S...>()>(args...);
+    }
+
+    template <class CT, class... S>
+    template <typename std::decay_t<CT>::size_type I, class T>
+    inline auto xview<CT, S...>::sliced_access(const xslice<T>& slice) const -> size_type
+    {
+        return slice.derived_cast()(0);
+    }
+
+    template <class CT, class... S>
+    template <typename std::decay_t<CT>::size_type I, class T, class Arg, class... Args>
+    inline auto xview<CT, S...>::sliced_access(const xslice<T>& slice, Arg arg, Args... args) const -> size_type
+    {
+        return slice.derived_cast()(argument<I>(arg, args...));
+    }
+
+    template <class CT, class... S>
+    template <typename std::decay_t<CT>::size_type I, class T, class... Args>
+    inline auto xview<CT, S...>::sliced_access(const T& squeeze, Args...) const -> disable_xslice<T, size_type>
+    {
+        return squeeze;
+    }
+
+    template <class CT, class... S>
+    template <class It>
+    inline auto xview<CT, S...>::make_index(It first, It last) const -> base_index_type
+    {
+        auto index = make_sequence<typename xexpression_type::shape_type>(m_e.dimension(), 0);
+        auto func1 = [&first](const auto& s)
+        {
+            return get_slice_value(s, first);
+        };
+        auto func2 = [](const auto& s)
+        {
+            return xt::value(s, 0);
+        };
+        for (size_type i = 0; i != m_e.dimension(); ++i)
+        {
+            size_type k = newaxis_skip<S...>(i);
+            std::advance(first, k - i);
+            if (first != last)
+            {
+                index[i] = k < sizeof...(S) ?
+                    apply<size_type>(k, func1, m_slices) : *first++;
+            }
+            else
+            {
+                index[i] = k < sizeof...(S) ?
+                    apply<size_type>(k, func2, m_slices) : 0;
+            }
+        }
+        return index;
+    }
+
+    template <class CT, class... S>
+    inline void xview<CT, S...>::assign_temporary_impl(temporary_type& tmp)
+    {
+        std::copy(tmp.cbegin(), tmp.cend(), this->xbegin());
+    }
+
+    namespace detail
+    {
+        template <class E, class... S>
+        inline std::size_t get_underlying_shape_index(std::size_t I)
+        {
+            return I - newaxis_count_before<get_slice_type<E, S>...>(I);
+        }
+
+        template <class E, std::size_t... I, class... S>
+        inline auto make_view_impl(E&& e, std::index_sequence<I...>, S&&... slices)
+        {
+            using view_type = xview<closure_t<E>, get_slice_type<std::decay_t<E>, S>...>;
+            return view_type(std::forward<E>(e),
+                get_slice_implementation(e, std::forward<S>(slices), get_underlying_shape_index<std::decay_t<E>, S...>(I))...
+            );
+        }
+    }
+
+    /**
+     * Constructs and returns a view on the specified xexpression. Users
+     * should not directly construct the slices but call helper functions
+     * instead.
+     * @param e the xexpression to adapt
+     * @param slices the slices list describing the view
+     * @sa range, all, newaxis
+     */
+    template <class E, class... S>
+    inline auto view(E&& e, S&&... slices)
+    {
+        return detail::make_view_impl(std::forward<E>(e), std::make_index_sequence<sizeof...(S)>(), std::forward<S>(slices)...);
+    }
+
+    /***************
+     * stepper api *
+     ***************/
+
+    template <class CT, class... S>
+    template <class ST>
+    inline auto xview<CT, S...>::stepper_begin(const ST& shape) -> stepper
+    {
+        size_type offset = shape.size() - dimension();
+        return stepper(this, m_e.stepper_begin(m_e.shape()), offset);
+    }
+
+    template <class CT, class... S>
+    template <class ST>
+    inline auto xview<CT, S...>::stepper_end(const ST& shape) -> stepper
+    {
+        size_type offset = shape.size() - dimension();
+        return stepper(this, m_e.stepper_end(m_e.shape()), offset, true);
+    }
+
+    template <class CT, class... S>
+    template <class ST>
+    inline auto xview<CT, S...>::stepper_begin(const ST& shape) const -> const_stepper
+    {
+        size_type offset = shape.size() - dimension();
+        const xexpression_type& e = m_e;
+        return const_stepper(this, e.stepper_begin(m_e.shape()), offset);
+    }
+
+    template <class CT, class... S>
+    template <class ST>
+    inline auto xview<CT, S...>::stepper_end(const ST& shape) const -> const_stepper
+    {
+        size_type offset = shape.size() - dimension();
+        const xexpression_type& e = m_e;
+        return const_stepper(this, e.stepper_end(m_e.shape()), offset, true);
+    }
+
+    /********************************
+     * xview_stepper implementation *
+     ********************************/
+
+    template <bool is_const, class CT, class... S>
+    inline xview_stepper<is_const, CT, S...>::xview_stepper(view_type* view, substepper_type it,
+                                                            size_type offset, bool end)
+        : p_view(view), m_it(it), m_offset(offset)
+    {
+        if (!end)
+        {
+            auto func = [](const auto& s) { return xt::value(s, 0); };
+            for (size_type i = 0; i < sizeof...(S); ++i)
+            {
+                if (!is_newaxis_slice(i))
+                {
+                    size_type s = apply<size_type>(i, func, p_view->slices());
+                    size_type index = i - newaxis_count_before<S...>(i);
+                    m_it.step(index, s);
+                }
+            }
+        }
+        else
+        {
+            to_end_impl();
+        }
+    }
+
+    template <bool is_const, class CT, class... S>
+    inline auto xview_stepper<is_const, CT, S...>::operator*() const -> reference
+    {
+        return *m_it;
+    }
+
+    template <bool is_const, class CT, class... S>
+    inline void xview_stepper<is_const, CT, S...>::step(size_type dim, size_type n)
+    {
+        auto func = [this](size_type index, size_type offset) { m_it.step(index, offset); };
+        common_step(dim, n, func);
+    }
+
+    template <bool is_const, class CT, class... S>
+    inline void xview_stepper<is_const, CT, S...>::step_back(size_type dim, size_type n)
+    {
+        auto func = [this](size_type index, size_type offset) { m_it.step_back(index, offset); };
+        common_step(dim, n, func);
+    }
+
+    template <bool is_const, class CT, class... S>
+    inline void xview_stepper<is_const, CT, S...>::reset(size_type dim)
+    {
+        auto func = [this](size_type index, size_type offset) { m_it.step_back(index, offset); };
+        common_reset(dim, func);
+    }
+
+    template <bool is_const, class CT, class... S>
+    inline void xview_stepper<is_const, CT, S...>::reset_back(size_type dim)
+    {
+        auto func = [this](size_type index, size_type offset) { m_it.step(index, offset); };
+        common_reset(dim, func);
+    }
+
+    template <bool is_const, class CT, class... S>
+    inline void xview_stepper<is_const, CT, S...>::to_begin()
+    {
+        m_it.to_begin();
+    }
+
+    template <bool is_const, class CT, class... S>
+    inline void xview_stepper<is_const, CT, S...>::to_end()
+    {
+        m_it.to_end();
+        to_end_impl();
+    }
+
+    template <bool is_const, class CT, class... S>
+    inline bool xview_stepper<is_const, CT, S...>::equal(const xview_stepper& rhs) const
+    {
+        return p_view == rhs.p_view && m_it == rhs.m_it && m_offset == rhs.m_offset;
+    }
+
+    template <bool is_const, class CT, class... S>
+    inline bool xview_stepper<is_const, CT, S...>::is_newaxis_slice(size_type index) const noexcept
+    {
+        // A bit tricky but avoids a lot of template instantiations
+        return newaxis_count_before<S...>(index + 1) != newaxis_count_before<S...>(index);
+    }
+
+    template <bool is_const, class CT, class... S>
+    inline void xview_stepper<is_const, CT, S...>::to_end_impl()
+    {
+        auto func = [](const auto& s) { return xt::value(s, get_size(s) - 1); };
+        for (size_type i = 0; i < sizeof...(S); ++i)
+        {
+            if (!is_newaxis_slice(i))
+            {
+                size_type s = apply<size_type>(i, func, p_view->slices());
+                size_type index = i - newaxis_count_before<S...>(i);
+                s = p_view->underlying_size(index) - 1 - s;
+                m_it.step_back(index, s);
+            }
+        }
+    }
+
+    template <bool is_const, class CT, class... S>
+    template <class F>
+    void xview_stepper<is_const, CT, S...>::common_step(size_type dim, size_type n, F f)
+    {
+        if (dim >= m_offset)
+        {
+            auto func = [](const auto& s) noexcept { return step_size(s); };
+            size_type index = integral_skip<S...>(dim);
+            if (!is_newaxis_slice(index))
+            {
+                size_type step_size = index < sizeof...(S) ?
+                    apply<size_type>(index, func, p_view->slices()) : 1;
+                index -= newaxis_count_before<S...>(index);
+                f(index, step_size * n);
+            }
+        }
+    }
+
+    template <bool is_const, class CT, class... S>
+    template <class F>
+    void xview_stepper<is_const, CT, S...>::common_reset(size_type dim, F f)
+    {
+        auto size_func = [](const auto& s) noexcept { return get_size(s); };
+        auto step_func = [](const auto& s) noexcept { return step_size(s); };
+        size_type index = integral_skip<S...>(dim);
+        if (!is_newaxis_slice(index))
+        {
+            size_type size = index < sizeof...(S) ? apply<size_type>(index, size_func, p_view->slices()) : p_view->shape()[dim];
+            if (size != 0)
+            {
+                size = size - 1;
+            }
+            size_type step_size = index < sizeof...(S) ? apply<size_type>(index, step_func, p_view->slices()) : 1;
+            index -= newaxis_count_before<S...>(index);
+            f(index, step_size * size);
+        }
+    }
+
+    template <bool is_const, class CT, class... S>
+    inline bool operator==(const xview_stepper<is_const, CT, S...>& lhs,
+                           const xview_stepper<is_const, CT, S...>& rhs)
+    {
+        return lhs.equal(rhs);
+    }
+
+    template <bool is_const, class CT, class... S>
+    inline bool operator!=(const xview_stepper<is_const, CT, S...>& lhs,
+                           const xview_stepper<is_const, CT, S...>& rhs)
+    {
+        return !(lhs.equal(rhs));
+    }
+}
+
+#endif

--- a/inst/include/xtensor/xview_utils.hpp
+++ b/inst/include/xtensor/xview_utils.hpp
@@ -1,0 +1,274 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XVIEW_UTILS_HPP
+#define XVIEW_UTILS_HPP
+
+#include <array>
+
+#include "xslice.hpp"
+
+namespace xt
+{
+
+    /********************************
+    * helper functions declaration *
+    ********************************/
+
+    // number of integral types in the specified sequence of types
+    template <class... S>
+    constexpr std::size_t integral_count();
+
+    // number of integral types in the specified sequence of types before specified index
+    template <class... S>
+    constexpr std::size_t integral_count_before(std::size_t i);
+
+    // index in the specified sequence of types of the ith non-integral type
+    template <class... S>
+    constexpr std::size_t integral_skip(std::size_t i);
+
+    // number of newaxis types in the specified sequence of types
+    template <class... S>
+    constexpr std::size_t newaxis_count();
+
+    // number of newaxis types in the specified sequence of types before specified index
+    template <class... S>
+    constexpr std::size_t newaxis_count_before(std::size_t i);
+
+    // index in the specified sequence of types of the ith non-newaxis type
+    template <class... S>
+    constexpr std::size_t newaxis_skip(std::size_t i);
+
+    // return slice evaluation and increment iterator
+    template <class S, class It>
+    inline disable_xslice<S, std::size_t> get_slice_value(const S& s, It&) noexcept
+    {
+        return s;
+    };
+
+    template <class S, class It>
+    inline auto get_slice_value(const xslice<S>& slice, It& it) noexcept
+    {
+        return slice.derived_cast()(typename S::size_type(*it++));
+    };
+
+    /***********************
+     * view_temporary_type *
+     ***********************/
+
+    namespace detail
+    {
+        template <class T, class S, layout_type L, class... SL>
+        struct view_temporary_type_impl
+        {
+            using type = xarray<T, L>;
+        };
+
+        template <class T, class I, std::size_t N, layout_type L, class... SL>
+        struct view_temporary_type_impl<T, std::array<I, N>, L, SL...>
+        {
+            using type = xtensor<T, N + newaxis_count<SL...>() - integral_count<SL...>(), L>;
+        };
+    }
+
+    template <class E, class... SL>
+    struct view_temporary_type
+    {
+        using type = typename detail::view_temporary_type_impl<typename E::value_type,
+                                                               typename E::shape_type,
+                                                               E::static_layout,
+                                                               SL...>::type;
+    };
+
+    template <class E, class... SL>
+    using view_temporary_type_t = typename view_temporary_type<E, SL...>::type;
+
+
+    /************************
+    * count integral types *
+    ************************/
+
+    namespace detail
+    {
+
+        template <class T, class... S>
+        struct integral_count_impl
+        {
+            static constexpr std::size_t count(std::size_t i) noexcept
+            {
+                return i ? (integral_count_impl<S...>::count(i - 1) + (std::is_integral<std::remove_reference_t<T>>::value ? 1 : 0)) : 0;
+            }
+        };
+
+        template <>
+        struct integral_count_impl<void>
+        {
+            static constexpr std::size_t count(std::size_t /*i*/) noexcept
+            {
+                return 0;
+            }
+        };
+    }
+
+    template <class... S>
+    constexpr std::size_t integral_count()
+    {
+        return detail::integral_count_impl<S..., void>::count(sizeof...(S));
+    }
+
+    template <class... S>
+    constexpr std::size_t integral_count_before(std::size_t i)
+    {
+        return detail::integral_count_impl<S..., void>::count(i);
+    }
+
+    /***********************
+    * count newaxis types *
+    ***********************/
+
+    namespace detail
+    {
+        template <class T>
+        struct is_newaxis : std::false_type
+        {
+        };
+
+        template <class T>
+        struct is_newaxis<xnewaxis<T>> : public std::true_type
+        {
+        };
+
+        template <class T, class... S>
+        struct newaxis_count_impl
+        {
+            static constexpr std::size_t count(std::size_t i) noexcept
+            {
+                return i ? (newaxis_count_impl<S...>::count(i - 1) + (is_newaxis<std::remove_reference_t<T>>::value ? 1 : 0)) : 0;
+            }
+        };
+
+        template <>
+        struct newaxis_count_impl<void>
+        {
+            static constexpr std::size_t count(std::size_t /*i*/) noexcept
+            {
+                return 0;
+            }
+        };
+    }
+
+    template <class... S>
+    constexpr std::size_t newaxis_count()
+    {
+        return detail::newaxis_count_impl<S..., void>::count(sizeof...(S));
+    }
+
+    template <class... S>
+    constexpr std::size_t newaxis_count_before(std::size_t i)
+    {
+        return detail::newaxis_count_impl<S..., void>::count(i);
+    }
+
+    /**********************************
+    * index of ith non-integral type *
+    **********************************/
+
+    namespace detail
+    {
+
+        template <class T, class... S>
+        struct integral_skip_impl
+        {
+            static constexpr std::size_t count(std::size_t i) noexcept
+            {
+                return i == 0 ? count_impl() : count_impl(i);
+            }
+
+        private:
+
+            static constexpr std::size_t count_impl(std::size_t i) noexcept
+            {
+                return 1 + (
+                    std::is_integral<std::remove_reference_t<T>>::value ?
+                    integral_skip_impl<S...>::count(i) :
+                    integral_skip_impl<S...>::count(i - 1)
+                    );
+            }
+
+            static constexpr std::size_t count_impl() noexcept
+            {
+                return std::is_integral<std::remove_reference_t<T>>::value ? 1 + integral_skip_impl<S...>::count(0) : 0;
+            }
+        };
+
+        template <>
+        struct integral_skip_impl<void>
+        {
+            static constexpr std::size_t count(std::size_t i) noexcept
+            {
+                return i;
+            }
+        };
+    }
+
+    template <class... S>
+    constexpr std::size_t integral_skip(std::size_t i)
+    {
+        return detail::integral_skip_impl<S..., void>::count(i);
+    }
+
+    /*********************************
+    * index of ith non-newaxis type *
+    *********************************/
+
+    namespace detail
+    {
+
+        template <class T, class... S>
+        struct newaxis_skip_impl
+        {
+            static constexpr std::size_t count(std::size_t i) noexcept
+            {
+                return i == 0 ? count_impl() : count_impl(i);
+            }
+
+        private:
+
+            static constexpr std::size_t count_impl(std::size_t i) noexcept
+            {
+                return 1 + (
+                    is_newaxis<std::remove_reference_t<T>>::value ?
+                    newaxis_skip_impl<S...>::count(i) :
+                    newaxis_skip_impl<S...>::count(i - 1)
+                    );
+            }
+
+            static constexpr std::size_t count_impl() noexcept
+            {
+                return is_newaxis<std::remove_reference_t<T>>::value ? 1 + newaxis_skip_impl<S...>::count(0) : 0;
+            }
+        };
+
+        template <>
+        struct newaxis_skip_impl<void>
+        {
+            static constexpr std::size_t count(std::size_t i) noexcept
+            {
+                return i;
+            }
+        };
+    }
+
+    template <class... S>
+    constexpr std::size_t newaxis_skip(std::size_t i)
+    {
+        return detail::newaxis_skip_impl<S..., void>::count(i);
+    }
+}
+
+#endif


### PR DESCRIPTION
taken from xtensor repo at release 0.10.3 and commit 504da95

including headers has the advantage of 
  - making the package self-sufficient, ie can now build on Travis
  - able to provide headers for other packages, see eg [BH](https://cran.r-project.org/package=BH), [AsioHeaders](https://cran.r-project.org/package=AsioHeaders) and more

possible downside of a diff to xtensor itself easy to manage to same team behind both