### PR TITLE
R logical support. Closes #62

### DIFF
--- a/include/xtensor-r/rarray.hpp
+++ b/include/xtensor-r/rarray.hpp
@@ -24,14 +24,15 @@
 
 namespace xt
 {
-
     template <class T>
     class rarray;
 
     template <class T>
     struct xcontainer_inner_types<rarray<T>>
     {
-        using storage_type = xbuffer_adaptor<T*>;
+        using r_type = T;
+        using underlying_type = r_detail::get_underlying_value_type_r<T>;
+        using storage_type = xbuffer_adaptor<typename underlying_type::type*>;
         constexpr static int SXP = Rcpp::traits::r_sexptype_traits<T>::rtype;
         using shape_type = xt::dynamic_shape<typename storage_type::size_type>;
         using strides_type = xt::dynamic_shape<typename storage_type::difference_type>;
@@ -63,6 +64,7 @@ namespace xt
 
         using inner_types = xcontainer_inner_types<self_type>;
 
+        using underlying_type = typename inner_types::underlying_type;
         using storage_type = typename inner_types::storage_type;
         using value_type = typename storage_type::value_type;
         using reference = typename storage_type::reference;

--- a/include/xtensor-r/rcontainer.hpp
+++ b/include/xtensor-r/rcontainer.hpp
@@ -37,10 +37,7 @@ namespace Rcpp
     {
         template<> struct r_sexptype_traits<rlogical>
         { 
-            enum
-            { 
-                rtype = LGLSXP 
-            }; 
+            static constexpr int rtype = LGLSXP;
         };
     }
 }

--- a/include/xtensor-r/rcontainer.hpp
+++ b/include/xtensor-r/rcontainer.hpp
@@ -35,7 +35,13 @@ namespace Rcpp
 {
     namespace traits
     {
-        template<> struct r_sexptype_traits<rlogical>{ enum{ rtype = LGLSXP }; };
+        template<> struct r_sexptype_traits<rlogical>
+        { 
+            enum
+            { 
+                rtype = LGLSXP 
+            }; 
+        };
     }
 }
 
@@ -131,7 +137,7 @@ namespace xt
                                        std::is_same<r_type, Rbyte>,
                                        std::is_same<r_type, rlogical>,
                                        std::is_same<r_type, std::complex<double>>>::value == true,
-                      "R containers can only be of type logical, int, double, complex<double>.");
+                      "R containers can only be of type rlogical, int, double, std::complex<double>.");
 #endif
         using shape_type = typename inner_types::shape_type;
         using strides_type = typename inner_types::strides_type;

--- a/include/xtensor-r/rtensor.hpp
+++ b/include/xtensor-r/rtensor.hpp
@@ -71,7 +71,10 @@ namespace xt
         using self_type = rtensor<T, N>;
         using semantic_base = xcontainer_semantic<self_type>;
         using base_type = rcontainer<self_type>;
-        using underlying_type = typename base_type::underlying_type;
+
+        using inner_types = xcontainer_inner_types<self_type>;
+        using underlying_type = typename inner_types::underlying_type;
+
         using storage_type = typename base_type::storage_type;
         using value_type = typename base_type::value_type;
         using reference = typename base_type::reference;

--- a/include/xtensor-r/rtensor.hpp
+++ b/include/xtensor-r/rtensor.hpp
@@ -35,7 +35,9 @@ namespace xt
     template <class T, std::size_t N>
     struct xcontainer_inner_types<rtensor<T, N>>
     {
-        using storage_type = xbuffer_adaptor<T*>;
+        using r_type = T;
+        using underlying_type = r_detail::get_underlying_value_type_r<T>;
+        using storage_type = xbuffer_adaptor<typename underlying_type::type*>;
         using shape_type = std::array<int, N>;
         using strides_type = shape_type;
         using backstrides_type = shape_type;
@@ -69,6 +71,7 @@ namespace xt
         using self_type = rtensor<T, N>;
         using semantic_base = xcontainer_semantic<self_type>;
         using base_type = rcontainer<self_type>;
+        using underlying_type = typename base_type::underlying_type;
         using storage_type = typename base_type::storage_type;
         using value_type = typename base_type::value_type;
         using reference = typename base_type::reference;

--- a/test/rcpp_tests.cpp
+++ b/test/rcpp_tests.cpp
@@ -43,6 +43,14 @@ int call_int(xt::rarray<int>& x)
 }
 
 // [[Rcpp::export]]
+int call_lgl(xt::rarray<rlogical>& x)
+{
+    xassert(x(0, 0) == 1);
+    x(1, 1) = 0;
+    return 1;
+}
+
+// [[Rcpp::export]]
 int call_stdcomplex(xt::rarray<std::complex<double>>& x)
 {
     using cplx = std::complex<double>;

--- a/test/unittest.R
+++ b/test/unittest.R
@@ -37,6 +37,13 @@ test_that("call_int", {
 	expect_equal(x[2, 2], 35)
 })
 
+x <- array(TRUE, c(2, 5))
+
+test_that("call_lgl", {
+  call_lgl(x)
+  expect_equal(x[2, 2], FALSE)
+})
+
 x <- array(as.complex(1:10), c(2, 5))
 
 x[1, 1] <- 0 + 1i


### PR DESCRIPTION
This PR adds logical support to xtensor-r.

Main changes:

* There is a fake type, `rlogical` that will represent R's logical type.

* When we ask for the type of `rlogical` on the R side, we get back `LGLSXP` (through `r_sexptype_traits<rlogical>`)

* When we ask for the type of `rlogical` on the xtensor side, we get back `int` (through `r_detail::get_underlying_value_type_r<rlogical>`

* The type checks in `rcontainer.hpp` when going R->rcontainer have been updated so they can use `rlogical` as a proxy for the logical type and error appropriately.

Questions:

* There are a few places where I define the `underlying_type` along with the preexisting `value_type` (in the constructors of `rarray` and `rtensor`) [here](https://github.com/QuantStack/xtensor-r/compare/master...DavisVaughan:feature/logical-support?expand=1#diff-2954451b0b7c248b14719cb456f0fe05R64). At this point, are those the same? I think so, but I wasn't sure because `value_type` came from `storage_type::value_type` and I didn't know what `storage_type` was since it came from `xbuffer_adaptor<T>`. If they are the same, I think this can be simplified to use the `value_type::type*` [here](https://github.com/QuantStack/xtensor-r/compare/master...DavisVaughan:feature/logical-support?expand=1#diff-2954451b0b7c248b14719cb456f0fe05R162)

* Should `struct rlogical{}` be somewhere else? It needs to be used in both `xt` and `Rcpp` so I defined it outside both namespaces. I don't know what the best thing to do here it. It's currently [here](https://github.com/QuantStack/xtensor-r/compare/master...DavisVaughan:feature/logical-support?expand=1#diff-ab994082b37838ce9eca599ee93433a5R25)

To use this, users should use the `rlogical` type rather than `bool`. This is working for me [in rray](https://github.com/DavisVaughan/rray/blob/feature/support-logical/src/broadcast.cpp#L29)

I was also able to coerce something that I knew would come back from `xtensor` as `bool` into `rlogical` and then convert it into an R logical array [here](https://github.com/DavisVaughan/rray/blob/feature/support-logical/src/arith.cpp#L49), which was nice to see.
