### PR TITLE
enable xtensor-specific warn on coercion

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -40,9 +40,9 @@ install:
   - initexmf --set-config-value [MPM]AutoInstall=1
   # Full build on x64 with msys64
   - set PATH=%PATH:C:\Program Files\Git\usr\bin;=%
-  - set R_HOME=%MINICONDA%\\R
+  - set R_HOME=%MINICONDA%\\Lib\\R
   - set MINGW_PATH=%MINICONDA%\\Library\\mingw-w64\\bin
-  - "set PATH=%PATH%;%MINGW_PATH%;%MINICONDA%\\R\\library\\RInside\\libs\\x64;%MINICONDA%\\R\\bin\\x64"
+  - "set PATH=%PATH%;%MINGW_PATH%;%MINICONDA%\\Lib\\R\\library\\RInside\\libs\\x64;%MINICONDA%\\Lib\\R\\bin\\x64"
   - appveyor DownloadFile https://cran.r-project.org/bin/windows/Rtools/Rtools34.exe
   - Rtools34.exe /VERYSILENT -NoNewWindow -Wait
   - cmake -D XTENSOR_INSTALL_R_PACKAGES=OFF -G "MinGW Makefiles" -DCMAKE_PREFIX_PATH=%MINGW_PATH% -D CMAKE_INSTALL_PREFIX=%MINICONDA%\\Library -DDOWNLOAD_GTEST=ON ..

--- a/include/xtensor-r/rarray.hpp
+++ b/include/xtensor-r/rarray.hpp
@@ -105,7 +105,7 @@ namespace xt
         rarray(nested_initializer_list_t<value_type, 5> t);
 
         template <class S = shape_type>
-        static rarray from_shape(const S& shape);
+        static rarray from_shape(S&& shape);
 
         template <class E>
         rarray(const xexpression<E>& e);
@@ -232,9 +232,9 @@ namespace xt
 
     template <class T>
     template <class S>
-    inline rarray<T> rarray<T>::from_shape(const S& shape)
+    inline rarray<T> rarray<T>::from_shape(S&& shape)
     {
-        return self_type(xtl::forward_sequence<shape_type, decltype(shape)>(shape));
+        return self_type(xtl::forward_sequence<shape_type, S>(shape));
     }
 
     template <class T>

--- a/include/xtensor-r/rarray.hpp
+++ b/include/xtensor-r/rarray.hpp
@@ -149,6 +149,7 @@ namespace xt
     template <class T>
     inline rarray<T>::rarray(SEXP exp)
     {
+        detail::check_coercion<SXP>(exp);
         base_type::rstorage::set__(Rcpp::r_cast<SXP>(exp));
     }
 

--- a/include/xtensor-r/rarray.hpp
+++ b/include/xtensor-r/rarray.hpp
@@ -234,7 +234,7 @@ namespace xt
     template <class S>
     inline rarray<T> rarray<T>::from_shape(const S& shape)
     {
-        return self_type(xtl::forward_sequence<shape_type>(shape));
+        return self_type(xtl::forward_sequence<shape_type, decltype(shape)>(shape));
     }
 
     template <class T>

--- a/include/xtensor-r/rcontainer.hpp
+++ b/include/xtensor-r/rcontainer.hpp
@@ -192,7 +192,7 @@ namespace xt
     {
         if (shape.size() != this->dimension() || !std::equal(std::begin(shape), std::end(shape), this->shape().cbegin()))
         {
-            derived_type tmp(xtl::forward_sequence<shape_type>(shape));
+            derived_type tmp(xtl::forward_sequence<shape_type, S>(shape));
             *static_cast<derived_type*>(this) = std::move(tmp);
         }
     }

--- a/include/xtensor-r/rcontainer.hpp
+++ b/include/xtensor-r/rcontainer.hpp
@@ -36,7 +36,7 @@ namespace Rcpp
     namespace traits
     {
         template<> struct r_sexptype_traits<rlogical>
-        { 
+        {
             static constexpr int rtype = LGLSXP;
         };
     }
@@ -93,6 +93,19 @@ namespace xt
             }
             return xbuffer_adaptor<int*>(
                 Rcpp::internal::r_vector_start<INTSXP>(shape_sexp), n);
+        }
+
+        template <int SXP>
+        inline void check_coercion(SEXP exp)
+        {
+        #if XTENSOR_WARN_ON_COERCE
+            if (TYPEOF(exp) != SXP)
+            {
+                Rcpp::warning("Coerced object from '%s' to '%s'. Avoid for speed & in-place operations.",
+                    Rf_type2char(TYPEOF(exp)),
+                    Rf_type2char(SXP));
+            }
+        #endif
         }
     }
 

--- a/include/xtensor-r/rtensor.hpp
+++ b/include/xtensor-r/rtensor.hpp
@@ -165,6 +165,7 @@ namespace xt
     template <class T, std::size_t N>
     inline rtensor<T, N>::rtensor(SEXP exp)
     {
+        detail::check_coercion<SXP>(exp);
         base_type::rstorage::set__(Rcpp::r_cast<SXP>(exp));
     }
 

--- a/include/xtensor-r/rtensor.hpp
+++ b/include/xtensor-r/rtensor.hpp
@@ -181,7 +181,7 @@ namespace xt
     template <class S>
     inline rtensor<T, N> rtensor<T, N>::from_shape(S&& shape)
     {
-        shape_type temp_shape = xtl::forward_sequence<shape_type>(shape);
+        shape_type temp_shape = xtl::forward_sequence<shape_type, S>(shape);
         return self_type(temp_shape);
     }
 

--- a/include/xtensor-r/xtensor_r_config.hpp
+++ b/include/xtensor-r/xtensor_r_config.hpp
@@ -14,7 +14,7 @@
 #define XTENSOR_R_VERSION_PATCH 2
 
 #ifndef XTENSOR_WARN_ON_COERCE
-#define RCPP_WARN_ON_COERCE 1
+#define XTENSOR_WARN_ON_COERCE 1
 #endif
 
 #endif


### PR DESCRIPTION
@DavisVaughan this should fix the over-eager warnings.