### PR TITLE
fix 0d initialization

### DIFF
--- a/include/xtensor-r/rarray.hpp
+++ b/include/xtensor-r/rarray.hpp
@@ -157,8 +157,16 @@ namespace xt
     template <class S>
     inline void rarray<T>::init_from_shape(const S& shape)
     {
-        auto tmp_shape = Rcpp::IntegerVector(shape.begin(), shape.end());
-        base_type::rstorage::set__(Rf_allocArray(SXP, SEXP(tmp_shape)));
+        if (shape.size() == 0)
+        {
+            Rcpp::IntegerVector tmp_shape = { 1 };
+            base_type::rstorage::set__(Rf_allocArray(SXP, SEXP(tmp_shape)));
+        }
+        else
+        {
+            Rcpp::IntegerVector tmp_shape(shape.begin(), shape.end());
+            base_type::rstorage::set__(Rf_allocArray(SXP, SEXP(tmp_shape)));
+        }
     }
 
     template <class T>

--- a/include/xtensor-r/rarray.hpp
+++ b/include/xtensor-r/rarray.hpp
@@ -159,8 +159,7 @@ namespace xt
     {
         if (shape.size() == 0)
         {
-            Rcpp::IntegerVector tmp_shape = { 1 };
-            base_type::rstorage::set__(Rf_allocArray(SXP, SEXP(tmp_shape)));
+            base_type::rstorage::set__(Rf_allocVector(SXP, 1));
         }
         else
         {

--- a/include/xtensor-r/rcontainer.hpp
+++ b/include/xtensor-r/rcontainer.hpp
@@ -68,6 +68,12 @@ namespace xt
         {
             if (Rf_isNull(Rf_getAttrib(exp, R_DimSymbol)))
             {
+                // This is a 0D scalar
+                if (Rf_xlength(exp) == 1)
+                {
+                    return xbuffer_adaptor<int*>(nullptr, 0);
+                }
+
                 auto d = Rcpp::IntegerVector::create(Rf_length(exp));
                 Rf_setAttrib(exp, R_DimSymbol, d);
             }
@@ -80,6 +86,10 @@ namespace xt
 
         inline xbuffer_adaptor<int*> r_shape_to_buffer_adaptor(SEXP exp, std::size_t n)
         {
+            if (n == 0)
+            {
+                return xbuffer_adaptor<int*>(nullptr, 0);
+            }
             if (Rf_isNull(Rf_getAttrib(exp, R_DimSymbol)))
             {
                 auto d = Rcpp::IntegerVector::create(Rf_length(exp));

--- a/include/xtensor-r/rcontainer.hpp
+++ b/include/xtensor-r/rcontainer.hpp
@@ -203,7 +203,8 @@ namespace xt
     template <class S>
     inline void rcontainer<D, SP>::resize(S&& shape)
     {
-        if (shape.size() != this->dimension() || !std::equal(std::begin(shape), std::end(shape), this->shape().cbegin()))
+        // if SEXP not initialized, it will be NULL (e.g. in constructor)
+        if (Rf_isNull(*this) || shape.size() != this->dimension() || !std::equal(std::begin(shape), std::end(shape), this->shape().cbegin()))
         {
             derived_type tmp(xtl::forward_sequence<shape_type, S>(shape));
             *static_cast<derived_type*>(this) = std::move(tmp);

--- a/include/xtensor-r/rtensor.hpp
+++ b/include/xtensor-r/rtensor.hpp
@@ -173,10 +173,13 @@ namespace xt
     template <class S>
     inline void rtensor<T, N>::init_from_shape(const S& shape)
     {
+        if (N != shape.size())
+        {
+            throw std::runtime_error("Wrong dimensions for rtensor.");
+        }
         if (shape.size() == 0)
         {
-            Rcpp::IntegerVector tmp_shape = { 1 };
-            base_type::rstorage::set__(Rf_allocArray(SXP, SEXP(tmp_shape)));
+            base_type::rstorage::set__(Rf_allocVector(SXP, 1));
         }
         else
         {

--- a/include/xtensor-r/rtensor.hpp
+++ b/include/xtensor-r/rtensor.hpp
@@ -173,8 +173,16 @@ namespace xt
     template <class S>
     inline void rtensor<T, N>::init_from_shape(const S& shape)
     {
-        auto tmp_shape = Rcpp::IntegerVector(shape.begin(), shape.end());
-        base_type::rstorage::set__(Rf_allocArray(SXP, SEXP(tmp_shape)));
+        if (shape.size() == 0)
+        {
+            Rcpp::IntegerVector tmp_shape = { 1 };
+            base_type::rstorage::set__(Rf_allocArray(SXP, SEXP(tmp_shape)));
+        }
+        else
+        {
+            auto tmp_shape = Rcpp::IntegerVector(shape.begin(), shape.end());
+            base_type::rstorage::set__(Rf_allocArray(SXP, SEXP(tmp_shape)));
+        }
         // everything else is handled by update()
     }
 

--- a/test/rcpp_tests.cpp
+++ b/test/rcpp_tests.cpp
@@ -2,6 +2,7 @@
 
 #include "xtensor-r/rcontainer.hpp"
 #include "xtensor-r/rarray.hpp"
+#include "xtensor/xmath.hpp"
 #include "xtensor/xio.hpp"
 
 // [[Rcpp::export]]
@@ -59,4 +60,11 @@ int call_stdcomplex(xt::rarray<std::complex<double>>& x)
 
     x(0, 2) = cplx(-10., -100.);
     return 1;
+}
+
+// [[Rcpp::export]]
+xt::rarray<double> reduce_1d()
+{
+    xt::rarray<double> a = {1, 2, 3, 4};
+    return xt::sum(a, 0);
 }

--- a/test/unittest.R
+++ b/test/unittest.R
@@ -56,5 +56,5 @@ test_that("call_stdcomplex", {
 
 test_that("reduce_1d", {
 	res1d <- reduce_1d()
-	expect_equal(res1d, array(10))
+	expect_equal(res1d, 10)
 })

--- a/test/unittest.R
+++ b/test/unittest.R
@@ -53,3 +53,8 @@ test_that("call_stdcomplex", {
 	call_stdcomplex(x)
 	expect_equal(x[1, 3], -10+-100i)
 })
+
+test_that("reduce_1d", {
+	res1d <- reduce_1d()
+	expect_equal(res1d, array(10))
+})


### PR DESCRIPTION
@DavisVaughan 

I have a remaining issue: In the test i put `expect_equal(result, array(10))` and that works fine. However, `expect_equal(result, 10)` does *not* work:

```
Error: Test failed: 'reduce_1d'
* `res1d` not equal to 10.
Attributes: < Modes: list, NULL >
Attributes: < Lengths: 1, 0 >
Attributes: < names for target but not for current >
Attributes: < current is not list-like >
```

Any chance you know how to create a scalar correctly in Rcpp? And even in R I thought everything was a atomic (e.g. when I do 1 + 2 I get `[1] 3` so I assume it's a vector?

In any case, this code resolves the segfault with 1D reducers. (But not the issues with your R-function reducers).