### PR TITLE
roptional inner types

### DIFF
--- a/include/xtensor-r/roptional.hpp
+++ b/include/xtensor-r/roptional.hpp
@@ -128,11 +128,12 @@ namespace xt
     struct xcontainer_inner_types<rcontainer_optional<RC>>
     {
         using raw_value_expression = RC;
-        using value_type = typename raw_value_expression::value_type;
-        using value_storage_type = typename raw_value_expression::storage_type&;
-        using raw_flag_expression = xfunctor_adaptor<rna_proxy_functor<value_type>, RC&>;
-        using flag_storage_type = xfunctor_adaptor<rna_proxy_functor<value_type>, RC&>;
-        using storage_type = xoptional_assembly_storage<value_storage_type&, flag_storage_type&>;
+        using raw_value_type = typename raw_value_expression::value_type;
+        using raw_value_storage_type = typename raw_value_expression::storage_type&;
+        using raw_flag_expression = xfunctor_adaptor<rna_proxy_functor<raw_value_type>, RC&>;
+        using flag_storage_type = xfunctor_adaptor<rna_proxy_functor<raw_value_type>, RC&>;
+        using storage_type = xoptional_assembly_storage<raw_value_storage_type&, flag_storage_type&>;
+        using value_type = typename storage_type::value_type;
         using temporary_type = rcontainer_optional<RC>;
     };
 

--- a/test/test_roptional.cpp
+++ b/test/test_roptional.cpp
@@ -116,4 +116,25 @@ namespace xt
         EXPECT_TRUE(o(1, 0).has_value());
         EXPECT_FALSE(o(1, 1).has_value());
     }
+
+    TEST(roptional, assign_expression)
+    {
+        using cpp_type = double;
+        constexpr static int rtype = Rcpp::traits::r_sexptype_traits<cpp_type>::rtype;
+        auto mi = Rcpp::traits::get_na<rtype>();
+
+        rarray<cpp_type> t {0};
+        SEXP exp = SEXP(t);
+        rarray_optional<cpp_type> o(exp);
+
+        // Assign expression
+        xtensor_optional<double, 2> m
+            {{ 1.0 ,       2.0         },
+             { 3.0 , xtl::missing<double>() }};
+        o = xt::sum(m);
+
+        EXPECT_EQ(o.dimension(), 1);
+        EXPECT_TRUE(o(0).has_value());
+        EXPECT_FALSE(o(1).has_value());
+    }
 }


### PR DESCRIPTION
Fixes #94

Failure is due to `rcontainer_optional` lacking the optional base setting the expression tag properly.