### PR TITLE
Check cran tarball

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: cpp
+dist: trusty
 matrix:
   include:
     - os: linux
@@ -78,7 +79,12 @@ before_install:
       elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         export CXX=clang++ CC=clang PYTHONHOME=$HOME/miniconda;
       fi
-    
+
+before_install:
+    - sudo apt-get install -y gcc-6 g++-6
+    - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 60 --slave /usr/bin/g++ g++ /usr/bin/g++-6
+    - sudo apt-get install -y texlive-latex-base texlive-latex-recommended texinfo texlive-fonts-extra texlive-fonts-recommended
+ 
 install:
     # Define the version of miniconda to download
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
@@ -105,11 +111,15 @@ install:
     - cd build
     - cmake -D XTENSOR_INSTALL_R_PACKAGES=OFF -D BUILD_TESTS=ON -D CMAKE_INSTALL_PREFIX=$HOME/miniconda ..
     - make cran
-    #- R CMD check --as-cran ./xtensor_*.tar.gz
     - make -j2 test_xtensor_r
     - make install
-    - cd test
 
 script:
+    - cd test
     - ./test_xtensor_r
-
+    - cd ..
+    - R CMD check --as-cran ./xtensor_*.tar.gz || ( 
+       cat /home/travis/build/QuantStack/xtensor-r/build/xtensor.Rcheck/00install.out &&
+       cat /home/travis/build/QuantStack/xtensor-r/build/xtensor.Rcheck/00check.log   &&
+       cat /home/travis/build/QuantStack/xtensor-r/build/xtensor.Rcheck/Rdlatex.log
+      )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,8 +46,9 @@ if(DOWNLOAD_GTEST OR GTEST_SRC_DIR)
     set(BUILD_TESTS ON)
 endif()
 
+find_package(R REQUIRED)
+
 if(BUILD_TESTS)
-    find_package(R REQUIRED)
     find_package(xtensor REQUIRED)
     include_directories(${xtensor_INCLUDE_DIRS})
     include_directories(${XTENSOR_R_INCLUDE_DIR})
@@ -142,6 +143,8 @@ set_target_properties(xtensor-r PROPERTIES EXCLUDE_FROM_ALL TRUE)
 add_custom_target(cran DEPENDS xtensor xtensor-r)
 
 OPTION(XTENSOR_INSTALL_R_PACKAGES "Install Rcpp and devtools from CRAN" ON)
+
+message(STATUS "R command" ${R_COMMAND})
 
 if (XTENSOR_INSTALL_R_PACKAGES)
     # Install Rcpp and devtools


### PR DESCRIPTION
Fixes #16 

**1) When using conda's R build**

Running

```bash
make cran
R CMD check --as-cran ./xtensor_*.tar.gz
```

on TravisCI yields 

```
Installation failed.
See ‘/home/travis/build/QuantStack/xtensor-r/build/xtensor.Rcheck/00install.out’ for details.
* DONE
Status: 1 ERROR, 1 NOTE
```

The log files says:

```
* installing *source* package ‘xtensor’ ...
** libs
g++ -I/home/travis/miniconda/lib/R/include -DNDEBUG  -I/home/travis/miniconda/include -I"/home/travis/miniconda/lib/R/library/Rcpp/include"  -I../inst/include --std=c++14 -fpic  -I/home/travis/miniconda/include  -c RcppExports.cpp -o RcppExports.o
g++: error: unrecognized option ‘--std=c++14’
make: *** [RcppExports.o] Error 1
ERROR: compilation failed for package ‘xtensor’
* removing ‘/home/travis/build/QuantStack/xtensor-r/build/xtensor.Rcheck/xtensor’
```

However, we set `GCC=5`, and other build tasks in travis seem to work fine.

From https://stackoverflow.com/questions/1616983/building-r-packages-using-alternate-gcc, it seems that R makes use of its own set version of gcc.

**2) When using travis's build for R**

See http://dirk.eddelbuettel.com/blog/2017/06/13/