### PR TITLE
Fix a typo on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ install.packages("xtensor")
 or from the repository using devtools:
 
 ```R
-devtools.install_github("QuantStack/xtensor-r", ref="package")
+devtools::install_github("QuantStack/xtensor-r", ref="package")
 ```
 
 ## Installation from Sources


### PR DESCRIPTION
Replaced `devtools`. by `devtools::`