### PR TITLE
add a dim attribute if none found

### DIFF
--- a/inst/include/xtensor-r/rxarray.hpp
+++ b/inst/include/xtensor-r/rxarray.hpp
@@ -138,6 +138,11 @@ namespace xt
     rxarray<T>::rxarray(SEXP exp, bool owned)
         : m_sexp(exp), m_owned(owned)
     {
+        // if dims attributes does not exist, set it to length of object
+        if (Rf_isNull(Rf_getAttrib(m_sexp, R_DimSymbol))) {
+            Rcpp::IntegerVector d = Rcpp::IntegerVector::create(Rf_length(m_sexp));
+            Rf_setAttrib(m_sexp, R_DimSymbol, d);
+        }
         m_shape = inner_shape_type(Rf_getAttrib(m_sexp, R_DimSymbol));
 
         resize_container(m_strides, base_type::dimension());


### PR DESCRIPTION
Consider a simple example taking an `int` vector:

```c++
// [[Rcpp::export]]
xt::rxarray<int> ex3(xt::rxarray<int> a) {
    a(0, 0) = 42;
    return a;
}
```

Without the change, we get an error on simple vectors:

```r
R> library(xtensorExamples)
R> ex3( 1:3 )     # class(1:3) is integer
Error in ex3(1:3) : 
  Not compatible with requested type: [type=NULL; target=integer].
R> 
R> ex3( array(1:3) )     # works for array() type 
[1] 42  2  3
R> 
```

The fix is pretty simple and in the PR -- if no `dim` attribute is present, set one:

```r
R> library(xtensorExamples)
R> ex3( 1:3 )     # class(1:3) is integer
[1] 42  2  3
R> 
```
