### PR TITLE
Revamp R memory model

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,13 +118,17 @@ install:
     - conda install r r-rcpp r-base r-devtools -c conda-forge
     - conda install xtensor==0.18.3 -c conda-forge
     - conda update readline -c conda-forge  # Requiring conda-forge version of readline
-    - R -e "install.packages('RInside', repos='http://cran.us.r-project.org')"
+    - R -e "install.packages(c('RInside', 'testthat'), repos='http://cran.us.r-project.org')"
     - mkdir build
     - cd build
     - cmake -D XTENSOR_INSTALL_R_PACKAGES=OFF -D BUILD_TESTS=ON -D CMAKE_INSTALL_PREFIX=$HOME/miniconda ..
     - cmake --build . --target test_xtensor_r
     - cmake --build . --target install
     - cmake --build . --target cran
+    - mkdir ~/.R
+    - touch ~/.R/Makevars
+    - echo "CXX14=$CXX" >> ~/.R/Makevars
+    - echo "CXX14FLAGS=-fPIC -O2" >> ~/.R/Makevars
 
 script:
     - cd test
@@ -135,3 +139,4 @@ script:
        cat /home/travis/build/QuantStack/xtensor-r/build/xtensor.Rcheck/00check.log   &&
        cat /home/travis/build/QuantStack/xtensor-r/build/xtensor.Rcheck/Rdlatex.log
       )
+    - cd ../test/; Rscript unittest.R

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ message(STATUS "Found xtensor: ${xtensor_INCLUDE_DIRS}/xtensor")
 set(XTENSOR_R_HEADERS
     ${XTENSOR_R_INCLUDE_DIR}/xtensor-r/rarray.hpp
     ${XTENSOR_R_INCLUDE_DIR}/xtensor-r/rcontainer.hpp
+    ${XTENSOR_R_INCLUDE_DIR}/xtensor-r/rcpp_extensions.hpp
     ${XTENSOR_R_INCLUDE_DIR}/xtensor-r/rtensor.hpp
     ${XTENSOR_R_INCLUDE_DIR}/xtensor-r/rvectorize.hpp
     ${XTENSOR_R_INCLUDE_DIR}/xtensor-r/xtensor_r_config.hpp

--- a/R-package/src/xtensor_r_example.cpp
+++ b/R-package/src/xtensor_r_example.cpp
@@ -15,7 +15,6 @@ xt::rtensor<double, 2> xtensor_r_example(xt::rtensor<int, 1> tens)
 {
     auto t = xt::rtensor<double, 2>({{1, 2, 3}, {5, 5, 5}});
     auto x = xt::rarray<double>({{1, 2, 3}, {5, 5, 5}});
-
     xt::rarray<double> rarr = t * x + 2;
     return t * x;
 }

--- a/include/xtensor-r/rarray.hpp
+++ b/include/xtensor-r/rarray.hpp
@@ -32,10 +32,13 @@ namespace xt
     struct xcontainer_inner_types<rarray<T>>
     {
         using storage_type = xbuffer_adaptor<T*>;
+        constexpr static int SXP = Rcpp::traits::r_sexptype_traits<T>::rtype;
         using shape_type = std::vector<typename storage_type::size_type>;
         using strides_type = std::vector<typename storage_type::difference_type>;
         using backstrides_type = std::vector<typename storage_type::difference_type>;
-        using inner_shape_type = xbuffer_adaptor<int*>;
+
+        using shape_value_type = typename Rcpp::traits::storage_type<INTSXP>::type;
+        using inner_shape_type = xbuffer_adaptor<shape_value_type*>;
         using inner_strides_type = strides_type;
         using inner_backstrides_type = backstrides_type;
         using temporary_type = rarray<T>;
@@ -86,7 +89,7 @@ namespace xt
 
         constexpr static int SXP = Rcpp::traits::r_sexptype_traits<T>::rtype;
 
-        rarray();
+        rarray() = default;
         rarray(SEXP exp);
 
         rarray(const shape_type& shape);
@@ -116,6 +119,8 @@ namespace xt
 
         layout_type layout() const;
 
+        void update(SEXP new_sexp); // called when the stored SEXP changes
+
     private:
 
         storage_type m_storage;
@@ -139,53 +144,37 @@ namespace xt
     };
 
     template <class T>
-    inline rarray<T>::rarray()
-        : base_type()
-    {
-    }
-
-    template <class T>
     inline rarray<T>::rarray(SEXP exp)
-        : base_type(exp)
     {
-        m_shape = detail::r_shape_to_buffer_adaptor(*this);
-
-        resize_container(m_strides, base_type::dimension());
-        resize_container(m_backstrides, base_type::dimension());
-
-        xt::compute_strides(m_shape, layout(), m_strides, m_backstrides);
-
-        std::size_t sz = compute_size(m_shape);
-        m_storage = storage_type(reinterpret_cast<T*>(Rcpp::internal::r_vector_start<SXP>(exp)), sz);
+        base_type::rstorage::set__(Rcpp::r_cast<SXP>(exp));
     }
 
     template <class T>
     template <class S>
     inline void rarray<T>::init_from_shape(const S& shape)
     {
-        resize_container(m_strides, shape.size());
-        resize_container(m_backstrides, shape.size());
         auto tmp_shape = Rcpp::IntegerVector(shape.begin(), shape.end());
+        base_type::rstorage::set__(Rf_allocArray(SXP, SEXP(tmp_shape)));
+    }
 
-        xt::compute_strides(shape, layout(), m_strides, m_backstrides);
-
-        std::size_t sz = compute_size(shape);
-
-        base_type::set_sexp(Rf_allocArray(SXP, SEXP(tmp_shape)));
-        m_storage = storage_type(reinterpret_cast<T*>(Rcpp::internal::r_vector_start<SXP>(SEXP(*this))), sz);
-        m_shape = detail::r_shape_to_buffer_adaptor(*this);
+    template <class T>
+    inline void rarray<T>::update(SEXP new_sexp)
+    {
+        this->m_shape = detail::r_shape_to_buffer_adaptor(new_sexp);
+        resize_container(m_strides, m_shape.size());
+        resize_container(m_backstrides, m_shape.size());
+        std::size_t sz = xt::compute_strides<layout_type::column_major>(m_shape, layout_type::column_major, m_strides, m_backstrides);
+        this->m_storage = storage_type(reinterpret_cast<value_type*>(Rcpp::internal::r_vector_start<SXP>(new_sexp)), sz);
     }
 
     template <class T>
     inline rarray<T>::rarray(const shape_type& shape)
-        : base_type()
     {
         init_from_shape(shape);
     }
 
     template <class T>
     inline rarray<T>::rarray(const shape_type& shape, const_reference value)
-        : base_type()
     {
         init_from_shape(shape);
         std::fill(this->begin(), this->end(), value);
@@ -194,7 +183,6 @@ namespace xt
     template <class T>
     template <class E>
     inline rarray<T>::rarray(const xexpression<E>& e)
-        : base_type()
     {
         semantic_base::assign(e);
     }
@@ -209,7 +197,6 @@ namespace xt
 
     template <class T>
     inline rarray<T>::rarray(const value_type& t)
-        : base_type()
     {
         init_from_shape(xt::shape<shape_type>(t));
         nested_copy(m_storage.begin(), t);
@@ -217,7 +204,6 @@ namespace xt
 
     template <class T>
     inline rarray<T>::rarray(nested_initializer_list_t<value_type, 1> t)
-        : base_type()
     {
         init_from_shape(xt::shape<shape_type>(t));
         nested_copy(this->begin(), t);
@@ -225,7 +211,6 @@ namespace xt
 
     template <class T>
     inline rarray<T>::rarray(nested_initializer_list_t<value_type, 2> t)
-        : base_type()
     {
         init_from_shape(xt::shape<shape_type>(t));
         nested_copy(this->begin(), t);
@@ -233,7 +218,6 @@ namespace xt
 
     template <class T>
     inline rarray<T>::rarray(nested_initializer_list_t<value_type, 3> t)
-        : base_type()
     {
         init_from_shape(xt::shape<shape_type>(t));
         nested_copy(this->begin(), t);
@@ -241,7 +225,6 @@ namespace xt
 
     template <class T>
     inline rarray<T>::rarray(nested_initializer_list_t<value_type, 4> t)
-        : base_type()
     {
         init_from_shape(xt::shape<shape_type>(t));
         nested_copy(this->begin(), t);

--- a/include/xtensor-r/rcontainer.hpp
+++ b/include/xtensor-r/rcontainer.hpp
@@ -18,12 +18,12 @@
 
 #include "xtl/xsequence.hpp"
 
-#if XTENSOR_WARN_ON_COERCE
-#define RCPP_WARN_ON_COERCE
-#endif
+#include "xtensor_r_config.hpp"
 
 #include <Rcpp.h>
 #include <RcppCommon.h>
+
+#include "rcpp_extensions.hpp"
 
 namespace xt
 {
@@ -61,7 +61,6 @@ namespace xt
                 Rcpp::internal::r_vector_start<INTSXP>(shape_sexp), n);
         }
     }
-
 
     /**
      * @class rcontainer
@@ -179,7 +178,7 @@ namespace xt
         {
             auto tmp_shape = Rcpp::IntegerVector(std::begin(shape), std::end(shape));
             Rf_setAttrib(rstorage::get__(), R_DimSymbol, SEXP(tmp_shape));
-            this->derived_cast().set_shape();
+            this->derived_cast().update_shape_and_strides();
         }
     }
 

--- a/include/xtensor-r/rcontainer.hpp
+++ b/include/xtensor-r/rcontainer.hpp
@@ -18,6 +18,10 @@
 
 #include "xtl/xsequence.hpp"
 
+#if XTENSOR_WARN_ON_COERCE
+#define RCPP_WARN_ON_COERCE
+#endif
+
 #include <Rcpp.h>
 #include <RcppCommon.h>
 
@@ -51,32 +55,10 @@ namespace xt
             SEXP shape_sexp = Rf_getAttrib(exp, R_DimSymbol);
             if (n != (std::size_t)Rf_xlength(shape_sexp))
             {
-                throw std::runtime_error("Could not convert shape. Dimensions don't match.");
+                throw std::runtime_error("Could not convert shape for rtensor. Dimensions don't match.");
             }
             return xbuffer_adaptor<int*>(
                 Rcpp::internal::r_vector_start<INTSXP>(shape_sexp), n);
-        }
-
-        template <class T>
-        inline const char* type_to_string(T) { return "unregistered type."; }
-        inline const char* type_to_string(Rbyte) { return "Raw (Rbyte)"; }
-        inline const char* type_to_string(double) { return "Numeric (double)"; }
-        inline const char* type_to_string(int) { return "Integer (int32)"; }
-        inline const char* type_to_string(bool) { return "Logical (bool)"; }
-        inline const char* type_to_string(std::complex<double>) { return "Complex (std::complex<double>>)"; }
-
-        inline const char* rtype_to_string(int rtype)
-        {
-            switch(rtype)
-            {
-                case REALSXP: return "Real";
-                case INTSXP: return "Int";
-                case LGLSXP: return "Logical";
-                case STRSXP: return "String";
-                case CPLXSXP: return "Complex";
-                case RAWSXP: return "Raw";
-                default: return "Unknown / Unmapped";
-            }
         }
     }
 
@@ -90,13 +72,16 @@ namespace xt
      *
      * @tparam D The derived type, i.e. the inheriting class for which rcontainer
      *           provides the interface.
+     * @tparam SP The Rcpp storage policy, defaults to Rcpp::PreserveStorage
      */
-    template <class D>
-    class rcontainer : public xcontainer<D>
+    template <class D, template <class> class SP = Rcpp::PreserveStorage>
+    class rcontainer : public xcontainer<D>, public SP<D>
     {
     public:
 
         using derived_type = D;
+
+        using rstorage = SP<D>;
 
         using base_type = xcontainer<D>;
         using inner_types = xcontainer_inner_types<D>;
@@ -113,7 +98,7 @@ namespace xt
         static_assert(xtl::disjunction<std::is_same<value_type, int32_t>,
                                        std::is_same<value_type, double>,
                                        std::is_same<value_type, Rbyte>,
-                                       // std::is_same<value_type, bool>, NOT YET IMPLEMENTED!
+                                        // std::is_same<value_type, bool>, // NOT YET IMPLEMENTED!
                                        std::is_same<value_type, std::complex<double>>>::value == true,
                       "R containers can only be of type bool, int, double, complex<double>.");
 #endif
@@ -142,15 +127,13 @@ namespace xt
 
         layout_type layout() const;
 
-        operator SEXP() const;
-        void set_sexp(SEXP exp);
+        // explicitly forward data against ambiguity with Rcpp::Storage::data;
+        using base_type::data;
 
     protected:
 
-        rcontainer();
-        ~rcontainer();
-
-        rcontainer(SEXP exp);
+        rcontainer() = default;
+        ~rcontainer() = default;
 
         rcontainer(const rcontainer&) = default;
         rcontainer& operator=(const rcontainer&) = default;
@@ -162,57 +145,15 @@ namespace xt
         derived_type& derived_cast() & noexcept;
         const derived_type& derived_cast() const & noexcept;
         derived_type derived_cast() && noexcept;
-
-    private:
-
-        SEXP m_sexp;
-        bool m_owned;
     };
-
-
-    template <class D>
-    inline rcontainer<D>::rcontainer()
-        : m_sexp(R_NilValue), m_owned(true)
-    {
-    }
-
-    template <class D>
-    inline rcontainer<D>::rcontainer(SEXP exp)
-        : m_sexp(R_NilValue), m_owned(false)
-    {
-        set_sexp(exp);
-        m_sexp = Rcpp::Rcpp_ReplaceObject(m_sexp, exp);
-    }
-
-    template <class D>
-    inline rcontainer<D>::~rcontainer()
-    {
-        if (m_owned)
-        {
-            Rcpp::Rcpp_ReleaseObject(m_sexp);
-            m_sexp = R_NilValue;
-        }
-    }
-
-    template <class D>
-    inline void rcontainer<D>::set_sexp(SEXP exp)
-    {
-        if (TYPEOF(exp) != D::SXP)
-        {
-            Rcpp::stop("R input has the wrong type. Expected %s, got %s",
-                       detail::type_to_string(value_type{}), detail::rtype_to_string(TYPEOF(exp)));
-        }
-
-        m_sexp = Rcpp::Rcpp_ReplaceObject(m_sexp, exp);
-    }
 
     /**
      * Resizes the container.
      * @param shape the new shape
      */
-    template <class D>
+    template <class D, template <class> class SP>
     template <class S>
-    inline void rcontainer<D>::resize(S&& shape)
+    inline void rcontainer<D, SP>::resize(S&& shape)
     {
         if (shape.size() != this->dimension() || !std::equal(std::begin(shape), std::end(shape), this->shape().cbegin()))
         {
@@ -225,9 +166,9 @@ namespace xt
      * Reshapes the container.
      * @param shape the new shape
      */
-    template <class D>
+    template <class D, template <class> class SP>
     template <class S>
-    inline void rcontainer<D>::reshape(S&& shape)
+    inline void rcontainer<D, SP>::reshape(S&& shape)
     {
         if (compute_size(shape) != this->size())
         {
@@ -237,37 +178,31 @@ namespace xt
         if (shape.size() != this->dimension() || !std::equal(std::begin(shape), std::end(shape), this->shape().cbegin()))
         {
             auto tmp_shape = Rcpp::IntegerVector(std::begin(shape), std::end(shape));
-            Rf_setAttrib(m_sexp, R_DimSymbol, SEXP(tmp_shape));
+            Rf_setAttrib(rstorage::get__(), R_DimSymbol, SEXP(tmp_shape));
             this->derived_cast().set_shape();
         }
     }
 
-    template <class D>
-    inline layout_type rcontainer<D>::layout() const
+    template <class D, template <class> class SP>
+    inline layout_type rcontainer<D, SP>::layout() const
     {
         return layout_type::column_major;
     }
 
-    template <class D>
-    inline rcontainer<D>::operator SEXP() const
-    {
-        return m_sexp;
-    }
-
-    template <class D>
-    inline auto rcontainer<D>::derived_cast() & noexcept -> derived_type&
+    template <class D, template <class> class SP>
+    inline auto rcontainer<D, SP>::derived_cast() & noexcept -> derived_type&
     {
         return *static_cast<derived_type*>(this);
     }
 
-    template <class D>
-    inline auto rcontainer<D>::derived_cast() const & noexcept -> const derived_type&
+    template <class D, template <class> class SP>
+    inline auto rcontainer<D, SP>::derived_cast() const & noexcept -> const derived_type&
     {
         return *static_cast<const derived_type*>(this);
     }
 
-    template <class D>
-    inline auto rcontainer<D>::derived_cast() && noexcept -> derived_type
+    template <class D, template <class> class SP>
+    inline auto rcontainer<D, SP>::derived_cast() && noexcept -> derived_type
     {
         return *static_cast<derived_type*>(this);
     }

--- a/include/xtensor-r/rcpp_extensions.hpp
+++ b/include/xtensor-r/rcpp_extensions.hpp
@@ -1,0 +1,71 @@
+/***************************************************************************
+* Copyright (c) 2017, Wolf Vollprecht, Johan Mabille, and Sylvain Corlay   *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XTENSOR_R_RCPP_EXTENSIONS_HPP
+#define XTENSOR_R_RCPP_EXTENSIONS_HPP
+
+
+#include <Rcpp.h>
+
+namespace xt
+{
+    template <class T>
+    class rarray;
+
+    template <class T, std::size_t N>
+    class rtensor;
+}
+
+namespace Rcpp
+{
+    namespace traits
+    {
+        // Specializing these traits here prevents copies from the default
+        // exporter in the generic `as<T>` function from Rcpp.
+        template <class T>
+        class Exporter<xt::rarray<T>>
+        {
+        
+        public:
+            Exporter(SEXP x)
+                : m_sexp(x)
+            {
+            }
+
+            inline xt::rarray<T> get()
+            {
+                return xt::rarray<T>(m_sexp);
+            }
+
+        private:
+            SEXP m_sexp;
+        };
+
+        template <class T, std::size_t N>
+        class Exporter<xt::rtensor<T, N>>
+        {
+        
+        public:
+            Exporter(SEXP x)
+                : m_sexp(x)
+            {
+            }
+
+            inline xt::rtensor<T, N> get()
+            {
+                return xt::rtensor<T, N>(m_sexp);
+            }
+
+        private:
+            SEXP m_sexp;
+        };
+    }
+}
+
+
+#endif

--- a/include/xtensor-r/rcpp_extensions.hpp
+++ b/include/xtensor-r/rcpp_extensions.hpp
@@ -9,7 +9,6 @@
 #ifndef XTENSOR_R_RCPP_EXTENSIONS_HPP
 #define XTENSOR_R_RCPP_EXTENSIONS_HPP
 
-
 #include <Rcpp.h>
 
 namespace xt
@@ -30,8 +29,8 @@ namespace Rcpp
         template <class T>
         class Exporter<xt::rarray<T>>
         {
-        
         public:
+
             Exporter(SEXP x)
                 : m_sexp(x)
             {
@@ -43,14 +42,15 @@ namespace Rcpp
             }
 
         private:
+
             SEXP m_sexp;
         };
 
         template <class T, std::size_t N>
         class Exporter<xt::rtensor<T, N>>
-        {
-        
+        { 
         public:
+
             Exporter(SEXP x)
                 : m_sexp(x)
             {
@@ -62,10 +62,10 @@ namespace Rcpp
             }
 
         private:
+
             SEXP m_sexp;
         };
     }
 }
-
 
 #endif

--- a/include/xtensor-r/xtensor_r_config.hpp
+++ b/include/xtensor-r/xtensor_r_config.hpp
@@ -13,4 +13,8 @@
 #define XTENSOR_R_VERSION_MINOR 8
 #define XTENSOR_R_VERSION_PATCH 2
 
+#ifndef XTENSOR_WARN_ON_COERCE
+#define XTENSOR_WARN_ON_COERCE 1
+#endif
+
 #endif

--- a/include/xtensor-r/xtensor_r_config.hpp
+++ b/include/xtensor-r/xtensor_r_config.hpp
@@ -14,7 +14,7 @@
 #define XTENSOR_R_VERSION_PATCH 2
 
 #ifndef XTENSOR_WARN_ON_COERCE
-#define XTENSOR_WARN_ON_COERCE 1
+#define RCPP_WARN_ON_COERCE 1
 #endif
 
 #endif

--- a/test/rcpp_tests.cpp
+++ b/test/rcpp_tests.cpp
@@ -1,0 +1,54 @@
+// [[Rcpp::plugins(cpp14)]]
+
+#include "xtensor-r/rcontainer.hpp"
+#include "xtensor-r/rarray.hpp"
+#include "xtensor/xio.hpp"
+
+// [[Rcpp::export]]
+int modify_cpp(xt::rarray<double>& x)
+{
+    // check that passing by reference works correctly
+    x(0, 0)  = -1000;
+    x(9, 2) = 1000;
+
+    return 1;
+}
+
+// [[Rcpp::export]]
+int reshape_cpp(xt::rarray<double>& x)
+{
+    // reshape in-place
+    x.reshape({3, 10});
+    return 1;
+}
+
+// [[Rcpp::export]]
+xt::rarray<double> cpp_add(xt::rarray<double>& x, xt::rarray<double>& y)
+{
+    return x + y;
+}
+
+void xassert(bool cond)
+{
+    if (!cond) throw std::runtime_error("CPP ASSERT TRIGGERED.");
+}
+
+// [[Rcpp::export]]
+int call_int(xt::rarray<int>& x)
+{
+    xassert(x(0, 0) == 1);
+    xassert(x(0, 2) == 5);
+    x(1, 1) = 35;
+    return 1;
+}
+
+// [[Rcpp::export]]
+int call_stdcomplex(xt::rarray<std::complex<double>>& x)
+{
+    using cplx = std::complex<double>;
+    xassert(x(0, 0) == cplx(0., 1.));
+    xassert(x(1, 2) == cplx(1., 5.));
+
+    x(0, 2) = cplx(-10., -100.);
+    return 1;
+}

--- a/test/unittest.R
+++ b/test/unittest.R
@@ -1,0 +1,48 @@
+# install.packages('testthat', repos='http://cran.us.r-project.org')
+
+library(testthat)
+
+Rcpp::sourceCpp("rcpp_tests.cpp", cacheDir="__cache__")
+
+x <- array(as.numeric(1:100), dim=c(10, 10))
+
+test_that("cpp_inplace", {
+	expect_equal(x[1, 1], 1)
+	expect_equal(x[10, 3], 30)
+	expect_equal(modify_cpp(x), 1)
+	expect_equal(x[2, 3], 22)
+	expect_equal(x[1, 1], -1000)
+	expect_equal(x[10, 3], 1000)
+})
+
+x <- array(as.numeric(1:100), dim=c(10, 10))
+y <- array(as.numeric(1:100), dim=c(10, 10))
+
+test_that("cpp_add", {
+	expect_equal(cpp_add(x, y), x + y)
+})
+
+x <- array(as.numeric(1:30), dim=c(1, 10, 3))
+
+test_that("cpp_reshape", {
+	expect_equal(dim(x), c(1, 10, 3))
+	reshape_cpp(x)
+	expect_equal(dim(x), c(3, 10))
+})
+
+x <- array(1:10, c(2, 5))
+
+test_that("call_int", {
+	call_int(x)
+	expect_equal(x[2, 2], 35)
+})
+
+x <- array(as.complex(1:10), c(2, 5))
+
+x[1, 1] <- 0 + 1i
+x[2, 3] <- 1 + 5i
+
+test_that("call_stdcomplex", {
+	call_stdcomplex(x)
+	expect_equal(x[1, 3], -10+-100i)
+})


### PR DESCRIPTION
This PR contains two changes:

- Use of Rcpp storage class for the SEXP handling
- Use of Rcpp's `r_cast<...>(...)` to case e.g. a numeric vector to integer vector. Note that this will emit a warning if the warning is not suppressed, because I think this can be quite expensive.

Unfortunately, Rcpp chose the rather generic `update()` name for the method that is called on the CRTP base class after the SEXP has changed. But I think this does not (yet) collide with any method that we have in xtensor. 

@DavisVaughan I hope this fixes the memory problems you were seeing! :)