### PR TITLE
Remove miktex

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,12 +26,6 @@ install:
   - conda install xtensor=0.20.6 r-rcpp r-rinside r-devtools -c conda-forge
   # Build dependencies 
   - conda install m2w64-gcc m2w64-make m2w64-toolchain m2-libbz2 posix -c conda-forge
-  # Install miktex
-  - if not exist c:\miktex\texmfs\install\miktex\bin\pdflatex.exe appveyor DownloadFile http://miktex.org/download/ctan/systems/win32/miktex/setup/windows-x86/miktex-portable.exe
-  - if not exist c:\miktex\texmfs\install\miktex\bin\pdflatex.exe 7z x miktex-portable.exe -oC:\miktex >NUL
-  - set "PATH=%PATH%;c:\miktex\texmfs\install\miktex\bin"
-  # Enable installing miktex packages on the fly
-  - initexmf --set-config-value [MPM]AutoInstall=1
   # Full build on x64 with msys64
   - mkdir build
   - cd build


### PR DESCRIPTION
miktex shouldn't be required, since I think it was only used for building the pdf manual over in Xtensor.R?